### PR TITLE
fix: make orchestrator platform-agnostic and fix Jira integration

### DIFF
--- a/.claude/config/platform.sh
+++ b/.claude/config/platform.sh
@@ -22,6 +22,15 @@ TEST_UNIT_CMD="${TEST_UNIT_CMD:-}"        # e.g., "npm test", "vendor/bin/phpuni
 TEST_E2E_CMD="${TEST_E2E_CMD:-}"          # e.g., "npx playwright test" — empty if no E2E
 TEST_E2E_BASE_URL="${TEST_E2E_BASE_URL:-}"
 
+# Claude CLI (resolve path for non-interactive shells where aliases aren't available)
+if [[ -z "${CLAUDE_CLI:-}" ]]; then
+  if [[ -x "$HOME/.claude/local/claude" ]]; then
+    CLAUDE_CLI="$HOME/.claude/local/claude"
+  else
+    CLAUDE_CLI="claude"
+  fi
+fi
+
 # Lint and format (set during /adapt)
 LINT_CMD="${LINT_CMD:-}"
 FORMAT_CMD="${FORMAT_CMD:-}"

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -121,11 +121,11 @@ Usage: $0 --issue <number> --branch <name> [options]
        $0 --resume-from <log-dir>
 
 Options:
-  --issue <number>       GitHub issue number (required for new runs)
+  --issue <number>       Issue number or key (required for new runs)
   --branch <name>        Base branch for PR (required for new runs)
   --agent <name>         Default agent for setup stage (optional)
   --status-file <path>   Custom status file path (optional)
-  --quiet                Suppress all issue comments (no GitHub issue noise)
+  --quiet                Suppress all issue comments (no tracker noise)
   --resume               Resume from existing status.json
   --resume-from <dir>    Resume from specific log directory
 
@@ -586,28 +586,13 @@ sync_status_to_log() {
 }
 
 # =============================================================================
-# GITHUB COMMENT HELPERS
+# ISSUE/PR COMMENT HELPERS
 # =============================================================================
-
-# Auto-detect repository from env var or git remote
-if [[ -n "${GITHUB_REPO:-}" ]]; then
-	REPO="$GITHUB_REPO"
-else
-	# Parse from git remote (handles both HTTPS and SSH URLs)
-	REPO=$(git remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
-fi
-
-if [[ -z "$REPO" ]]; then
-	echo "ERROR: Could not determine GitHub repository." >&2
-	echo "Set GITHUB_REPO=owner/repo or run from a repo with a GitHub remote." >&2
-	exit 3
-fi
-log "Using GitHub repository: $REPO"
 
 # comment_issue <title> <body> [agent]
 # If agent is provided, shows "Written by `agent`", otherwise "Posted by orchestrator"
 # When QUIET=true, this is a no-op — ALL issue comments are suppressed (use --quiet
-# for automated runs where GitHub issue noise should be eliminated entirely).
+# for automated runs where issue tracker noise should be eliminated entirely).
 comment_issue() {
 	[[ "${QUIET:-false}" == "true" ]] && return 0
 	local title="$1"
@@ -815,18 +800,26 @@ run_stage() {
         fallback_args=(--fallback-model "$fallback_model")
     fi
 
-    # Cap exploration for light-tier (haiku) stages — these are mechanical and
-    # should complete in a few turns rather than open-endedly exploring.
+    # Cap exploration for inherently light-tier stages (parse, pr, complete, etc.)
+    # These are mechanical and should complete in a few turns.
+    # Do NOT cap implement/review/fix stages that use haiku via S-complexity override —
+    # those still need enough turns to read files, make edits, and produce output.
     local -a turns_args=()
-    if [[ "$model" == "haiku" ]]; then
-        turns_args=(--max-turns 5)
-        log "  Max turns: 5 (light-tier cap)"
+    local _matched_prefix _inherent_tier
+    _matched_prefix=$(_match_stage_prefix "$stage_name") || true
+    _inherent_tier=$(_stage_to_tier "${_matched_prefix:-}")
+    if [[ "$model" == "haiku" && "$_inherent_tier" == "light" ]]; then
+        turns_args=(--max-turns 10)
+        log "  Max turns: 10 (inherently light stage)"
+    elif [[ "$model" == "haiku" ]]; then
+        turns_args=(--max-turns 15)
+        log "  Max turns: 15 (haiku via complexity override)"
     fi
 
     local output
     local exit_code=0
 
-    output=$(timeout "$stage_timeout" env -u CLAUDECODE claude -p "$prompt" \
+    output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
         ${agent_args[@]+"${agent_args[@]}"} \
         --model "$model" \
         ${fallback_args[@]+"${fallback_args[@]}"} \
@@ -851,7 +844,7 @@ run_stage() {
     if detect_rate_limit "$output"; then
         handle_rate_limit "$output"
         # Retry
-        output=$(timeout "$stage_timeout" env -u CLAUDECODE claude -p "$prompt" \
+        output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
             ${agent_args[@]+"${agent_args[@]}"} \
             --model "$model" \
             ${fallback_args[@]+"${fallback_args[@]}"} \
@@ -1465,7 +1458,7 @@ $validation_section
 
 Output both test results and validation findings in one structured response.
 - result: 'passed' or 'failed' (from test execution)
-- summary: overall summary suitable for a GitHub comment
+- summary: overall summary suitable for an issue comment
 - validation_result: 'passed', 'failed', or 'skipped'
 - validation_issues: array of issues found (if any)
 - pre_existing_issues: array of pre-existing quality issues (informational only)
@@ -1697,7 +1690,7 @@ Log directory: \`$LOG_BASE\`"
     else
         set_stage_started "parse_issue"
 
-        log "Fetching issue #$ISSUE_NUMBER from GitHub..."
+        log "Fetching issue #$ISSUE_NUMBER..."
         local issue_body
         issue_body=$("$PLATFORM_DIR/read-issue.sh" "$ISSUE_NUMBER" 2>>"${LOG_FILE:-/dev/stderr}" | jq -r '.body')
 
@@ -1723,16 +1716,17 @@ Log directory: \`$LOG_BASE\`"
         fi
 
         # Parse tasks into JSON array
-        # Regex matches only unchecked boxes: - [ ] `[agent]` description
-        # This is intentional — checked boxes [x] are considered already
-        # complete and are skipped during parsing.
+        # Regex matches both GitHub checkboxes and plain Jira bullets:
+        #   - [ ] `[agent]` description   (GitHub — unchecked only)
+        #   - `[agent]` description        (Jira — no checkbox syntax)
+        # Checked boxes [x] are considered already complete and skipped.
         local task_id=0
         tasks_json="[]"
         while IFS= read -r line; do
-            if [[ "$line" =~ ^-\ \[\ \]\ \`\[([^\]]+)\]\`\ (.+)$ ]]; then
+            if [[ "$line" =~ ^-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
                 task_id=$((task_id + 1))
-                local agent="${BASH_REMATCH[1]}"
-                local desc="${BASH_REMATCH[2]}"
+                local agent="${BASH_REMATCH[2]}"
+                local desc="${BASH_REMATCH[3]}"
                 tasks_json=$(printf '%s' "$tasks_json" | jq \
                     --argjson id "$task_id" \
                     --arg desc "$desc" \
@@ -2059,7 +2053,7 @@ $impl_summary" "$task_agent"
         # After PR tests pass, run jest --changedSince once to surface any
         # pre-existing failures pulled in by the dependency graph.  This does
         # NOT block the pipeline — failures are posted as an informational
-        # GitHub comment so maintainers are aware.
+        # issue comment so maintainers are aware.
         # ---------------------------------------------------------------------
         if [[ "$branch_scope" == "typescript" || "$branch_scope" == "mixed" ]]; then
             log "Running informational full-scope check (non-blocking)..."
@@ -2221,15 +2215,13 @@ Add comprehensive JSDoc/TSDoc comments and commit with message: docs(issue-$ISSU
     else
         set_stage_started "pr"
 
-        local pr_prompt="Create or update PR for issue #$ISSUE_NUMBER.
+        local pr_prompt="Create a merge request for issue #$ISSUE_NUMBER.
 
-If no PR exists, create one:
-Use the platform wrapper to create a PR/MR:
-$PLATFORM_DIR/create-mr.sh --source "\$branch" --target "$BASE_BRANCH" --title 'feat(issue-$ISSUE_NUMBER): <description>' --body '<body with Closes #$ISSUE_NUMBER>'
+Run this exact command (substitute a short description for <description>):
 
-If PR exists, push and comment.
+git push -u origin $branch 2>/dev/null; $PLATFORM_DIR/create-mr.sh --source '$branch' --target '$BASE_BRANCH' --title 'feat(issue-$ISSUE_NUMBER): <description>' --body 'Closes #$ISSUE_NUMBER'
 
-Include 'Closes #$ISSUE_NUMBER' in the body."
+The command will output the MR number. Use that as pr_number in your response."
 
         local pr_result
         pr_result=$(run_stage "pr" "$pr_prompt" "implement-issue-pr.json")
@@ -2297,7 +2289,7 @@ Include 'Closes #$ISSUE_NUMBER' in the body."
 Part 1 — Spec Review: Verify the PR achieves the goals of the issue. Check goal achievement, not code quality. Flag scope creep.
 Part 2 — Code Review: Review code quality, patterns, standards, and security.
 
-Approve or request changes. Output a summary suitable for a GitHub comment."
+Approve or request changes. Output a summary suitable for an issue comment."
 
         local review_result
         review_result=$(run_stage "pr-review-iter-$pr_iteration" "$review_prompt" "implement-issue-review.json" "code-reviewer")
@@ -2399,7 +2391,7 @@ Include:
 - Reviews passed
 - Final status
 
-Output a summary suitable for a GitHub PR comment."
+Output a summary suitable for a PR/MR comment."
 
         local complete_result
         complete_result=$(run_stage "complete" "$complete_prompt" "implement-issue-complete.json")

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -49,6 +49,8 @@ _stage_to_tier() {
 		review)         printf '%s' "standard" ;;
 		simplify)       printf '%s' "light" ;;
 		pr)             printf '%s' "light" ;;
+		pr-review)      printf '%s' "standard" ;;
+		pr-fix)         printf '%s' "standard" ;;
 		spec-review)    printf '%s' "standard" ;;
 		code-review)    printf '%s' "standard" ;;
 		complete)       printf '%s' "light" ;;
@@ -90,7 +92,7 @@ _complexity_to_tier() {
 if [[ -z "${_STAGE_PREFIXES+set}" ]]; then
 	readonly -a _STAGE_PREFIXES=(
 		acceptance-test spec-review code-review task-review validate-plan
-		parse-issue implement simplify complete review test docs fix pr
+		parse-issue implement simplify complete pr-review pr-fix review test docs fix pr
 	)
 fi
 

--- a/.claude/scripts/platform/adf-to-markdown.py
+++ b/.claude/scripts/platform/adf-to-markdown.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Convert Jira ADF (Atlassian Document Format) JSON to markdown.
+
+Reads a Jira workitem JSON from stdin (as returned by acli --json),
+outputs JSON { title, body, status } with body as markdown text.
+"""
+
+import json
+import sys
+
+
+def adf_to_md(node):
+    """Recursively convert an ADF node to markdown."""
+    if isinstance(node, str):
+        return node
+    if not isinstance(node, dict):
+        return ""
+
+    t = node.get("type", "")
+    content = node.get("content", [])
+    text = node.get("text", "")
+
+    # Inline text with marks
+    if t == "text":
+        marks = [m["type"] for m in node.get("marks", [])]
+        if "code" in marks:
+            return "`" + text + "`"
+        if "strong" in marks:
+            return "**" + text + "**"
+        if "em" in marks:
+            return "*" + text + "*"
+        return text
+
+    # Block nodes
+    hashes = {1: "#", 2: "##", 3: "###", 4: "####", 5: "#####", 6: "######"}
+    if t == "doc":
+        return "\n".join(adf_to_md(c) for c in content)
+    if t == "heading":
+        level = node.get("attrs", {}).get("level", 2)
+        prefix = hashes.get(level, "##")
+        inline = "".join(adf_to_md(c) for c in content)
+        return prefix + " " + inline
+    if t == "paragraph":
+        return "".join(adf_to_md(c) for c in content)
+    if t == "bulletList":
+        items = []
+        for item in content:
+            item_text = "\n".join(adf_to_md(c) for c in item.get("content", []))
+            items.append("- " + item_text)
+        return "\n".join(items)
+    if t == "orderedList":
+        items = []
+        for i, item in enumerate(content, 1):
+            item_text = "\n".join(adf_to_md(c) for c in item.get("content", []))
+            items.append(str(i) + ". " + item_text)
+        return "\n".join(items)
+    if t == "listItem":
+        return "\n".join(adf_to_md(c) for c in content)
+    if t == "codeBlock":
+        lang = node.get("attrs", {}).get("language", "")
+        code = "".join(adf_to_md(c) for c in content)
+        return "```" + lang + "\n" + code + "\n```"
+
+    # Fallback: recurse into content
+    return "".join(adf_to_md(c) for c in content)
+
+
+def main():
+    data = json.load(sys.stdin)
+    fields = data.get("fields", {})
+    desc = fields.get("description", "")
+
+    if isinstance(desc, dict):
+        body = adf_to_md(desc)
+    elif isinstance(desc, str):
+        body = desc
+    else:
+        body = ""
+
+    result = {
+        "title": fields.get("summary", ""),
+        "body": body,
+        "status": fields.get("status", {}).get("name", ""),
+    }
+    json.dump(result, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/platform/comment-issue.sh
+++ b/.claude/scripts/platform/comment-issue.sh
@@ -8,5 +8,5 @@ ISSUE="$1" COMMENT="$2"
 
 case "$TRACKER" in
   github) gh issue comment "$ISSUE" --body "$COMMENT" ;;
-  jira) acli jira add-comment --issue "$ISSUE" --comment "$COMMENT" ;;
+  jira) acli jira workitem comment create --key "$ISSUE" --body "$COMMENT" ;;
 esac

--- a/.claude/scripts/platform/create-issue.sh
+++ b/.claude/scripts/platform/create-issue.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
-# Usage: create-issue.sh --title "Title" --body "Body" [--labels "bug,critical"]
+# Usage: create-issue.sh --title "Title" --body "Body" [--labels "bug,critical"] [--parent "EPIC-KEY"]
 # Returns: issue number or key on stdout (e.g., "42" or "KIN-123")
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../../config/platform.sh"
 
-TITLE="" BODY="" LABELS=""
+TITLE="" BODY="" LABELS="" PARENT=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --title) TITLE="$2"; shift 2 ;;
     --body) BODY="$2"; shift 2 ;;
     --labels) LABELS="$2"; shift 2 ;;
+    --parent) PARENT="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
@@ -22,11 +23,13 @@ case "$TRACKER" in
     "${ARGS[@]}" 2>/dev/null | grep -oE '[0-9]+$'
     ;;
   jira)
-    acli jira create-issue \
-      --project "$JIRA_PROJECT" \
-      --type "$JIRA_DEFAULT_ISSUE_TYPE" \
-      --summary "$TITLE" \
-      --description "$BODY" 2>/dev/null \
-      | grep -oE '[A-Z]+-[0-9]+'
+    ARGS=(acli jira workitem create
+      --project "$JIRA_PROJECT"
+      --type "$JIRA_DEFAULT_ISSUE_TYPE"
+      --summary "$TITLE"
+      --description "$BODY")
+    [[ -n "$PARENT" ]] && ARGS+=(--parent "$PARENT")
+    [[ -n "$LABELS" ]] && ARGS+=(--label "$LABELS")
+    "${ARGS[@]}" 2>/dev/null | grep -oE '[A-Z]+-[0-9]+'
     ;;
 esac

--- a/.claude/scripts/platform/read-issue.sh
+++ b/.claude/scripts/platform/read-issue.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Usage: read-issue.sh <issue-number-or-key>
 # Returns: JSON { title, body, status }
+# Body is always returned as plain markdown text.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../../config/platform.sh"
@@ -13,7 +14,9 @@ case "$TRACKER" in
       | jq '{ title, body, status: .state }'
     ;;
   jira)
-    acli jira get-issue --issue "$ISSUE" --outputFormat json 2>/dev/null \
-      | jq '{ title: .fields.summary, body: .fields.description, status: .fields.status.name }'
+    # acli returns description as ADF (Atlassian Document Format) JSON.
+    # Pipe through adf-to-markdown.py to convert to { title, body, status }.
+    acli jira workitem view "$ISSUE" --fields summary,description,status --json 2>/dev/null \
+      | python3 "$SCRIPT_DIR/adf-to-markdown.py"
     ;;
 esac

--- a/.claude/scripts/platform/transition-issue.sh
+++ b/.claude/scripts/platform/transition-issue.sh
@@ -11,5 +11,5 @@ TRANSITION="${2:-$JIRA_DONE_TRANSITION}"
 
 case "$TRACKER" in
   github) gh issue close "$ISSUE" ;;
-  jira) acli jira transition-issue --issue "$ISSUE" --transition "$TRANSITION" ;;
+  jira) acli jira workitem transition --key "$ISSUE" --status "$TRANSITION" ;;
 esac


### PR DESCRIPTION
## Summary

Makes the implement-issue orchestrator work with both GitHub and Jira/GitLab, fixes several bugs discovered during real-world pipeline testing.

**Context:** These fixes were discovered while running the full implement-issue pipeline against a Jira/GitLab project (Precis). The pipeline failed at multiple stages due to GitHub-specific assumptions and incorrect turn caps.

## Bug fixes

- **Haiku turn cap too aggressive** — All haiku stages were capped at 5 turns, but implement/review/fix stages downgraded to haiku via S-complexity override need more turns to read files, make edits, and produce structured output. Now: inherently light stages get 10 turns, complexity-override stages get 15 turns.
- **PR review stages using wrong model** — `pr-review-iter-N` matched the `pr` prefix (light/haiku) instead of being treated as a review stage (standard/sonnet). Added `pr-review` and `pr-fix` to model-config.sh stage prefixes.
- **Task parsing regex only matched GitHub format** — Jira bullets produce `- \`[agent]\` description` (no checkbox), but the parser only matched `- [ ] \`[agent]\` description`. Made the checkbox group optional.
- **`claude` CLI not found in non-interactive shells** — `env(1)` can't resolve shell aliases. Added `CLAUDE_CLI` variable to platform.sh that resolves the actual binary path.
- **PR prompt too vague** — Subagents wasted all turns exploring instead of running the exact commands. Replaced with explicit command template.

## Platform improvements

- Remove hardcoded GitHub repo detection block — orchestrator now uses platform wrappers exclusively
- Replace GitHub-specific wording with generic terms throughout
- Update all Jira platform wrappers to current `acli` syntax (`workitem` subcommands)
- Add `adf-to-markdown.py` for converting Jira's ADF description format to markdown
- Add `--parent` support to `create-issue.sh` for Jira issue hierarchies

## Files changed

| File | Change |
|------|--------|
| `.claude/config/platform.sh` | Add CLAUDE_CLI resolution |
| `.claude/scripts/implement-issue-orchestrator.sh` | Turn caps, task regex, PR prompt, platform-neutral wording, CLAUDE_CLI |
| `.claude/scripts/model-config.sh` | Add pr-review/pr-fix tier mappings |
| `.claude/scripts/platform/adf-to-markdown.py` | New: ADF-to-markdown converter |
| `.claude/scripts/platform/comment-issue.sh` | Fix acli syntax |
| `.claude/scripts/platform/create-issue.sh` | Fix acli syntax, add --parent |
| `.claude/scripts/platform/read-issue.sh` | Fix acli syntax, pipe through ADF converter |
| `.claude/scripts/platform/transition-issue.sh` | Fix acli syntax |

## Test plan

- [x] Tested end-to-end: `/implement-issue KIKS-622 main` against Jira/GitLab
- [x] Orchestrator parsed issue from Jira, implemented task, ran tests, created GitLab MR
- [x] Verified `resolve_model` returns correct tiers for all stage names
- [ ] Verify GitHub path still works (no regressions for existing GitHub users)