### PR TITLE
feat(#15): Wire up model-config.sh to orchestrator

### DIFF
--- a/.claude/scripts/implement-issue-test/helpers/test-helper.bash
+++ b/.claude/scripts/implement-issue-test/helpers/test-helper.bash
@@ -32,6 +32,11 @@ setup_test_env() {
         cp -r "$SCRIPT_DIR/schemas/"* "$TEST_TMP/schemas/" 2>/dev/null || true
     fi
 
+    # Copy model-config.sh so run_stage can resolve models
+    if [[ -f "$SCRIPT_DIR/model-config.sh" ]]; then
+        cp "$SCRIPT_DIR/model-config.sh" "$TEST_TMP/model-config.sh"
+    fi
+
     # Change to test directory
     cd "$TEST_TMP" || exit 1
 }
@@ -312,6 +317,11 @@ LOG_FILE="${LOG_FILE:-$LOG_BASE/orchestrator.log}"
 STAGE_COUNTER="${STAGE_COUNTER:-0}"
 QUIET="${QUIET:-false}"
 EOF
+
+    # Source model-config.sh first (provides resolve_model, _next_model_up)
+    if [[ -f "$TEST_TMP/model-config.sh" ]]; then
+        source "$TEST_TMP/model-config.sh"
+    fi
 
     # Source it
     source "$func_file"

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -159,3 +159,25 @@ resolve_model() {
 
 	printf '%s\n' "$(_tier_to_model "$tier")"
 }
+
+# =============================================================================
+# MODEL ESCALATION (_next_model_up)
+# =============================================================================
+#
+# Given a model name, returns the next model up in the tier hierarchy.
+# Used for --fallback-model to provide resilience when the primary model
+# is unavailable or rate-limited.
+#
+# haiku  -> sonnet
+# sonnet -> opus
+# opus   -> opus (ceiling)
+#
+
+_next_model_up() {
+	case "$1" in
+		haiku)  printf '%s' "sonnet" ;;
+		sonnet) printf '%s' "opus" ;;
+		opus)   printf '%s' "opus" ;;
+		*)      printf '%s' "opus" ;;
+	esac
+}


### PR DESCRIPTION
## Summary
- Port model-config.sh integration from beegee-farm-3 to the template repo
- `run_stage()` now resolves model dynamically via `resolve_model()` based on stage name + task complexity (S/M/L)
- Adds `--model` and `--fallback-model` flags to all `claude -p` invocations
- Forwards complexity hint through `run_quality_loop()` and `run_test_loop()` to all child `run_stage()` calls
- Adds `_next_model_up()` for automatic fallback escalation (haiku→sonnet→opus)
- Fixes test helper to copy and source model-config.sh in the test environment

## Test plan
- [x] All 121 model-config BATS tests pass
- [x] 17/18 stage-runner tests pass (1 pre-existing `fail` command issue)
- [ ] Run full test suite to verify no regressions

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)