### PR TITLE
feat(explore): hybrid explore with pipeline-tracked research

### DIFF
--- a/.claude/agents/research-agent.md
+++ b/.claude/agents/research-agent.md
@@ -1,0 +1,33 @@
+# Research Agent
+
+Codebase research specialist. Investigates code structure, maps affected files, and produces structured findings for the explore workflow.
+
+## Role
+You are a research agent. Your job is to thoroughly investigate a codebase question and return structured findings. You do NOT evaluate approaches, create issues, or write implementation plans. You only research and report facts.
+
+## Tools Priority
+1. **Context7** — always check for framework/library documentation first
+2. **Serena** — use for class hierarchies, method signatures, symbol relationships
+3. **Grep/Glob** — use for text-based file search and pattern discovery
+4. **Read** — use for reading specific file sections when you know what you need
+
+## Research Protocol
+1. Start with the broadest relevant search to understand scope
+2. Narrow to specific files and functions
+3. Map dependencies and callers
+4. Document current behavior with evidence (line numbers, function names)
+5. Note patterns the codebase follows for similar features
+
+## Output Requirements
+Return structured JSON with:
+- `affected_files` — every file that would need changing, with what specifically needs changing
+- `current_behavior` — factual description of what happens now
+- `desired_behavior` — what should happen (from the input description)
+- `patterns_to_follow` — existing patterns in the codebase that the implementation should match
+- `data_findings` — any measurements, counts, or data relevant to the investigation
+
+## What NOT To Do
+- Do not propose solutions or evaluate trade-offs
+- Do not create files or modify code
+- Do not ask clarifying questions — research what you can and note gaps
+- Do not speculate — only report what you find in the code

--- a/.claude/scripts/explore-orchestrator.sh
+++ b/.claude/scripts/explore-orchestrator.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+#
+# explore-orchestrator.sh — Lightweight orchestrator for the explore research phase.
+# Runs a single research subagent to investigate an idea against a project.
+#
+# Usage:
+#   ./explore-orchestrator.sh --idea "description of what to explore"
+#   ./explore-orchestrator.sh --idea "description" --project-dir /path/to/project
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMA_DIR="$SCRIPT_DIR/schemas"
+source "$SCRIPT_DIR/model-config.sh"
+
+# Claude CLI — allow override via env, else resolve path
+if [[ -z "${CLAUDE_CLI:-}" ]]; then
+    if [[ -x "$HOME/.claude/local/claude" ]]; then
+        CLAUDE_CLI="$HOME/.claude/local/claude"
+    else
+        CLAUDE_CLI="claude"
+    fi
+fi
+
+STAGE_TIMEOUT="${EXPLORE_TIMEOUT:-600}"
+
+# Portable timeout (macOS does not ship GNU timeout)
+if ! command -v timeout &>/dev/null; then
+    timeout() {
+        local duration="$1"; shift
+        perl -e '
+            use POSIX ":sys_wait_h";
+            alarm shift @ARGV;
+            $SIG{ALRM} = sub { kill 15, $pid; waitpid($pid, 0); exit 124 };
+            $pid = fork // die "fork: $!";
+            if ($pid == 0) { exec @ARGV; die "exec: $!" }
+            waitpid($pid, 0);
+            exit ($? >> 8);
+        ' "$duration" "$@"
+    }
+fi
+
+# --- Argument parsing ---
+IDEA=""
+PROJECT_DIR=""
+
+usage() {
+    cat <<EOF
+Usage: $0 --idea "description" [--project-dir /path/to/project]
+Options:
+  --idea <text>           Description of what to explore (required)
+  --project-dir <path>    Project directory (defaults to \$PWD)
+  --help, -h              Show this help
+EOF
+    exit 3
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --idea)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --idea requires a value" >&2; exit 3; }
+            IDEA="$2"; shift 2 ;;
+        --project-dir)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --project-dir requires a value" >&2; exit 3; }
+            PROJECT_DIR="$2"; shift 2 ;;
+        --help|-h) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+[[ -n "$IDEA" ]] || { echo "ERROR: --idea is required" >&2; usage; }
+
+PROJECT_DIR="${PROJECT_DIR:-$PWD}"
+[[ "$PROJECT_DIR" == /* ]] || PROJECT_DIR="$PWD/$PROJECT_DIR"
+[[ -d "$PROJECT_DIR" ]] || { echo "ERROR: project directory does not exist: $PROJECT_DIR" >&2; exit 1; }
+
+# --- Log directory ---
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+LOG_DIR="$PROJECT_DIR/logs/explore/explore-${TIMESTAMP}"
+mkdir -p "$LOG_DIR/stages"
+LOG_FILE="$LOG_DIR/orchestrator.log"
+STATUS_FILE="$LOG_DIR/status.json"
+STAGE_LOG="$LOG_DIR/stages/01-research.log"
+
+# --- Logging ---
+log()       { local m="[$(date -Iseconds)] $*"; printf '%s\n' "$m" >> "$LOG_FILE"; printf '%s\n' "$m" >&2; }
+log_error() { local m="[$(date -Iseconds)] ERROR: $*"; printf '%s\n' "$m" >> "$LOG_FILE"; printf '%s\n' "$m" >&2; }
+
+# --- Status file ---
+init_status() {
+    local now; now=$(date -Iseconds)
+    jq -n --argjson issue "null" --arg log_dir "$LOG_DIR" --arg now "$now" \
+        '{
+            state: "running", issue: $issue,
+            tasks: [{description: "**(S)** Research codebase for explore", agent: "research-agent", status: "in_progress"}],
+            stages: { research: {status: "in_progress", started_at: $now} },
+            quality_iterations: 0, test_iterations: 0,
+            last_update: $now, log_dir: $log_dir
+        }' > "$STATUS_FILE"
+}
+
+update_status() {
+    local state="$1" stage_status="$2" task_status="$3" now
+    now=$(date -Iseconds)
+    jq --arg state "$state" --arg ss "$stage_status" --arg ts "$task_status" --arg now "$now" \
+        '.state=$state | .stages.research.status=$ss | .stages.research.completed_at=$now
+         | .tasks[0].status=$ts | .last_update=$now' \
+        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+}
+
+# --- Metrics ---
+START_EPOCH=$(date +%s)
+ESCALATIONS=0
+MODEL_USED=""
+
+write_metrics() {
+    local end_epoch; end_epoch=$(date +%s)
+    jq -n --argjson duration "$(( end_epoch - START_EPOCH ))" \
+        --arg model "$MODEL_USED" --argjson escalations "$ESCALATIONS" \
+        '{ duration_seconds: $duration, model_used: $model, escalations: $escalations }' \
+        > "$LOG_DIR/metrics.json"
+}
+
+# --- Main ---
+log "Explore orchestrator started"
+log "  Idea: $IDEA"
+log "  Project: $PROJECT_DIR"
+log "  Log dir: $LOG_DIR"
+init_status
+
+# Resolve model — research stage, S complexity
+MODEL=$(resolve_model research S)
+FALLBACK=$(_next_model_up "$MODEL")
+MODEL_USED="$MODEL"
+log "  Model: $MODEL (fallback: $FALLBACK)"
+
+PROMPT="You are a research agent investigating a project codebase.
+
+## Your task
+Investigate the following idea against this project:
+
+$IDEA
+
+## Project directory
+$PROJECT_DIR
+
+## Instructions
+1. Explore the project structure, key files, and relevant code
+2. Understand the current behavior related to the idea
+3. Identify files that would need to change
+4. Note existing patterns the implementation should follow
+5. Summarize your findings clearly
+
+Be thorough but focused. Read relevant files, understand the architecture, and provide actionable findings."
+
+SCHEMA=$(jq -c . "$SCHEMA_DIR/explore-research.json")
+
+FALLBACK_ARGS=()
+[[ "$FALLBACK" != "$MODEL" ]] && FALLBACK_ARGS=(--fallback-model "$FALLBACK")
+
+log "Running research stage..."
+OUTPUT=""
+EXIT_CODE=0
+
+OUTPUT=$(timeout "$STAGE_TIMEOUT" env -u CLAUDECODE "$CLAUDE_CLI" -p "$PROMPT" \
+    --model "$MODEL" \
+    ${FALLBACK_ARGS[@]+"${FALLBACK_ARGS[@]}"} \
+    --max-turns 15 \
+    --dangerously-skip-permissions \
+    --output-format json \
+    --json-schema "$SCHEMA" \
+    2>&1) || EXIT_CODE=$?
+
+printf '%s\n' "=== research output ===" >> "$STAGE_LOG"
+printf '%s\n' "$OUTPUT" >> "$STAGE_LOG"
+printf '%s\n' "=== exit code: $EXIT_CODE ===" >> "$STAGE_LOG"
+
+# Handle max_turns exhaustion — escalate to sonnet, retry without turn cap
+if (( EXIT_CODE != 0 )); then
+    SUBTYPE=$(printf '%s' "$OUTPUT" | jq -r '.subtype // empty' 2>/dev/null || true)
+    if [[ "$SUBTYPE" == "error_max_turns" ]]; then
+        log "Max turns exhausted — escalating to sonnet and retrying without turn cap"
+        ESCALATIONS=$((ESCALATIONS + 1))
+        MODEL="sonnet"; MODEL_USED="sonnet"
+        FALLBACK=$(_next_model_up "$MODEL")
+        FALLBACK_ARGS=()
+        [[ "$FALLBACK" != "$MODEL" ]] && FALLBACK_ARGS=(--fallback-model "$FALLBACK")
+
+        EXIT_CODE=0
+        OUTPUT=$(timeout "$STAGE_TIMEOUT" env -u CLAUDECODE "$CLAUDE_CLI" -p "$PROMPT" \
+            --model "$MODEL" ${FALLBACK_ARGS[@]+"${FALLBACK_ARGS[@]}"} \
+            --dangerously-skip-permissions --output-format json --json-schema "$SCHEMA" \
+            2>&1) || EXIT_CODE=$?
+
+        printf '%s\n' "=== escalated output ===" >> "$STAGE_LOG"
+        printf '%s\n' "$OUTPUT" >> "$STAGE_LOG"
+        printf '%s\n' "=== exit code: $EXIT_CODE ===" >> "$STAGE_LOG"
+    fi
+fi
+
+# Handle timeout — retry once with 20% longer timeout
+if (( EXIT_CODE == 124 )); then
+    TIMEOUT_STRUCTURED=$(printf '%s' "$OUTPUT" | jq -c '.structured_output // empty' 2>/dev/null || true)
+    if [[ -n "$TIMEOUT_STRUCTURED" ]]; then
+        log "WARN: Timed out but produced structured output — using it"
+        EXIT_CODE=0
+    else
+        RETRY_TIMEOUT=$(( STAGE_TIMEOUT * 120 / 100 ))
+        log "Timed out after ${STAGE_TIMEOUT}s — retrying with ${RETRY_TIMEOUT}s"
+        ESCALATIONS=$((ESCALATIONS + 1))
+        EXIT_CODE=0
+        OUTPUT=$(timeout "$RETRY_TIMEOUT" env -u CLAUDECODE "$CLAUDE_CLI" -p "$PROMPT" \
+            --model "$MODEL" ${FALLBACK_ARGS[@]+"${FALLBACK_ARGS[@]}"} \
+            --max-turns 15 --dangerously-skip-permissions --output-format json --json-schema "$SCHEMA" \
+            2>&1) || EXIT_CODE=$?
+
+        printf '%s\n' "=== timeout retry output ===" >> "$STAGE_LOG"
+        printf '%s\n' "$OUTPUT" >> "$STAGE_LOG"
+        printf '%s\n' "=== exit code: $EXIT_CODE ===" >> "$STAGE_LOG"
+    fi
+fi
+
+# Extract structured output
+STRUCTURED=""
+if (( EXIT_CODE == 0 )); then
+    STRUCTURED=$(printf '%s' "$OUTPUT" | jq -c '.structured_output // empty' 2>/dev/null || true)
+    if [[ -z "$STRUCTURED" ]]; then
+        STRUCTURED=$(printf '%s' "$OUTPUT" | jq -c '.result // empty' 2>/dev/null || true)
+        [[ -n "$STRUCTURED" ]] && log "WARN: No .structured_output — using .result fallback"
+    fi
+fi
+
+# Write results or handle failure
+if [[ -n "$STRUCTURED" ]]; then
+    log "Research completed successfully"
+    printf '%s\n' "$STRUCTURED" | jq . > "$LOG_DIR/research-summary.json"
+    update_status "completed" "completed" "completed"
+    write_metrics
+    printf '%s\n' "$LOG_DIR/research-summary.json"
+else
+    log_error "Research stage failed (exit code: $EXIT_CODE)"
+    update_status "failed" "failed" "failed"
+    write_metrics
+    printf '%s\n' "$LOG_DIR"
+    exit 1
+fi

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -47,6 +47,7 @@ _stage_to_tier() {
 		fix)            printf '%s' "standard" ;;
 		test)           printf '%s' "light" ;;
 		review)         printf '%s' "standard" ;;
+		research)       printf '%s' "light" ;;
 		simplify)       printf '%s' "light" ;;
 		pr)             printf '%s' "standard" ;;
 		pr-review)      printf '%s' "standard" ;;
@@ -98,7 +99,7 @@ if [[ -z "${_STAGE_PREFIXES+set}" ]]; then
 	readonly -a _STAGE_PREFIXES=(
 		fix-acceptance-test acceptance-test validate-plan
 		fix-deploy-verify deploy-verify spec-review code-review task-review parse-issue e2e-verify
-		pr-review implement simplify complete pr-fix fix-e2e review test docs fix pr
+		pr-review implement simplify research complete pr-fix fix-e2e review test docs fix pr
 	)
 fi
 
@@ -155,8 +156,8 @@ resolve_model() {
 	fi
 
 	# Apply complexity hint — overrides stage default when provided.
-	# Light-tier stages (test, parse-issue, validate-plan, complete, docs,
-	# simplify, acceptance-test) are mechanical and always use haiku;
+	# Light-tier stages (test, parse-issue, validate-plan, research, complete,
+	# docs, simplify, acceptance-test) are mechanical and always use haiku;
 	# complexity hints are ignored for them.
 	# The quality loop forwards task-level complexity to implement, review,
 	# and fix stages so model selection scales with task size.

--- a/.claude/scripts/schemas/explore-research.json
+++ b/.claude/scripts/schemas/explore-research.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["status", "summary"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["success", "partial", "error"]
+    },
+    "summary": {
+      "type": "string",
+      "description": "Concise summary of research findings (2-5 sentences)"
+    },
+    "affected_files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "what_needs_changing"],
+        "properties": {
+          "path": { "type": "string" },
+          "what_needs_changing": { "type": "string" }
+        }
+      }
+    },
+    "current_behavior": {
+      "type": "string",
+      "description": "What happens now"
+    },
+    "desired_behavior": {
+      "type": "string",
+      "description": "What should happen"
+    },
+    "patterns_to_follow": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Existing codebase patterns the implementation should follow"
+    },
+    "data_findings": {
+      "type": "string",
+      "description": "Raw data or measurements relevant to the investigation"
+    }
+  },
+  "additionalProperties": false
+}

--- a/.claude/skills/explore/SKILL.md
+++ b/.claude/skills/explore/SKILL.md
@@ -24,23 +24,34 @@ Refine the vague input into concrete requirements:
 - If the description is specific enough, proceed without questions
 - Identify: what's wrong / what's wanted, who's affected, what success looks like
 
-### Step 2: Research the Codebase
+### Step 2: Research the Codebase (Pipeline-Tracked)
 
-**Framework/library documentation (use Context7 first):**
-- `context7.resolve_library_id` → `context7.get_library_docs` for framework API docs
-- Fall back to web search only if Context7 doesn't have the library or is unavailable
-- See `mcp-tools` skill for full decision matrix
+**Run the research subagent** to gather findings cheaply (haiku, escalates to sonnet if needed):
 
-**Code structure and patterns (use Serena for structural queries):**
-- Use Serena for class hierarchies, method signatures, call graphs
-- Use Grep/Glob for text-based file search and discovery
+```bash
+bash .claude/scripts/explore-orchestrator.sh \
+  --idea "$DESCRIPTION" \
+  --project-dir "$PWD"
+```
 
-**Document findings:**
-- Identify affected files, services, components
-- Document current behaviour vs desired behaviour
-- Note architectural patterns to follow
+This runs a tracked research phase that:
+- Uses the research-agent on haiku (cheapest model) for mechanical file reading
+- Escalates to sonnet if max turns hit
+- Writes `status.json` + `metrics.json` to `logs/explore/` (tracked by claude-spend)
+- Outputs `research-summary.json` with structured findings
 
-**Context Checkpoint (Optional):** If the research phase read many files or generated extensive tool output, consider writing a concise research summary to a temp file and suggesting `/clear` before evaluation. The evaluation and planning phases only need the summary, not the raw exploration context. Use `/create-session-summary` if checkpointing.
+**After the subagent completes**, read the research summary:
+
+```bash
+cat logs/explore/explore-*/research-summary.json | jq .
+```
+
+**Review the findings** — if the research is insufficient, do supplemental interactive research:
+- Use Context7 for framework docs (`context7.resolve_library_id` → `context7.get_library_docs`)
+- Use Serena for class hierarchies and symbol relationships
+- Use Grep/Glob for text-based file search
+
+**Present findings to the user** before proceeding to evaluation. The research phase is the boundary between cheap pipeline work and valuable interactive judgment.
 
 ### Step 3: Evaluate Approaches
 
@@ -53,12 +64,13 @@ Determine the best implementation strategy:
 ### Step 4: Generate Implementation Plan
 
 Break the chosen approach into implementable tasks:
+- **Maximum 3 tasks per issue** — if you need more, split into multiple issues with dependency ordering
 - Each task specifies an agent type (see Task Format below)
+- **Prefer S-complexity tasks** — they use haiku (cheapest). Break M tasks into multiple S tasks when possible. Avoid L tasks entirely.
 - Tasks are ordered by dependency (data layer first, then presentation)
-- Each task is a single logical unit of work
-- Each task should target 5-30 minutes of subagent execution time
+- Each task is a single logical unit of work targeting 5-15 minutes of subagent execution
 - If a task requires reading more than 3 files or modifying more than 2 files, split it
-- Add a complexity hint: `- [ ] \`[agent]\` **(S)** Description` where S=small (~5 min), M=medium (~15 min), L=large (~30 min)
+- Add a complexity hint: `- [ ] \`[agent]\` **(S)** Description` where S=small (~5 min), M=medium (~15 min)
 - Frontend and backend changes in the same task should be split — backend first (data layer), then frontend (presentation)
 
 **REQUIRED: Each task description MUST include specific file paths from Step 2 research.** Include file names, paths, and line numbers inline. This prevents vague descriptions that cause subagents to explore broadly.
@@ -203,7 +215,7 @@ Task sizing directly controls model cost via `model-config.sh`:
 |------------|--------------|
 | Skip research, jump to planning | Plan won't account for existing patterns |
 | Create local plan files | The issue IS the plan — single source of truth |
-| Over-plan with 20+ tasks | Keep it focused; split into multiple issues if needed |
+| More than 3 tasks in one issue | Split into multiple issues — issues with 5+ tasks fail ~70% of the time |
 | Combine multiple concerns in one issue | One issue = one problem = one PR |
 | Ask too many clarifying questions | 0-2 questions max; research answers most questions |
 | Single task modifies 5+ files | Split into focused subtasks |


### PR DESCRIPTION
## Summary
Closes #110

Makes `/explore` a hybrid skill — research phase runs as a tracked pipeline subagent (haiku, escalates to sonnet), evaluation/planning stays interactive.

### New files
- **`explore-orchestrator.sh`** (~250 lines) — lightweight orchestrator for research phase. Writes `status.json` + `metrics.json` to `logs/explore/`. Single stage, single task, one output.
- **`research-agent.md`** — agent definition with Context7/Serena/Grep research protocol
- **`explore-research.json`** — structured output schema for research findings

### Modified files
- **`model-config.sh`** — added `research` as light-tier stage (starts haiku)
- **`explore/SKILL.md`** — Step 2 now invokes explore-orchestrator.sh, max 3 tasks per issue, prefer S-complexity

### Cross-repo
- **claude-spend** `src/parser.js` — added `logs/explore` to scan patterns (committed directly to main)

## Test plan
- [ ] Run `/explore "test idea"` and verify `logs/explore/` directory created with status.json
- [ ] Verify research-summary.json contains structured findings
- [ ] Verify claude-spend dashboard picks up explore runs
- [ ] Verify existing `/implement-issue` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)