### PR TITLE
feat(#29): embed token efficiency practices into 5 existing skills

### DIFF
--- a/.claude/skills/adapting-claude-pipeline/SKILL.md
+++ b/.claude/skills/adapting-claude-pipeline/SKILL.md
@@ -163,6 +163,15 @@ Categorize every `.claude/` file into one of four buckets:
 |--------|-----------------|
 | frontend audit/refactor | Delete if not web, replace if different frontend |
 
+#### Token Efficiency Audit
+
+Context size compounds across every message in every conversation. Audit these during adaptation:
+
+- [ ] CLAUDE.md under 200 lines (re-read on every message in every conversation — each line multiplies)
+- [ ] Each agent file body under 40 lines (loaded globally; move technology checklists to `.claude/prompts/`)
+- [ ] No technology-specific checklists in agent definitions (put in stage-specific prompts, loaded once per invocation)
+- [ ] Rarely-used CLAUDE.md sections moved to separate files that are read on-demand
+
 ### Phase 4: Write the Plan
 
 **REQUIRED:** Use the `writing-plans` skill.

--- a/.claude/skills/explore/SKILL.md
+++ b/.claude/skills/explore/SKILL.md
@@ -133,6 +133,15 @@ The `## Implementation Tasks` section must use this parseable convention:
 - **YAGNI** — only plan what's needed, don't gold-plate
 - **Minimal questions** — if the description is clear enough, proceed without asking
 
+## Token Efficiency
+
+Task sizing directly controls model cost via `model-config.sh`:
+
+- **Prefer S-complexity tasks** — they use haiku (cheapest model). Only use M/L when the work genuinely requires it.
+- **Split M/L tasks into multiple S tasks** when the work is decomposable into independent steps.
+- **Point tasks to specific files and line numbers** — vague descriptions cause subagents to explore broadly, triggering 19x more tool calls.
+- **Each task's affected file list reduces subagent exploration cost** — include file paths in the task description.
+
 ## Integration
 
 **Produces:** A GitHub Issue ready for `/implement-issue N main`

--- a/.claude/skills/subagent-driven-development/implementer-prompt.md
+++ b/.claude/skills/subagent-driven-development/implementer-prompt.md
@@ -4,6 +4,15 @@ Use this template when dispatching an implementer subagent.
 
 **CRITICAL:** Always include the feature branch name. Subagents have no memory of branch context.
 
+## Context Minimization
+
+Every token in the subagent prompt is re-read on each tool call the subagent makes. Keep prompts lean:
+
+- **Include ONLY the task description and directly affected file paths** — not the full issue body.
+- **Do NOT paste the full issue body** — the subagent can `gh issue view` if it needs broader context.
+- **Reference specific files and line numbers** rather than "find the relevant code" — this prevents broad exploratory searches.
+- **Shorter prompts = fewer input tokens re-read on every tool call** within the subagent session.
+
 **Agent selection:** Choose the appropriate `subagent_type` based on task:
 - `laravel-backend-developer` — Backend tasks (PHP, Laravel, APIs, database)
 - `bulletproof-frontend-developer` — Frontend tasks (CSS, HTML, Blade, JS, accessibility)

--- a/.claude/skills/using-skills/SKILL.md
+++ b/.claude/skills/using-skills/SKILL.md
@@ -85,3 +85,11 @@ The skill itself tells you which.
 ## User Instructions
 
 Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
+
+## Token Awareness
+
+Over 99% of token usage is reading, not writing. These practices reduce cost significantly:
+
+- **Conversation length:** If a conversation exceeds ~40 messages, suggest starting a fresh conversation with a brief summary. Long conversations cost 2x+ more per message due to context re-reading.
+- **Model selection:** For simple tasks (run tests, format files, quick questions), suggest `/model haiku`. Save opus for complex multi-file changes and architecture decisions.
+- **Be specific:** "Fix the bug in `src/auth.js` line 42" triggers far fewer tool calls than "fix the login bug". File paths and line numbers reduce exploratory reading.

--- a/.claude/skills/writing-agents/SKILL.md
+++ b/.claude/skills/writing-agents/SKILL.md
@@ -386,6 +386,9 @@ Test edge cases:
 - [ ] Persona is specific, not generic
 - [ ] Anti-patterns are actionable, not vague
 - [ ] No process summary in description
+- [ ] Agent file body under 40 lines (move checklists to `.claude/prompts/`)
+- [ ] No technology-specific checklists in agent body (loaded globally every invocation — put in stage prompts instead)
+- [ ] Model tier matches agent complexity (haiku for simple tasks, sonnet for reviews, opus for complex reasoning)
 
 **Deployment:**
 - [ ] Agent file written to `.claude/agents/[name].md`


### PR DESCRIPTION
## Summary

- **`using-skills`**: Added Token Awareness section — conversation length guidance (~40 msg threshold), `/model haiku` for simple tasks, specificity reduces tool calls
- **`writing-agents`**: Added 3 quality checks — agent body under 40 lines, no tech checklists in agents, model tier appropriate to complexity
- **`explore`**: Added Token Efficiency section — prefer S-complexity (uses haiku), split M/L into S when possible, include file paths in task descriptions
- **`adapting-claude-pipeline`**: Added Token Efficiency Audit checklist in Phase 3 — CLAUDE.md under 200 lines, agent files under 40 lines, checklists in prompts not agents
- **`implementer-prompt.md`**: Added Context Minimization section — lean prompts, no full issue body, specific file references

Moves token efficiency from passive README documentation (#27) to active enforcement at the 5 natural decision points where token-costly choices are made.

Closes #29

## Test plan

- [ ] Verify `using-skills/SKILL.md` contains "Token Awareness" section
- [ ] Verify `writing-agents/SKILL.md` Quality Checks includes 40-line limit and no-checklists rule
- [ ] Verify `explore/SKILL.md` contains "Token Efficiency" section between Key Principles and Integration
- [ ] Verify `adapting-claude-pipeline/SKILL.md` Phase 3 contains "Token Efficiency Audit" checklist
- [ ] Verify `implementer-prompt.md` contains "Context Minimization" section before agent selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)