### PR TITLE
feat(#27): reduce token consumption via model tier tuning and context minimization

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,91 +1,26 @@
 ---
 name: code-reviewer
 description: |
-  Use this agent when a major project step has been completed and needs to be reviewed against the original plan and coding standards. Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the code-reviewer agent should review the work.</commentary></example>
+  Use this agent when a major project step has been completed and needs to be reviewed against the original plan and coding standards.
 model: sonnet
 ---
 
-You are a Senior Code Reviewer with expertise in software architecture, design patterns, and best practices. Your role is to review completed project steps against original plans and ensure code quality standards are met.
+You are a Senior Code Reviewer. Review completed project steps against plans and ensure code quality.
 
 ## Prior Iteration Context
 
-When reviewing code within a quality loop iteration (iterations 2+), you may receive prior iteration findings. If provided:
+When reviewing within a quality loop (iterations 2+), you may receive prior findings. If provided:
 
-1. **Verify fixes first** — Check each previously reported issue to confirm it was actually resolved
-2. **Do NOT re-report fixed issues** — If an issue from a prior iteration has been addressed, do not include it in your findings
-3. **Report only NEW issues** — Focus your review on problems not identified in prior iterations
-4. **Note verification results** — In your comments, briefly state which prior issues were verified as fixed
+1. **Verify fixes first** — Confirm previously reported issues were resolved
+2. **Do NOT re-report fixed issues** — Only report NEW issues
+3. **Note verification results** — Briefly state which prior issues were fixed
 
-This prevents review convergence failures where the same issues cycle through multiple iterations without resolution.
+## Review Focus
 
-When reviewing completed work, you will:
+1. **Plan Alignment** — Does the implementation match the planned approach?
+2. **Code Quality** — Patterns, error handling, type safety, maintainability
+3. **Architecture** — SOLID principles, separation of concerns, integration
+4. **Security** — Vulnerabilities, input validation, authentication
+5. **Issue Categorization** — Critical (must fix), Important (should fix), Suggestions (nice to have)
 
-1. **Plan Alignment Analysis**:
-   - Compare the implementation against the original planning document or step description
-   - Identify any deviations from the planned approach, architecture, or requirements
-   - Assess whether deviations are justified improvements or problematic departures
-   - Verify that all planned functionality has been implemented
-
-2. **Code Quality Assessment**:
-   - Review code for adherence to established patterns and conventions
-   - Check for proper error handling, type safety, and defensive programming
-   - Evaluate code organization, naming conventions, and maintainability
-   - Assess test coverage and quality of test implementations
-   - Look for potential security vulnerabilities or performance issues
-   - **TypeScript strictness**: Ensure `strict` mode compliance, no `any` types without justification, proper null checks
-   - **React component patterns**: Verify proper use of shadcn/ui components, correct prop typing, accessible markup
-   - **Fastify route patterns**: Validate response schema declarations, proper error handling, authentication middleware usage
-   - **Prisma patterns**: Check for N+1 query issues, proper transaction usage, correct relation handling
-
-3. **Architecture and Design Review**:
-   - Ensure the implementation follows SOLID principles and established architectural patterns
-   - Check for proper separation of concerns and loose coupling
-   - Verify that the code integrates well with existing systems
-   - Assess scalability and extensibility considerations
-   - **Frontend/Backend boundary**: Verify API proxy routes match backend endpoints, proper data serialization
-
-4. **Documentation and Standards**:
-   - Verify that code includes appropriate comments and documentation
-   - Check that JSDoc/TSDoc comments, function documentation, and inline comments are present and accurate
-   - Ensure adherence to project-specific coding standards and conventions
-
-5. **Issue Identification and Recommendations**:
-   - Clearly categorize issues as: Critical (must fix), Important (should fix), or Suggestions (nice to have)
-   - For each issue, provide specific examples and actionable recommendations
-   - When you identify plan deviations, explain whether they're problematic or beneficial
-   - Suggest specific improvements with code examples when helpful
-
-6. **Communication Protocol**:
-   - If you find significant deviations from the plan, ask the coding agent to review and confirm the changes
-   - If you identify issues with the original plan itself, recommend plan updates
-   - For implementation problems, provide clear guidance on fixes needed
-   - Always acknowledge what was done well before highlighting issues
-
-Your output should be structured, actionable, and focused on helping maintain high code quality while ensuring project goals are met. Be thorough but concise, and always provide constructive feedback that helps improve both the current implementation and future development practices.
-
-## Technology-Specific Review Checklist
-
-### TypeScript
-- [ ] No implicit `any` types
-- [ ] Proper use of discriminated unions and type guards
-- [ ] Exhaustive switch/case handling with `never` checks
-- [ ] Correct `async/await` usage (no floating promises)
-- [ ] Proper error boundaries in React components
-
-### Fastify Backend
-- [ ] Response schemas declared for all routes (fast-json-stringify strips undeclared fields)
-- [ ] Proper Prisma transaction usage for multi-step operations
-- [ ] Authentication middleware applied to protected routes
-- [ ] Input validation via Fastify JSON Schema
-
-### Next.js Frontend
-- [ ] Server components vs client components used appropriately
-- [ ] Proper use of `useSearchParams()` with `<Suspense>` boundaries
-- [ ] Data fetching follows established patterns (API proxy routes)
-- [ ] Accessible markup with proper ARIA attributes
-
-### Testing
-- [ ] Jest unit tests for services and utilities
-- [ ] Playwright E2E tests for user-facing flows
-- [ ] Test data cleanup to avoid accumulation across runs
-- [ ] No subprocess calls in unit tests (use direct APIs)
+Your output should be structured, actionable, and concise. Acknowledge what was done well before highlighting issues.

--- a/.claude/prompts/review-checklist.md
+++ b/.claude/prompts/review-checklist.md
@@ -1,0 +1,28 @@
+# Technology-Specific Review Checklist
+
+Apply these checks when reviewing code changes. Only check items relevant to the files modified.
+
+## TypeScript
+- No implicit `any` types
+- Proper use of discriminated unions and type guards
+- Exhaustive switch/case handling with `never` checks
+- Correct `async/await` usage (no floating promises)
+- Proper error boundaries in React components
+
+## Fastify Backend
+- Response schemas declared for all routes (fast-json-stringify strips undeclared fields)
+- Proper Prisma transaction usage for multi-step operations
+- Authentication middleware applied to protected routes
+- Input validation via Fastify JSON Schema
+
+## Next.js Frontend
+- Server components vs client components used appropriately
+- Proper use of `useSearchParams()` with `<Suspense>` boundaries
+- Data fetching follows established patterns (API proxy routes)
+- Accessible markup with proper ARIA attributes
+
+## Testing
+- Jest unit tests for services and utilities
+- Playwright E2E tests for user-facing flows
+- Test data cleanup to avoid accumulation across runs
+- No subprocess calls in unit tests (use direct APIs)

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -802,6 +802,14 @@ run_stage() {
         fallback_args=(--fallback-model "$fallback_model")
     fi
 
+    # Cap exploration for light-tier (haiku) stages — these are mechanical and
+    # should complete in a few turns rather than open-endedly exploring.
+    local -a turns_args=()
+    if [[ "$model" == "haiku" ]]; then
+        turns_args=(--max-turns 5)
+        log "  Max turns: 5 (light-tier cap)"
+    fi
+
     local output
     local exit_code=0
 
@@ -809,6 +817,7 @@ run_stage() {
         ${agent_args[@]+"${agent_args[@]}"} \
         --model "$model" \
         ${fallback_args[@]+"${fallback_args[@]}"} \
+        ${turns_args[@]+"${turns_args[@]}"} \
         --dangerously-skip-permissions \
         --output-format json \
         --json-schema "$schema" \
@@ -833,6 +842,7 @@ run_stage() {
             ${agent_args[@]+"${agent_args[@]}"} \
             --model "$model" \
             ${fallback_args[@]+"${fallback_args[@]}"} \
+            ${turns_args[@]+"${turns_args[@]}"} \
             --dangerously-skip-permissions \
             --output-format json \
             --json-schema "$schema" \

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -33,27 +33,28 @@ _tier_to_model() {
 #
 # Each orchestrator stage maps to a tier based on its cognitive demands.
 #
-# light    — mechanical: parse markdown, run commands, fill templates
-# standard — judgment: reviews, simple implementations, pattern matching
+# light    — mechanical: parse markdown, run commands, fill templates, simplify
+# standard — judgment: reviews, fixes, pattern matching
 # advanced — deep reasoning: complex implementation, root cause analysis
 #
 
 _stage_to_tier() {
 	case "$1" in
-		parse-issue)   printf '%s' "light" ;;
-		validate-plan) printf '%s' "light" ;;
-		implement)     printf '%s' "advanced" ;;
-		task-review)   printf '%s' "standard" ;;
-		fix)           printf '%s' "advanced" ;;
-		test)          printf '%s' "light" ;;
-		review)        printf '%s' "standard" ;;
-		simplify)      printf '%s' "standard" ;;
-		pr)            printf '%s' "light" ;;
-		spec-review)   printf '%s' "standard" ;;
-		code-review)   printf '%s' "standard" ;;
-		complete)      printf '%s' "light" ;;
-		docs)          printf '%s' "light" ;;
-		*)             printf '%s' "" ;;
+		parse-issue)    printf '%s' "light" ;;
+		validate-plan)  printf '%s' "light" ;;
+		implement)      printf '%s' "advanced" ;;
+		task-review)    printf '%s' "standard" ;;
+		fix)            printf '%s' "standard" ;;
+		test)           printf '%s' "light" ;;
+		review)         printf '%s' "standard" ;;
+		simplify)       printf '%s' "light" ;;
+		pr)             printf '%s' "light" ;;
+		spec-review)    printf '%s' "standard" ;;
+		code-review)    printf '%s' "standard" ;;
+		complete)       printf '%s' "light" ;;
+		docs)           printf '%s' "light" ;;
+		acceptance-test) printf '%s' "light" ;;
+		*)              printf '%s' "" ;;
 	esac
 }
 
@@ -67,8 +68,8 @@ _stage_to_tier() {
 
 _complexity_to_tier() {
 	case "$1" in
-		S) printf '%s' "standard" ;;
-		M) printf '%s' "advanced" ;;
+		S) printf '%s' "light" ;;
+		M) printf '%s' "standard" ;;
 		L) printf '%s' "advanced" ;;
 		*) printf '%s' "" ;;
 	esac
@@ -88,7 +89,7 @@ _complexity_to_tier() {
 # All known stage prefixes, ordered longest-first for greedy matching
 if [[ -z "${_STAGE_PREFIXES+set}" ]]; then
 	readonly -a _STAGE_PREFIXES=(
-		spec-review code-review task-review validate-plan
+		acceptance-test spec-review code-review task-review validate-plan
 		parse-issue implement simplify complete review test docs fix pr
 	)
 fi
@@ -146,10 +147,11 @@ resolve_model() {
 	fi
 
 	# Apply complexity hint — overrides stage default when provided.
-	# Light-tier stages (test, parse-issue, validate-plan, pr, complete, docs)
-	# are mechanical and always use haiku; complexity hints are ignored for them.
-	# The quality loop forwards task-level complexity to implement, simplify,
-	# review, and fix stages so model selection scales with task size.
+	# Light-tier stages (test, parse-issue, validate-plan, pr, complete, docs,
+	# simplify, acceptance-test) are mechanical and always use haiku;
+	# complexity hints are ignored for them.
+	# The quality loop forwards task-level complexity to implement, review,
+	# and fix stages so model selection scales with task size.
 	if [[ -n "$complexity" && "$tier" != "light" ]]; then
 		local complexity_tier
 		complexity_tier=$(_complexity_to_tier "$complexity")

--- a/README.md
+++ b/README.md
@@ -191,6 +191,35 @@ Other preserved principles:
 - **Quality gates over trust** — every implementation goes through multiple reviews
 - **Delete aggressively** — remove what you don't need
 
+## Token Efficiency
+
+Over 99% of token usage is Claude **reading** context, not writing. These practices reduce consumption significantly.
+
+### Conversation Hygiene
+
+- **One conversation per task.** Long conversations compound cost — message #80 costs 2x more than message #5 because the entire history is re-read each turn.
+- **Be specific.** "Fix the bug in `src/auth.js` line 42" triggers far fewer tool calls than "fix the login bug". Specificity reduces exploratory reading.
+- **Start fresh when switching topics.** Paste a short summary in your first message instead of carrying forward hundreds of messages.
+
+### Model Selection
+
+- **Use `/model` to switch tiers.** Haiku handles simple tasks (run tests, format code, quick questions) at a fraction of Opus cost.
+- **The pipeline auto-selects models** via `model-config.sh`: haiku for mechanical stages (parse, test, simplify, PR creation), sonnet for reviews, opus for complex implementation.
+- **S-complexity tasks use haiku.** Small mechanical tasks don't need heavy reasoning.
+
+### CLAUDE.md Size
+
+Your CLAUDE.md is re-read on every message in every conversation. Each line compounds across the entire session.
+
+- Keep it under 200 lines. Move rarely-needed sections to separate files.
+- Remove technology checklists from agent definitions — put them in stage-specific prompts loaded only when needed.
+
+### Pipeline-Specific
+
+- **Agent definitions are loaded globally.** Keep `.claude/agents/*.md` files focused on role identity (under 40 lines). Technology checklists belong in `.claude/prompts/` — loaded once per stage, not every invocation.
+- **Light-tier stages cap at 5 turns** via `--max-turns` to prevent open-ended exploration.
+- **Parallel subagents** reduce wall-clock time and prevent context accumulation in a single session.
+
 ## License
 
 MIT — see [LICENSE](LICENSE)


### PR DESCRIPTION
## Summary

- **Model tier tuning**: Downgraded `simplify` from standard→light, `fix` from advanced→standard, S-complexity from standard→light, M-complexity from advanced→standard. Added `acceptance-test` as light tier.
- **Agent slimming**: Reduced `code-reviewer.md` from 92→26 lines. Extracted technology-specific checklists to `prompts/review-checklist.md` (loaded per-stage, not globally).
- **Turn caps**: Added `--max-turns 5` for all haiku (light-tier) stages to prevent open-ended exploration on mechanical tasks.
- **Documentation**: Added Token Efficiency section to README covering conversation hygiene, model selection, CLAUDE.md sizing, and pipeline-specific practices.

Closes #27

## Test plan

- [ ] Verify `model-config.sh` resolves correctly: `source .claude/scripts/model-config.sh && resolve_model "simplify" ""` → haiku
- [ ] Verify S-complexity: `resolve_model "implement-task-1" "S"` → haiku
- [ ] Verify M-complexity: `resolve_model "implement-task-1" "M"` → sonnet
- [ ] Verify L-complexity: `resolve_model "implement-task-1" "L"` → opus
- [ ] Verify `--max-turns` appears in haiku stage invocations (check orchestrator log)
- [ ] Verify `code-reviewer.md` is under 40 lines
- [ ] Verify `prompts/review-checklist.md` contains the extracted checklists
- [ ] Run existing BATS tests: `cd .claude/scripts/implement-issue-test && ./run-tests.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)