### PR TITLE
fix: scale pipeline stages by complexity and fix timeout output extraction

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -758,6 +758,8 @@ run_stage() {
     local schema_file="$3"
     local agent="${4:-}"
     local complexity="${5:-}"
+    local timeout_override="${6:-}"   # optional: override stage timeout (seconds)
+    local model_override="${7:-}"    # optional: override model (haiku|sonnet|opus)
 
     local stage_log="$LOG_BASE/stages/$(next_stage_log "$stage_name")"
 
@@ -773,7 +775,11 @@ run_stage() {
 
     # Resolve model and fallback from stage name + complexity hint
     local model fallback_model
-    model=$(resolve_model "$stage_name" "$complexity")
+    if [[ -n "$model_override" ]]; then
+        model="$model_override"
+    else
+        model=$(resolve_model "$stage_name" "$complexity")
+    fi
     fallback_model=$(_next_model_up "$model")
 
     log "Running stage: $stage_name"
@@ -791,7 +797,11 @@ run_stage() {
     fi
 
     local stage_timeout
-    stage_timeout=$(get_stage_timeout "$stage_name")
+    if [[ -n "$timeout_override" ]]; then
+        stage_timeout="$timeout_override"
+    else
+        stage_timeout=$(get_stage_timeout "$stage_name")
+    fi
     log "  Timeout: ${stage_timeout}s"
 
     # Pass --fallback-model for resilience (skip if same as primary — CLI rejects duplicates)
@@ -814,6 +824,9 @@ run_stage() {
     elif [[ "$model" == "haiku" ]]; then
         turns_args=(--max-turns 15)
         log "  Max turns: 15 (haiku via complexity override)"
+    elif [[ "$model" == "sonnet" ]]; then
+        turns_args=(--max-turns 25)
+        log "  Max turns: 25 (sonnet cap)"
     fi
 
     local output
@@ -833,8 +846,16 @@ run_stage() {
     printf '%s\n' "$output" >> "$stage_log"
     printf '%s\n' "=== exit code: $exit_code ===" >> "$stage_log"
 
-    # Check timeout
+    # Check timeout — but still try to extract structured output first.
+    # The agent may have produced valid output before the timeout killed the CLI.
     if (( exit_code == 124 )); then
+        local timeout_structured
+        timeout_structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
+        if [[ -n "$timeout_structured" ]]; then
+            log "WARN: Stage $stage_name timed out after ${stage_timeout}s but produced structured output — using it"
+            printf '%s\n' "$timeout_structured"
+            return 0
+        fi
         log_error "Stage $stage_name timed out after ${stage_timeout}s"
         echo '{"status":"error","error":"timeout"}'
         return 1
@@ -1097,6 +1118,38 @@ should_run_docs_stage() {
         bash|config) return 1 ;;
         *)            return 0 ;;
     esac
+}
+
+# Check if all tasks in status.json are S-complexity.
+# Returns:
+#   0 if all tasks are S-complexity (docs can be skipped)
+#   1 if any task is M, L, or unknown complexity
+all_tasks_s_complexity() {
+    local tasks_json
+    tasks_json=$(jq -r '.tasks[]?.description // empty' "$STATUS_FILE" 2>/dev/null)
+    [[ -z "$tasks_json" ]] && return 1
+    while IFS= read -r desc; do
+        local size
+        size=$(extract_task_size "$desc")
+        [[ "$size" != "S" ]] && return 1
+    done <<< "$tasks_json"
+    return 0
+}
+
+# Get PR review configuration based on diff size.
+# Returns JSON: { "model": "...", "timeout": N, "max_iterations": N }
+# Small diffs get haiku/300s/1 iter; medium get sonnet/900s/2; large get sonnet/1800s/2.
+get_pr_review_config() {
+    local diff_lines
+    diff_lines=$(get_diff_line_count "$BASE_BRANCH")
+
+    if (( diff_lines < 20 )); then
+        printf '{"model":"haiku","timeout":300,"max_iterations":1}'
+    elif (( diff_lines < 100 )); then
+        printf '{"model":"sonnet","timeout":900,"max_iterations":2}'
+    else
+        printf '{"model":"sonnet","timeout":1800,"max_iterations":2}'
+    fi
 }
 
 # Determines whether the quality loop should run for a given task size.
@@ -2183,6 +2236,11 @@ Investigate the root cause and fix the issue. Commit your changes."
             set_stage_started "docs"
             comment_issue "Docs Stage: Skipped" "⏭️ No TypeScript/React files changed (scope: \`$branch_scope\`). Skipping docs stage."
             set_stage_completed "docs"
+        elif all_tasks_s_complexity; then
+            log "Skipping docs stage: all tasks are S-complexity"
+            set_stage_started "docs"
+            comment_issue "Docs Stage: Skipped" "⏭️ All tasks are S-complexity. Skipping docs stage."
+            set_stage_completed "docs"
         else
             set_stage_started "docs"
 
@@ -2268,13 +2326,24 @@ The command will output the MR number. Use that as pr_number in your response."
 
         local pr_approved=false
 
+        # Scale PR review by diff size
+        local pr_review_config
+        pr_review_config=$(get_pr_review_config)
+        local pr_review_model pr_review_timeout pr_review_max_iter
+        pr_review_model=$(printf '%s' "$pr_review_config" | jq -r '.model')
+        pr_review_timeout=$(printf '%s' "$pr_review_config" | jq -r '.timeout')
+        pr_review_max_iter=$(printf '%s' "$pr_review_config" | jq -r '.max_iterations')
+        local diff_lines
+        diff_lines=$(get_diff_line_count "$BASE_BRANCH")
+        log "PR review config: model=$pr_review_model, timeout=${pr_review_timeout}s, max_iter=$pr_review_max_iter (diff: ${diff_lines} lines)"
+
     while [[ "$pr_approved" != "true" ]]; do
         increment_pr_review_iteration
         local pr_iteration
         pr_iteration=$(jq -r '.pr_review_iterations' "$STATUS_FILE")
 
-        if (( pr_iteration > MAX_PR_REVIEW_ITERATIONS )); then
-            log_error "PR review loop exceeded max iterations ($MAX_PR_REVIEW_ITERATIONS)"
+        if (( pr_iteration > pr_review_max_iter )); then
+            log_error "PR review loop exceeded max iterations ($pr_review_max_iter)"
             set_final_state "max_iterations_pr_review"
             exit 2
         fi
@@ -2292,7 +2361,7 @@ Part 2 — Code Review: Review code quality, patterns, standards, and security.
 Approve or request changes. Output a summary suitable for an issue comment."
 
         local review_result
-        review_result=$(run_stage "pr-review-iter-$pr_iteration" "$review_prompt" "implement-issue-review.json" "code-reviewer")
+        review_result=$(run_stage "pr-review-iter-$pr_iteration" "$review_prompt" "implement-issue-review.json" "code-reviewer" "" "$pr_review_timeout" "$pr_review_model")
 
         # Handle timeout: skip result inspection and retry on next iteration
         if is_stage_timeout "$review_result"; then

--- a/.claude/scripts/platform/adf-to-markdown.py
+++ b/.claude/scripts/platform/adf-to-markdown.py
@@ -6,7 +6,27 @@ outputs JSON { title, body, status } with body as markdown text.
 """
 
 import json
+import re
 import sys
+
+
+def wiki_to_md(text):
+    """Convert Jira wiki markup fragments to markdown.
+
+    Handles common patterns that appear when acli stores description text
+    as a single ADF paragraph containing wiki markup rather than structured nodes.
+    """
+    lines = text.split("\n")
+    result = []
+    for line in lines:
+        # h1. through h6. headings
+        m = re.match(r"^h([1-6])\.\s+(.*)", line)
+        if m:
+            level = int(m.group(1))
+            result.append("#" * level + " " + m.group(2))
+        else:
+            result.append(line)
+    return "\n".join(result)
 
 
 def adf_to_md(node):
@@ -76,6 +96,11 @@ def main():
         body = desc
     else:
         body = ""
+
+    # Post-process: convert any remaining wiki markup to markdown.
+    # This handles cases where acli stores wiki markup as raw text
+    # inside ADF paragraph nodes rather than as structured heading nodes.
+    body = wiki_to_md(body)
 
     result = {
         "title": fields.get("summary", ""),


### PR DESCRIPTION
## Summary

- Extract structured output before timeout bail-out (agent can produce valid results before timeout kills CLI)
- Scale docs and PR review stages by complexity and diff size
- ADF converter handles wiki markup in paragraph nodes
- Add sonnet turn cap (25 max turns)

## Context

A 2-line CSS change took 4.5 hours and ~$10.60 in API costs because:
1. Docs stage added 35 lines of JSDoc to a trivial change (no complexity check)
2. PR review used sonnet + 1800s timeout for all changes regardless of size
3. Timeout bug discarded valid "approved" output, causing unnecessary retries

## Changes

### `implement-issue-orchestrator.sh`
- `run_stage()`: Add `timeout_override` and `model_override` optional params (args 6 & 7)
- `run_stage()`: Extract `structured_output` from CLI JSON before checking exit code 124
- `run_stage()`: Add `--max-turns 25` cap for sonnet stages
- New helper `all_tasks_s_complexity()`: Check if all tasks are S-size
- New helper `get_pr_review_config()`: Returns model/timeout/max_iterations based on diff size
- Docs stage: Skip when all tasks are S-complexity
- PR review loop: Use diff-size-based config instead of static `MAX_PR_REVIEW_ITERATIONS`

### `platform/adf-to-markdown.py`
- New `wiki_to_md()`: Converts `h1.` through `h6.` wiki markup to `#` through `######` markdown headings
- Applied as post-processing after ADF conversion

## Test plan

- [ ] S-complexity task with <20 line diff: pipeline completes in <10 minutes using haiku review
- [ ] M/L task with 100+ line diff: still uses sonnet + 1800s timeout (no regression)
- [ ] Docs stage skipped when all tasks are S-complexity
- [ ] Stage that times out but produces structured output: output is used, not discarded
- [ ] Jira issue with wiki markup headings (h2.) parsed correctly as ## headings