### PR TITLE
feat: embed output truncation and background execution patterns into skills

### DIFF
--- a/.claude/skills/playwright-testing/SKILL.md
+++ b/.claude/skills/playwright-testing/SKILL.md
@@ -135,6 +135,15 @@ e2e/
 | `npx playwright show-report` | View HTML report |
 | `npx playwright test --update-snapshots` | Update screenshot baselines |
 
+## Output Management
+
+Playwright test runs produce verbose output. Use truncation and background execution to keep context clean:
+
+- **Pass/fail checks:** `npx playwright test 2>&1 | tail -20`
+- **Full test suites:** Use `run_in_background: true` and read the summary with `TaskOutput`
+- **Debugging specific failures:** Only request full output when investigating a specific failing test
+- **If truncated output shows failure:** Re-run the specific failing test without truncation to see the full error
+
 ## Integration
 
 **Used by:** `playwright-test-developer` agent

--- a/.claude/skills/subagent-driven-development/implementer-prompt.md
+++ b/.claude/skills/subagent-driven-development/implementer-prompt.md
@@ -12,6 +12,7 @@ Every token in the subagent prompt is re-read on each tool call the subagent mak
 - **Do NOT paste the full issue body** — the subagent can use `.claude/scripts/platform/read-issue.sh` if it needs broader context.
 - **Reference specific files and line numbers** rather than "find the relevant code" — this prevents broad exploratory searches.
 - **Shorter prompts = fewer input tokens re-read on every tool call** within the subagent session.
+- **Truncate build/test output** — use `| tail -10` when running builds or test suites. Use `run_in_background: true` for builds >30s. Full build logs in context are re-read on every subsequent tool call.
 
 **Agent selection:** Choose the appropriate `subagent_type` based on task, using the agents configured in `.claude/agents/` for this project.
 

--- a/.claude/skills/systematic-debugging/SKILL.md
+++ b/.claude/skills/systematic-debugging/SKILL.md
@@ -107,7 +107,13 @@ You MUST complete each phase before proceeding to the next.
 
    **This reveals:** Which layer fails (secrets → workflow ✓, workflow → build ✗)
 
-5. **Trace Data Flow**
+5. **Manage Command Output**
+      - When running diagnostic commands that produce verbose output, use `| tail -20` to capture the relevant end
+      - For long-running diagnostic builds, use `run_in_background: true`
+      - Full output floods context — capture only what you need to form hypotheses
+      - If truncated output isn't enough to diagnose, re-run without truncation for the specific failing command
+
+6. **Trace Data Flow**
 
    **WHEN error is deep in call stack:**
 

--- a/.claude/skills/test-driven-development/SKILL.md
+++ b/.claude/skills/test-driven-development/SKILL.md
@@ -115,8 +115,10 @@ Vague name, tests mock not code
 **MANDATORY. Never skip.**
 
 ```bash
-npm test path/to/test.test.ts
+npm test path/to/test.test.ts 2>&1 | tail -10
 ```
+
+Truncate output to last 10 lines — you only need pass/fail and error summary. If test fails unexpectedly, re-run without truncation to see full output.
 
 Confirm:
 - Test fails (not errors)
@@ -170,7 +172,7 @@ Don't add features, refactor other code, or "improve" beyond the test.
 **MANDATORY.**
 
 ```bash
-npm test path/to/test.test.ts
+npm test path/to/test.test.ts 2>&1 | tail -10
 ```
 
 Confirm:

--- a/.claude/skills/using-skills/SKILL.md
+++ b/.claude/skills/using-skills/SKILL.md
@@ -93,3 +93,5 @@ Over 99% of token usage is reading, not writing. These practices reduce cost sig
 - **Conversation length:** If a conversation exceeds ~40 messages, suggest starting a fresh conversation with a brief summary. Long conversations cost 2x+ more per message due to context re-reading.
 - **Model selection:** For simple tasks (run tests, format files, quick questions), suggest `/model haiku`. Save opus for complex multi-file changes and architecture decisions.
 - **Be specific:** "Fix the bug in `src/auth.js` line 42" triggers far fewer tool calls than "fix the login bug". File paths and line numbers reduce exploratory reading.
+- **Truncate command output:** For builds and test runs, pipe through `| tail -10` to capture only the result. If it fails, re-run without truncation to see the full error. A 200-line build log re-read 50 times = 10,000 lines of wasted context.
+- **Background long processes:** For builds >30s, docker operations, or full test suites, use `run_in_background: true` and read the result with `TaskOutput` when notified — keeps context clean while waiting.


### PR DESCRIPTION
Closes #45

## Summary

Embeds output truncation (`| tail -10/20`) and background execution (`run_in_background: true`) patterns directly into 5 skill files, so agents naturally reduce context bloat during builds, test runs, and diagnostic commands.

### Files changed

- **`.claude/skills/using-skills/SKILL.md`** — Added two new bullets under Token Awareness: truncate command output with `| tail -10`, and background long processes with `run_in_background: true`.
- **`.claude/skills/test-driven-development/SKILL.md`** — Updated Verify RED and Verify GREEN commands to pipe through `| tail -10`, with guidance to re-run without truncation if output is insufficient.
- **`.claude/skills/systematic-debugging/SKILL.md`** — Inserted new step 5 "Manage Command Output" in Phase 1 (before Trace Data Flow, now step 6) with truncation and background execution guidance.
- **`.claude/skills/subagent-driven-development/implementer-prompt.md`** — Added truncation bullet to Context Minimization section.
- **`.claude/skills/playwright-testing/SKILL.md`** — Added "Output Management" section with Playwright-specific truncation and background patterns.

## Test plan

- [ ] Verify each skill file renders correctly in Claude Code skill loader
- [ ] Confirm no unintended content changes beyond the 6 targeted edits
- [ ] Spot-check that numbered steps in systematic-debugging remain sequential (new step 5, old step 5 renumbered to 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)