### PR TITLE
feat: improve first-pass quality via prompt enhancements (#81)

### DIFF
--- a/.claude/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/.claude/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -17,4 +17,19 @@ Task tool (code-reviewer):
   DESCRIPTION: [task summary]
 ```
 
+## Style vs Correctness Filter
+
+When reviewing, apply this filter to every potential issue before reporting it:
+
+1. **Only flag issues that affect correctness, performance, or security.** These are the things that matter: bugs, logic errors, missing error handling, type safety gaps, security vulnerabilities, performance regressions, and missing test coverage.
+
+2. **Explicitly skip style-only feedback.** Do NOT flag:
+   - Variable/function naming preferences (unless genuinely misleading)
+   - Formatting or whitespace opinions
+   - Comment style or quantity (unless documentation is completely absent for public APIs)
+   - Minor code organization preferences that don't affect maintainability
+   - Subjective "I would have done it differently" suggestions
+
+3. **Approve if all functional criteria pass.** If the code is correct, tested, type-safe, and handles errors properly, approve it — even if the style is not exactly how you would write it. Style-only feedback wastes iteration cycles and does not improve the product.
+
 **Code reviewer returns:** Strengths, Issues (Critical/Important/Minor), Assessment

--- a/.claude/skills/subagent-driven-development/implementer-prompt.md
+++ b/.claude/skills/subagent-driven-development/implementer-prompt.md
@@ -82,15 +82,40 @@ Task tool (subagent_type: <project-specific agent>):
     1. **Verify you're on the feature branch** (see above)
     2. Implement exactly what the task specifies
     3. Write tests (following TDD if task says to)
-    4. Verify implementation works
-    5. Commit your work to the feature branch
-    6. Self-review (see below)
-    7. Report back
+    4. Run targeted tests before committing (see below)
+    5. Verify implementation works
+    6. Complete the Pre-Submission Checklist (see below)
+    7. Commit your work to the feature branch
+    8. Self-review (see below)
+    9. Report back
+
+    ### Run Targeted Tests Before Committing
+
+    Before committing, run tests relevant to your changes — not the full suite:
+    ```bash
+    npm test -- --testPathPattern='relevant-test-file-or-pattern'
+    ```
+    Replace `relevant-test-file-or-pattern` with the test file or directory that covers your changes.
+    If tests fail, fix the failures before proceeding. Do not commit code with failing tests.
 
     Work from: [directory]
 
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.
+
+    ## Pre-Submission Checklist
+
+    Before committing, verify ALL of the following:
+
+    - [ ] **Tests pass:** Ran targeted tests (`npm test -- --testPathPattern='...'`) and they pass
+    - [ ] **TypeScript compiles:** Ran `npx tsc --noEmit` (or project build) with no errors
+    - [ ] **No unrelated changes:** `git diff --stat` shows only files relevant to the task
+    - [ ] **All imports are used:** No unused imports left behind (TypeScript compiler will flag these)
+    - [ ] **No debug statements:** No `console.log`, `console.debug`, or debugging code left in production files
+    - [ ] **Changes match task description:** Re-read the task spec and confirm every requirement is addressed
+    - [ ] **No commented-out code:** Removed any commented-out code blocks added during development
+
+    If any item fails, fix it before committing. These items directly correspond to what the code quality reviewer checks — addressing them now avoids revision cycles.
 
     ## Before Reporting Back: Self-Review
 


### PR DESCRIPTION
## Summary
- Adds 7-item pre-submission checklist to implementer prompt aligned with reviewer criteria
- Adds targeted test-before-commit instructions (`npm test -- --testPathPattern=...`)
- Adds "Style vs Correctness Filter" to reviewer prompt to skip non-functional feedback

## Test plan
- [x] Markdown-only changes — no code affected
- [x] Checklist items align with reviewer pass criteria (AC4)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)