### PR TITLE
fix(batch-orchestrator): use @ instead of * for array expansion

### DIFF
--- a/.claude/scripts/batch-orchestrator.sh
+++ b/.claude/scripts/batch-orchestrator.sh
@@ -439,7 +439,7 @@ process_issue() {
         agent_args=(--agent "$AGENT")
     fi
 
-    log "Running: implement-issue-orchestrator.sh --issue $issue_num --branch $BRANCH ${agent_args[*]+"${agent_args[*]}"}"
+    log "Running: implement-issue-orchestrator.sh --issue $issue_num --branch $BRANCH ${agent_args[@]+"${agent_args[@]}"}"
 
     local impl_output
     local impl_exit=0


### PR DESCRIPTION
## Description

Fixes the bash portability issue in batch-orchestrator.sh where ${agent_args[*]} was incorrectly joining array elements into a single string.

### Change

Line 442: Changed ${agent_args[*]} to ${agent_args[@]} for proper array handling.

This ensures the log message correctly displays array elements as separate arguments rather than concatenating them.

### Related Issue

Addresses issue #87