### PR TITLE
fix(model-config): default test-iter stages to sonnet — 100% haiku escalation rate wastes tokens

### DIFF
--- a/.claude/scripts/implement-issue-test/test-model-config.bats
+++ b/.claude/scripts/implement-issue-test/test-model-config.bats
@@ -113,6 +113,18 @@ run_with_config() {
 	[[ "$output" == "light" ]]
 }
 
+@test "stage test-iter maps to standard" {
+	run_with_config '_stage_to_tier "test-iter"'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "standard" ]]
+}
+
+@test "resolve_model test-iter-1 resolves to sonnet" {
+	run_with_config 'resolve_model "test-iter-1"'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "sonnet" ]]
+}
+
 @test "stage review maps to standard" {
 	run_with_config '_stage_to_tier "review"'
 	[ "$status" -eq 0 ]

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -45,6 +45,7 @@ _stage_to_tier() {
 		implement)      printf '%s' "standard" ;;
 		task-review)    printf '%s' "standard" ;;
 		fix)            printf '%s' "standard" ;;
+		test-iter)      printf '%s' "standard" ;;
 		test)           printf '%s' "light" ;;
 		review)         printf '%s' "standard" ;;
 		research)       printf '%s' "light" ;;
@@ -99,7 +100,7 @@ if [[ -z "${_STAGE_PREFIXES+set}" ]]; then
 	readonly -a _STAGE_PREFIXES=(
 		fix-acceptance-test acceptance-test validate-plan
 		fix-deploy-verify deploy-verify spec-review code-review task-review parse-issue e2e-verify
-		pr-review implement simplify research complete pr-fix fix-e2e review test docs fix pr
+		pr-review implement simplify research complete pr-fix fix-e2e review test-iter test docs fix pr
 	)
 fi
 


### PR DESCRIPTION
## Summary
- Add `test-iter` case to `_stage_to_tier()` returning `standard` tier (placed before `test` for priority)
- Insert `test-iter` into `_STAGE_PREFIXES` array before `test` for correct prefix matching
- Add two BATS test cases: `_stage_to_tier "test-iter"` returns `standard`, `resolve_model "test-iter-1"` returns `sonnet`

100% of `test-iter` runs were exhausting haiku's 10-turn cap then escalating to sonnet. Defaulting directly to sonnet eliminates the always-wasted haiku attempt, saving ~10-15% per test-iter stage.

## Test plan
- [ ] `_stage_to_tier "test-iter"` returns `standard` ✅ (BATS green)
- [ ] `resolve_model "test-iter-1"` returns `sonnet` ✅ (BATS green)
- [ ] `_stage_to_tier "test"` still returns `light` (no regression) ✅
- [ ] `test-iter-2`, `test-iter-3` also resolve to sonnet via prefix match ✅

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)