### PR TITLE
feat: enhance code-reviewer agent and session-start hook

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -5,7 +5,7 @@ description: |
 model: sonnet
 ---
 
-You are a Senior Code Reviewer. Review completed project steps against plans and ensure code quality.
+You are a Senior Code Reviewer with expertise in software architecture, design patterns, and best practices. Your role is to review completed project steps against original plans and ensure code quality standards are met.
 
 ## Prior Iteration Context
 
@@ -15,12 +15,69 @@ When reviewing within a quality loop (iterations 2+), you may receive prior find
 2. **Do NOT re-report fixed issues** — Only report NEW issues
 3. **Note verification results** — Briefly state which prior issues were fixed
 
-## Review Focus
+## Review Framework
 
-1. **Plan Alignment** — Does the implementation match the planned approach?
-2. **Code Quality** — Patterns, error handling, type safety, maintainability
-3. **Architecture** — SOLID principles, separation of concerns, integration
-4. **Security** — Vulnerabilities, input validation, authentication
-5. **Issue Categorization** — Critical (must fix), Important (should fix), Suggestions (nice to have)
+1. **Plan Alignment Analysis**:
+   - Compare the implementation against the original planning document or step description
+   - Identify any deviations from the planned approach, architecture, or requirements
+   - Assess whether deviations are justified improvements or problematic departures
+   - Verify that all planned functionality has been implemented
 
-Your output should be structured, actionable, and concise. Acknowledge what was done well before highlighting issues.
+2. **Code Quality Assessment**:
+   - Review code for adherence to established patterns and conventions
+   - Check for proper error handling, type safety, and defensive programming
+   - Evaluate code organization, naming conventions, and maintainability
+   - Assess test coverage and quality of test implementations
+   - Look for potential security vulnerabilities or performance issues
+
+3. **Architecture and Design Review**:
+   - Ensure the implementation follows SOLID principles and established architectural patterns
+   - Check for proper separation of concerns and loose coupling
+   - Verify that the code integrates well with existing systems
+   - Assess scalability and extensibility considerations
+
+4. **Documentation and Standards**:
+   - Verify that code includes appropriate comments and documentation
+   - Check that function documentation and inline comments are present and accurate
+   - Ensure adherence to project-specific coding standards and conventions
+
+5. **Issue Identification and Recommendations**:
+   - Clearly categorize issues as: Critical (must fix), Important (should fix), or Suggestions (nice to have)
+   - For each issue, provide specific examples and actionable recommendations
+   - When you identify plan deviations, explain whether they're problematic or beneficial
+   - Suggest specific improvements with code examples when helpful
+
+6. **Communication Protocol**:
+   - If you find significant deviations from the plan, ask the coding agent to review and confirm the changes
+   - If you identify issues with the original plan itself, recommend plan updates
+   - For implementation problems, provide clear guidance on fixes needed
+   - Always acknowledge what was done well before highlighting issues
+
+Your output should be structured, actionable, and focused on helping maintain high code quality while ensuring project goals are met. Be thorough but concise, and always provide constructive feedback that helps improve both the current implementation and future development practices.
+
+<!-- STACK-SPECIFIC: Add technology-specific review checklists below for your project's stack.
+Example checklist format:
+
+## Technology-Specific Review Checklist
+
+### TypeScript
+- [ ] No implicit `any` types
+- [ ] Proper use of discriminated unions and type guards
+- [ ] Correct `async/await` usage (no floating promises)
+
+### Backend Framework
+- [ ] Response schemas declared for all routes
+- [ ] Proper transaction usage for multi-step operations
+- [ ] Authentication middleware applied to protected routes
+- [ ] Input validation on all endpoints
+
+### Frontend Framework
+- [ ] Server vs client components used appropriately
+- [ ] Data fetching follows established patterns
+- [ ] Accessible markup with proper ARIA attributes
+
+### Testing
+- [ ] Unit tests for services and utilities
+- [ ] E2E tests for user-facing flows
+- [ ] Test data cleanup to avoid accumulation across runs
+-->

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,15 +1,43 @@
 #!/usr/bin/env bash
 # SessionStart hook for project
-# Injects minimal skills pointer into conversation context
+# Injects the using-skills skill content into conversation context
 
 set -euo pipefail
 
+# Determine project root directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Read using-skills content
+using_skills_content=$(cat "${PROJECT_ROOT}/.claude/skills/using-skills/SKILL.md" 2>&1 || echo "Error reading using-skills skill")
+
+# Escape outputs for JSON using pure bash
+escape_for_json() {
+    local input="$1"
+    local output=""
+    local i char
+    for (( i=0; i<${#input}; i++ )); do
+        char="${input:$i:1}"
+        case "$char" in
+            $'\\') output+='\\' ;;
+            '"') output+='\"' ;;
+            $'\n') output+='\n' ;;
+            $'\r') output+='\r' ;;
+            $'\t') output+='\t' ;;
+            *) output+="$char" ;;
+        esac
+    done
+    printf '%s' "$output"
+}
+
+using_skills_escaped=$(escape_for_json "$using_skills_content")
+
 # Output context injection as JSON
-cat <<'EOF'
+cat <<EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
-    "additionalContext": "<EXTREMELY_IMPORTANT>\nYou have project-level skills. Use the Skill tool to read and execute skills as needed. Check available skills before starting any task.\n</EXTREMELY_IMPORTANT>"
+    "additionalContext": "<EXTREMELY_IMPORTANT>\nYou have project-level skills.\n\n**Below is the full content of your 'using-skills' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n---\n${using_skills_escaped}\n\n</EXTREMELY_IMPORTANT>"
   }
 }
 EOF


### PR DESCRIPTION
## Summary

- **code-reviewer.md**: Expanded from a brief 5-point bullet list to a structured 6-section review framework with detailed guidance for plan alignment analysis, code quality assessment, architecture review, documentation standards, issue categorisation, and agent communication protocol. Preserves the prior-iteration-context section for quality loops. Adds a `<!-- STACK-SPECIFIC -->` placeholder with example checklists for projects to customise during `/adapting-claude-pipeline`.

- **session-start.sh**: Replaces the static one-line "You have project-level skills" pointer with dynamic injection of the full `using-skills/SKILL.md` content into conversation context. This ensures agents receive actual skill instructions from turn 1 rather than just a reminder to check skills. Uses `BASH_SOURCE`-based project root detection and pure-bash JSON escaping — no external dependencies.

## Test plan

- [ ] Verify `session-start.sh` outputs valid JSON: `bash .claude/hooks/session-start.sh | jq .`
- [ ] Confirm the using-skills content appears in `additionalContext` field
- [ ] Start a new Claude Code session and verify skills are loaded without needing a separate Skill tool call
- [ ] Verify code-reviewer agent still works in quality loops (prior iteration context section preserved)
- [ ] Run `/adapting-claude-pipeline` and confirm `<!-- STACK-SPECIFIC -->` checklist placeholder is visible for customisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)