### PR TITLE
fix(pipeline): enforce S-task decomposition — M-tasks complete at 14% vs S at 36%

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -4419,6 +4419,27 @@ $excerpt
             fi
         done
 
+        # (c) Warn about M/L complexity tasks
+        local ml_warn_count=0
+        local -a ml_warn_list=()
+        for ((i=0; i<task_count; i++)); do
+            local check_ml_desc
+            check_ml_desc=$(printf '%s' "$tasks_json" | jq -r ".[$i].description")
+            if echo "$check_ml_desc" | grep -qE '\*\*\([ML]\)\*\*'; then
+                log "⚠️  M/L task detected (task $((i+1))): ${check_ml_desc:0:80}..."
+                ml_warn_list+=("$check_ml_desc")
+                ((ml_warn_count++)) || true
+            fi
+        done
+        if ((ml_warn_count > 0)); then
+            log "⚠️  $ml_warn_count M/L task(s) in this run — M-tasks fail at 3× the rate of S-tasks. Consider decomposing."
+            local ml_warnings_json
+            ml_warnings_json=$(printf '%s\n' "${ml_warn_list[@]}" | jq -R . | jq -s .)
+            jq --argjson warnings "$ml_warnings_json" \
+               '.complexity_warnings = $warnings | .last_update = (now | todate)' \
+               "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+        fi
+
         # (d) Extract backtick-quoted file paths from issue body and check existence
         if [[ -f "$issue_body_file" ]]; then
             local -a found_paths=()

--- a/.claude/skills/explore/SKILL.md
+++ b/.claude/skills/explore/SKILL.md
@@ -71,6 +71,7 @@ Break the chosen approach into implementable tasks:
 - Each task is a single logical unit of work targeting 5-15 minutes of subagent execution
 - If a task requires reading more than 3 files or modifying more than 2 files, split it
 - Add a complexity hint: `- [ ] \`[agent]\` **(S)** Description` where S=small (~5 min), M=medium (~15 min)
+- **M-task review (required):** After drafting the task list, for each M or L task: (1) can it split by file? (2) can it split by named function — each function becomes its own S-task? (3) can it split into add/test/config concerns? If any split is possible, replace the M/L task with 2-3 S-tasks. Keep M only for genuinely single-file, single-concern work that cannot run in under 5 minutes.
 - Frontend and backend changes in the same task should be split — backend first (data layer), then frontend (presentation)
 
 **REQUIRED: Each task description MUST include specific file paths from Step 2 research.** Include file names, paths, and line numbers inline. This prevents vague descriptions that cause subagents to explore broadly.
@@ -200,6 +201,7 @@ Task sizing directly controls model cost via `model-config.sh`:
 
 - **Prefer S-complexity tasks** — they use haiku (cheapest model). Only use M/L when the work genuinely requires it.
 - **Split M/L tasks into multiple S tasks** when the work is decomposable into independent steps.
+  - After drafting, apply the M-task review: for each M/L task check if it splits by file, by named function, or by concern (add/test/config). Replace with S-tasks if split is possible.
 - **Point tasks to specific files and line numbers** — vague descriptions cause subagents to explore broadly, triggering 19x more tool calls.
 - **Each task's affected file list reduces subagent exploration cost** — include file paths in the task description.
 


### PR DESCRIPTION
## Summary
- Add mandatory **M-task review** step to explore skill: after drafting tasks, each M/L task must be checked for decomposition by file, by named function, or by add/test/config concern — replaced with S-tasks if split is possible
- Add sub-bullet in Token Efficiency section reinforcing the M-task review procedure
- Add `(c) Warn about M/L complexity tasks` block in `validate_plan` stage: logs per-task warnings and writes `complexity_warnings` array to `status.json`

## Test plan
- [ ] Run `/explore` on a multi-function task and verify it produces S-tasks instead of a single M-task
- [ ] Run a pipeline with M/L tasks and verify `status.json` contains `complexity_warnings` array
- [ ] Verify `validate_plan` logs `⚠️ N M/L tasks detected` when M/L tasks are present

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)