### PR TITLE
fix(#25): Prevent pipeline from approving issues with unresolved major findings

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -1414,7 +1414,16 @@ For each modified implementation file that warrants testing, identify the corres
 1. Check for TODO/FIXME/incomplete tests
 2. Check for hollow assertions (expect(true).toBe(true), no assertions)
 3. Verify edge cases and error conditions are tested
-4. Check for mock abuse patterns"
+4. Check for mock abuse patterns
+
+INTEGRATION TEST REQUIREMENT FOR API ROUTES (claude-pipeline#25):
+- If ANY changed file is an API route file (matches */routes/*.ts or */routes/*.js), there MUST be
+  an integration test that verifies the actual HTTP response shape (not just unit tests of service methods).
+- Unit tests that mock the service layer are NOT sufficient for route changes — the Fastify response schema
+  can silently strip fields via fast-json-stringify, which unit tests cannot catch.
+- If route files were changed but no integration test exists for the changed endpoint(s), set
+  validation_result to 'failed' and describe which endpoint(s) lack integration test coverage.
+- This is a HARD REQUIREMENT, not a suggestion. Do NOT pass with a note about missing integration tests."
         else
             validation_section="STEP 2 — TEST VALIDATION: SKIPPED
 No changed files detected vs $BASE_BRANCH. Set validation_result to 'skipped'."


### PR DESCRIPTION
## Summary
- **Major-issue override**: When a reviewer says "approved" but flags issues with `severity: "major"`, the orchestrator overrides the verdict to `changes_requested` — applied to both PR review loop and per-task quality loop
- **Acceptance-test stage**: New pipeline stage after test_loop that hits actual API endpoints in Docker to verify the fix works end-to-end, not just in unit tests. Skips gracefully when Docker is unavailable.
- **Stricter test validation**: Changed API route files now MUST have integration tests that verify HTTP response shape. Missing integration tests = hard fail, not a note.

## Test plan
- [ ] Run pipeline on a bug-fix issue that changes API routes — verify acceptance-test stage runs and hits the endpoint
- [ ] Create a review with `result: "approved"` and `issues: [{severity: "major", ...}]` — verify it gets overridden to `changes_requested`
- [ ] Change a route file without adding integration tests — verify test-validate stage fails
- [ ] Run pipeline on a config-only change — verify acceptance-test stage skips gracefully
- [ ] Run pipeline without Docker available — verify acceptance-test stage skips with warning

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)