### PR TITLE
fix: Improve pipeline quality — validation, task sizing, agent routing

### DIFF
--- a/.claude/scripts/batch-runner.sh
+++ b/.claude/scripts/batch-runner.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DEPRECATED: Use batch-orchestrator.sh instead. This script is maintained for backward compatibility only.
 #
 # batch-runner.sh
 # Executes implement-issue and process-pr for a single issue

--- a/.claude/skills/explore/SKILL.md
+++ b/.claude/skills/explore/SKILL.md
@@ -47,6 +47,10 @@ Break the chosen approach into implementable tasks:
 - Each task specifies an agent type (see Task Format below)
 - Tasks are ordered by dependency (data layer first, then presentation)
 - Each task is a single logical unit of work
+- Each task should target 5-30 minutes of subagent execution time
+- If a task requires reading more than 3 files or modifying more than 2 files, split it
+- Add a complexity hint: `- [ ] \`[agent]\` **(S)** Description` where S=small (~5 min), M=medium (~15 min), L=large (~30 min)
+- Frontend and backend changes in the same task should be split — backend first (data layer), then frontend (presentation)
 - Include acceptance criteria for the overall issue
 
 ### Step 5: Create GitHub Issue
@@ -81,10 +85,10 @@ gh issue create --title "$TITLE" --body "$(cat <<'EOF'
 - [alternative 2] — rejected because [reason]
 
 ## Implementation Tasks
-- [ ] `[agent-name]` Description of task 1
-- [ ] `[agent-name]` Description of task 2
-- [ ] `[agent-name]` Description of task 3
-- [ ] `[default]` Description of general task (e.g., tests, config)
+- [ ] `[agent-name]` **(S)** Description of task 1
+- [ ] `[agent-name]` **(M)** Description of task 2
+- [ ] `[agent-name]` **(L)** Description of task 3
+- [ ] `[default]` **(S)** Description of general task (e.g., tests, config)
 
 ## Acceptance Criteria
 - [ ] AC1: [measurable criterion]
@@ -109,7 +113,7 @@ Ready for implementation: /implement-issue NNN main
 The `## Implementation Tasks` section must use this parseable convention:
 
 ```markdown
-- [ ] `[agent-name]` Task description
+- [ ] `[agent-name]` **(M)** Task description
 ```
 
 **Agent values** (adapt to your project's agents):
@@ -142,3 +146,4 @@ The `## Implementation Tasks` section must use this parseable convention:
 | Over-plan with 20+ tasks | Keep it focused; split into multiple issues if needed |
 | Combine multiple concerns in one issue | One issue = one problem = one PR |
 | Ask too many clarifying questions | 0-2 questions max; research answers most questions |
+| Single task modifies 5+ files | Split into focused subtasks |


### PR DESCRIPTION
## Summary
- **Agent routing**: Removed non-existent `code-simplifier` agent, replaced hardcoded `laravel-backend-developer` with task's agent variable in fix/review stages, made all prompts language-agnostic (removed PHP/Laravel specifics)
- **Plan validation**: Implemented real `validate_plan` — verifies `## Implementation Tasks` section exists, checks agent names against `.claude/agents/`, flags oversized task descriptions, validates backtick-quoted file paths
- **Task sizing**: Enhanced `/explore` skill with S/M/L complexity hints, 5-30 min target per task, split guidance
- **Batch orchestrator**: Fixed `echo "$var" | jq` anti-pattern (replaced with `printf '%s'`), fixed `log()` functions, deprecated `batch-runner.sh`

Supersedes #2 (rebased cleanly on main). Ported from stevegrocott/beegee-farm-3#552.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)