### PR TITLE
feat(#6): reduce pipeline invocations

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,43 +1,15 @@
 #!/usr/bin/env bash
 # SessionStart hook for project
-# Injects using-skills content into conversation context
+# Injects minimal skills pointer into conversation context
 
 set -euo pipefail
 
-# Determine project root directory
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-
-# Read using-skills content
-using_skills_content=$(cat "${PROJECT_ROOT}/.claude/skills/using-skills/SKILL.md" 2>&1 || echo "Error reading using-skills skill")
-
-# Escape outputs for JSON using pure bash
-escape_for_json() {
-    local input="$1"
-    local output=""
-    local i char
-    for (( i=0; i<${#input}; i++ )); do
-        char="${input:$i:1}"
-        case "$char" in
-            $'\\') output+='\\' ;;
-            '"') output+='\"' ;;
-            $'\n') output+='\n' ;;
-            $'\r') output+='\r' ;;
-            $'\t') output+='\t' ;;
-            *) output+="$char" ;;
-        esac
-    done
-    printf '%s' "$output"
-}
-
-using_skills_escaped=$(escape_for_json "$using_skills_content")
-
 # Output context injection as JSON
-cat <<EOF
+cat <<'EOF'
 {
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
-    "additionalContext": "<EXTREMELY_IMPORTANT>\nYou have project-level skills.\n\n**Below is the full content of your 'using-skills' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n---\n${using_skills_escaped}\n\n</EXTREMELY_IMPORTANT>"
+    "additionalContext": "<EXTREMELY_IMPORTANT>\nYou have project-level skills. Use the Skill tool to read and execute skills as needed. Check available skills before starting any task.\n</EXTREMELY_IMPORTANT>"
   }
 }
 EOF

--- a/.claude/scripts/implement-issue-test/run-tests.sh
+++ b/.claude/scripts/implement-issue-test/run-tests.sh
@@ -135,7 +135,7 @@ main() {
     echo ""
 
     # Run tests
-    if bats "${bats_args[@]}" "${test_files[@]}"; then
+    if bats ${bats_args[@]+"${bats_args[@]}"} "${test_files[@]}"; then
         echo ""
         echo -e "${GREEN}All tests passed!${NC}"
         exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // empty' | { read f; if [ -n \"$f\" ] && echo \"$f\" | grep -q '\\.php$'; then cd \"$CLAUDE_PROJECT_DIR\" && ./vendor/bin/pint \"$f\" 2>/dev/null; fi; }",
+            "command": "jq -r '.tool_input.file_path // empty' | { read f; if [ -n \"$f\" ] && echo \"$f\" | grep -q '\\.php$'; then if [ -f \"$CLAUDE_PROJECT_DIR/composer.json\" ] || find \"$CLAUDE_PROJECT_DIR\" -maxdepth 2 -name '*.php' -print -quit 2>/dev/null | grep -q .; then cd \"$CLAUDE_PROJECT_DIR\" && ./vendor/bin/pint \"$f\" 2>/dev/null; fi; fi; }",
             "timeout": 30
           }
         ]


### PR DESCRIPTION
## Summary
- **Convergence detection**: Track failure signature hashes in test-fix loop; exit early after 3 identical failures to prevent wasted Claude invocations
- **Conditional PHP linter hook**: Check for `composer.json` or `.php` files before running pint — no-op in non-PHP projects
- **Trimmed session-start.sh**: Replace ~200-line SKILL.md injection with 1-line pointer, saving tokens on every invocation
- **Merged self-review into implement stage**: Eliminates separate task-review invocation
- **Combined spec + code review**: Single PR review stage instead of two
- **Fix BATS test runner**: Unbound variable with empty `bats_args` array

## Test plan
- [x] `bash -n .claude/scripts/implement-issue-orchestrator.sh` — syntax valid
- [x] `jq . .claude/settings.json` — valid JSON
- [x] `bash -n .claude/hooks/session-start.sh` — syntax valid
- [x] BATS tests run (pre-existing failures unrelated to changes)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)