### PR TITLE
Optimize model selection for fix and review stages (#48)

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -1189,7 +1189,9 @@ get_pr_review_config() {
 
     if (( diff_lines < 20 )); then
         printf '{"model":"haiku","timeout":300,"max_iterations":1}'
-    elif (( diff_lines < 100 )); then
+    elif (( diff_lines < 50 )); then
+        printf '{"model":"haiku","timeout":600,"max_iterations":1}'
+    elif (( diff_lines < 200 )); then
         printf '{"model":"sonnet","timeout":900,"max_iterations":2}'
     else
         printf '{"model":"sonnet","timeout":1800,"max_iterations":2}'

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -1182,7 +1182,11 @@ all_tasks_s_complexity() {
 
 # Get PR review configuration based on diff size.
 # Returns JSON: { "model": "...", "timeout": N, "max_iterations": N }
-# Small diffs get haiku/300s/1 iter; medium get sonnet/900s/2; large get sonnet/1800s/2.
+# Four tiers by diff line count:
+#   <20  lines  → haiku,  300s timeout, 1 iteration  (tiny)
+#   <50  lines  → haiku,  600s timeout, 1 iteration  (small)
+#   <200 lines  → sonnet, 900s timeout, 2 iterations (medium)
+#   200+ lines  → sonnet, 1800s timeout, 2 iterations (large)
 get_pr_review_config() {
     local diff_lines
     diff_lines=$(get_diff_line_count "$BASE_BRANCH")

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -2387,7 +2387,7 @@ Commit your changes."
             verify_on_feature_branch "$branch" || true
 
             local e2e_fix_result
-            e2e_fix_result=$(run_stage "fix-e2e" "$e2e_fix_prompt" "implement-issue-fix.json" "$AGENT")
+            e2e_fix_result=$(run_stage "fix-e2e" "$e2e_fix_prompt" "implement-issue-fix.json" "$AGENT" "$max_task_size")
 
             local e2e_fix_summary
             e2e_fix_summary=$(printf '%s' "$e2e_fix_result" | jq -r '.summary // "Fix applied"')

--- a/.claude/scripts/implement-issue-test/test-pr-review-config.bats
+++ b/.claude/scripts/implement-issue-test/test-pr-review-config.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+#
+# test-pr-review-config.bats
+# Tests for get_pr_review_config() four-tier diff-size routing.
+#
+# Boundary values under test (from the four-tier specification):
+#   <20  lines  → haiku,  300s,  1 iteration  (tiny)
+#   <50  lines  → haiku,  600s,  1 iteration  (small)
+#   <200 lines  → sonnet, 900s,  2 iterations (medium)
+#   200+ lines  → sonnet, 1800s, 2 iterations (large)
+#
+
+load 'helpers/test-helper.bash'
+
+# =============================================================================
+# TEST SETUP / TEARDOWN
+# =============================================================================
+
+setup() {
+	setup_test_env
+	install_mocks
+
+	export ISSUE_NUMBER=123
+	export BASE_BRANCH=test
+	export STATUS_FILE="$TEST_TMP/status.json"
+	export LOG_BASE="$TEST_TMP/logs/test"
+	export LOG_FILE="$LOG_BASE/orchestrator.log"
+	export STAGE_COUNTER=0
+	export SCHEMA_DIR="$TEST_TMP/schemas"
+
+	mkdir -p "$LOG_BASE/stages" "$LOG_BASE/context"
+	mkdir -p "$SCHEMA_DIR"
+
+	for schema in \
+		implement-issue-implement \
+		implement-issue-test \
+		implement-issue-review \
+		implement-issue-fix \
+		implement-issue-simplify; do
+		printf '{"type":"object"}\n' > "$SCHEMA_DIR/${schema}.json"
+	done
+
+	source_orchestrator_functions
+	init_status
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# =============================================================================
+# get_pr_review_config() — FOUR-TIER BOUNDARY TESTS
+#
+# Each test overrides get_diff_line_count() to inject a controlled diff size,
+# then calls get_pr_review_config() and asserts the exact JSON output.
+# Boundary values chosen to hit the first value of each tier transition.
+# =============================================================================
+
+@test "get_pr_review_config: tiny diff (<20 lines) returns haiku/300s/1 iter" {
+	# 19 is the highest value still in the <20 tier
+	get_diff_line_count() { printf '%s' "19"; }
+	local result
+	result=$(get_pr_review_config)
+	[[ "$result" == '{"model":"haiku","timeout":300,"max_iterations":1}' ]]
+}
+
+@test "get_pr_review_config: small diff (20-49 lines) returns haiku/600s/1 iter" {
+	# 20 is the exact boundary entering the second tier
+	get_diff_line_count() { printf '%s' "20"; }
+	local result
+	result=$(get_pr_review_config)
+	[[ "$result" == '{"model":"haiku","timeout":600,"max_iterations":1}' ]]
+}
+
+@test "get_pr_review_config: medium diff (50-199 lines) returns sonnet/900s/2 iter" {
+	# 50 is the exact boundary entering the third tier
+	get_diff_line_count() { printf '%s' "50"; }
+	local result
+	result=$(get_pr_review_config)
+	[[ "$result" == '{"model":"sonnet","timeout":900,"max_iterations":2}' ]]
+}
+
+@test "get_pr_review_config: large diff (>=200 lines) returns sonnet/1800s/2 iter" {
+	# 200 is the exact boundary entering the fourth (else) tier
+	get_diff_line_count() { printf '%s' "200"; }
+	local result
+	result=$(get_pr_review_config)
+	[[ "$result" == '{"model":"sonnet","timeout":1800,"max_iterations":2}' ]]
+}

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -55,6 +55,7 @@ _stage_to_tier() {
 		code-review)    printf '%s' "standard" ;;
 		e2e-verify)     printf '%s' "light" ;;
 		fix-e2e)        printf '%s' "standard" ;;
+		fix-acceptance-test) printf '%s' "standard" ;;
 		complete)       printf '%s' "light" ;;
 		docs)           printf '%s' "light" ;;
 		acceptance-test) printf '%s' "light" ;;
@@ -94,7 +95,7 @@ _complexity_to_tier() {
 if [[ -z "${_STAGE_PREFIXES+set}" ]]; then
 	readonly -a _STAGE_PREFIXES=(
 		acceptance-test spec-review code-review task-review validate-plan
-		parse-issue e2e-verify fix-e2e implement simplify complete pr-review pr-fix review test docs fix pr
+		parse-issue e2e-verify fix-e2e fix-acceptance-test implement simplify complete pr-review pr-fix review test docs fix pr
 	)
 fi
 


### PR DESCRIPTION
## Summary
- Add explicit `fix-acceptance-test` prefix matching to `_stage_to_tier` and `_STAGE_PREFIXES` in model-config.sh
- Pass complexity hint (`$max_task_size`) to `fix-e2e` `run_stage` call so fix stages use appropriate model tier
- Refine `get_pr_review_config` from 3 tiers to 4 tiers: <20→haiku/300s/1, 20-50→haiku/600s/1, 50-200→sonnet/900s/2, 200+→sonnet/1800s/2
- Add BATS boundary tests for all 4 `get_pr_review_config` tiers

Closes #48

## Test plan
- [ ] Run `bats .claude/scripts/implement-issue-test/test-pr-review-config.bats` — all 4 boundary tests pass
- [ ] Run existing BATS suite — no regressions
- [ ] Run a pipeline with an S-complexity task and verify fix-e2e uses haiku (check log for "Model: haiku")

🤖 Generated with [Claude Code](https://claude.com/claude-code)