### PR TITLE
feat(#13): Add context checkpoint pattern for token optimization

### DIFF
--- a/.claude/skills/create-session-summary/SKILL.md
+++ b/.claude/skills/create-session-summary/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: create-session-summary
+description: Create Session Summary
+---
+
+# Create Session Summary
+
+Save the current session's working state to a file so work can resume after `/clear` or in a new conversation.
+
+**Announce at start:** "Creating session summary for resumption."
+
+## When to Use
+
+- Before suggesting `/clear` to optimize token usage
+- At the end of a long session that may continue later
+- When switching context to a different task mid-session
+- When a skill's context checkpoint triggers (see executing-plans, subagent-driven-development)
+
+## The Process
+
+### Step 1: Gather State
+
+Collect all relevant context:
+
+```bash
+# Git state
+BRANCH=$(git branch --show-current)
+LAST_COMMIT=$(git log --oneline -1)
+UNCOMMITTED=$(git status --short)
+
+# Timestamp
+TIMESTAMP=$(date +%Y-%m-%d-%H%M)
+```
+
+### Step 2: Write Summary File
+
+Write to `.claude/sessions/session-YYYY-MM-DD-HHMM.md`:
+
+```markdown
+# Session Summary — YYYY-MM-DD HH:MM
+
+## Active Skill
+[Name of the skill that was running, or "manual" if no skill]
+
+## Current Phase
+[Which step/phase within the skill, e.g., "executing-plans Step 3: batch 2 of 4 complete"]
+
+## Git State
+- **Branch:** `feature/issue-NNN`
+- **Last commit:** `abc1234 feat: description`
+- **Uncommitted changes:** [yes/no — list if yes]
+
+## Key Decisions Made
+- [Decision 1 and rationale]
+- [Decision 2 and rationale]
+
+## Remaining Work
+- [ ] Task/step still pending
+- [ ] Task/step still pending
+
+## Files Modified This Session
+- `path/to/file.ts` — [what was changed]
+- `path/to/other.ts` — [what was changed]
+
+## Context for Resumption
+[Any additional context needed to pick up where you left off — error states, blockers, pending questions, relevant findings]
+```
+
+### Step 3: Confirm and Suggest
+
+After writing the file:
+
+1. Print the file path
+2. Suggest: "Session saved. You can run `/clear` to free context, then `/resume-session .claude/sessions/session-TIMESTAMP.md` to continue."
+
+## File Location
+
+All session files go in `.claude/sessions/`. Create the directory if it doesn't exist:
+
+```bash
+mkdir -p .claude/sessions
+```
+
+**Naming convention:** `session-YYYY-MM-DD-HHMM.md`
+
+## Key Principles
+
+- **Capture everything needed to resume** — the reader has zero context
+- **Be specific** — "Task 3 of 7" not "partway through"
+- **Include git state** — branch and commit are essential for resumption
+- **List remaining work explicitly** — don't assume the reader remembers the plan
+- **Keep it concise** — this is a handoff document, not a narrative
+
+## Integration
+
+**Called by:** Any skill at a context checkpoint, or user directly via `/create-session-summary`
+**Followed by:** `/clear` (optional) then `/resume-session`

--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -42,6 +42,16 @@ When batch complete:
 - Show verification output
 - Say: "Ready for feedback."
 
+### Context Checkpoint (Optional — Token Optimization)
+
+After reporting a batch and before continuing, check whether context has grown large (many file reads, tool calls, or 3+ batches completed). If so:
+
+1. **Save state:** Run `/create-session-summary` to persist progress to `.claude/sessions/`
+2. **Suggest to user:** "This session has accumulated significant context. You can run `/clear` to free tokens, then `/resume-session` to continue from where we left off. Or just say 'continue' to keep going."
+3. **If user clears:** They will invoke `/resume-session` which will reload this skill at Step 4
+
+**When to suggest:** After the 2nd batch completes, or whenever the session feels heavy. This is optional — skip if the plan is nearly complete or context is manageable.
+
 ### Step 4: Continue
 Based on feedback:
 - Apply changes if needed

--- a/.claude/skills/explore/SKILL.md
+++ b/.claude/skills/explore/SKILL.md
@@ -33,6 +33,8 @@ Explore relevant files, patterns, and dependencies:
 - Document current behavior vs desired behavior
 - Note architectural patterns to follow
 
+**Context Checkpoint (Optional):** If the research phase read many files or generated extensive tool output, consider writing a concise research summary to a temp file and suggesting `/clear` before evaluation. The evaluation and planning phases only need the summary, not the raw exploration context. Use `/create-session-summary` if checkpointing.
+
 ### Step 3: Evaluate Approaches
 
 Determine the best implementation strategy:

--- a/.claude/skills/resume-session/SKILL.md
+++ b/.claude/skills/resume-session/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: resume-session
+description: Resume Previous Session
+argument-hint: "[session-file-path]"
+---
+
+# Resume Session
+
+Reload context from a session summary file and continue where you left off.
+
+**Announce at start:** "Resuming session from $FILE_PATH"
+
+**Arguments:**
+- `$1` — Path to session summary file (required), e.g., `.claude/sessions/session-2026-02-20-1430.md`
+
+## The Process
+
+### Step 1: Read Session File
+
+```bash
+cat "$SESSION_FILE"
+```
+
+If no argument provided, find the most recent session file:
+
+```bash
+ls -t .claude/sessions/session-*.md 2>/dev/null | head -1
+```
+
+If no session files exist, stop and inform the user.
+
+### Step 2: Verify Git State
+
+Check that the current git state matches what's in the session file:
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+# Compare against branch listed in session file
+```
+
+**If branch doesn't match:**
+- Inform user: "Session was on branch `X` but you're on `Y`."
+- Offer to checkout the correct branch
+- If there are uncommitted changes, warn before switching
+
+**If branch matches:** Proceed.
+
+### Step 3: Verify Last Commit
+
+```bash
+git log --oneline -1
+# Compare against last commit in session file
+```
+
+**If commits diverged** (new commits since session was saved):
+- Show what changed: `git log --oneline SESSION_COMMIT..HEAD`
+- Inform user but proceed — the new commits may be intentional
+
+### Step 4: Restore Context
+
+Read the session file sections and internalize:
+
+1. **Active Skill** — If a skill was running, announce: "Resuming `skill-name` at `phase`."
+2. **Remaining Work** — Load the pending tasks as your current work items
+3. **Key Decisions** — Note these so you don't re-decide them
+4. **Context for Resumption** — Apply any special context (blockers, error states, etc.)
+
+### Step 5: Continue Work
+
+Based on the Active Skill:
+
+- **If a skill was active:** Resume that skill at the noted phase. Don't restart from the beginning.
+- **If "manual":** Present the remaining work items and ask what to work on next.
+- **If remaining work is empty:** Inform user the previous session appears complete.
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| Session file not found | Stop, show available sessions in `.claude/sessions/` |
+| Branch doesn't exist locally | Offer to fetch and checkout |
+| Session file is empty or malformed | Stop, show file contents, ask user for guidance |
+| No remaining work | Inform user, ask if there's new work |
+| Multiple session files match | Show list, ask user to pick |
+
+## Key Principles
+
+- **Verify before acting** — always confirm git state matches before resuming work
+- **Don't re-decide** — honor decisions listed in the session file
+- **Don't restart skills** — resume at the noted phase, not from step 1
+- **Be transparent** — if state doesn't match, explain the discrepancy clearly
+
+## Integration
+
+**Preceded by:** `/create-session-summary` then `/clear`
+**Calls:** Whatever skill was active in the session (if any)

--- a/.claude/skills/subagent-driven-development/SKILL.md
+++ b/.claude/skills/subagent-driven-development/SKILL.md
@@ -190,6 +190,22 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Context Checkpoint (Optional — Token Optimization)
+
+The orchestrator session accumulates context from every subagent dispatch, review cycle, and decision — even though subagents themselves get fresh contexts. After every **3 completed task cycles**, evaluate whether to checkpoint:
+
+1. **Check:** Have 3+ tasks completed since the last checkpoint (or since start)?
+2. **Save state:** Run `/create-session-summary` with:
+   - Active skill: `subagent-driven-development`
+   - Current phase: "Task N of M complete"
+   - Remaining work: list of pending task descriptions from the plan
+   - Key decisions: any answers given to subagent questions
+   - Feature branch name (critical — subagents need this)
+3. **Suggest to user:** "Orchestrator context is growing. You can `/clear` and `/resume-session` to continue with fresh context, or say 'continue' to keep going."
+4. **If user clears and resumes:** Reload the plan, skip completed tasks (check git log / TodoWrite), and continue dispatching from the next pending task.
+
+**When to skip:** If running in headless mode (called from implement-issue), don't suggest `/clear` — the orchestrator script already handles context isolation via `claude -p` per stage. This checkpoint is for interactive sessions only.
+
 ## Advantages
 
 **vs. Manual execution:**


### PR DESCRIPTION
## Summary

- Create `create-session-summary` skill — persists session state (skill, phase, decisions, remaining work, git branch) to `.claude/sessions/` for resumption after `/clear`
- Create `resume-session` skill — reads session file, verifies git state, restores context to continue work
- Add context checkpoint guidance to `executing-plans` (between batch report and continue), `subagent-driven-development` (every 3 task cycles), and `explore` (between research and evaluation)

All checkpoints are framed as **optional optimization** — users can continue without clearing if token budget allows.

Closes #13

## Test plan

- [ ] Verify `create-session-summary` skill file exists with all required sections (skill, phase, decisions, remaining work, branch)
- [ ] Verify `resume-session` skill file exists with git state verification and edge case handling
- [ ] Verify `executing-plans` checkpoint appears between Step 3 and Step 4
- [ ] Verify `subagent-driven-development` checkpoint mentions headless mode exclusion
- [ ] Verify `explore` checkpoint is lightweight (single paragraph, not a full section)
- [ ] Verify all checkpoint language uses "optional" framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)