### PR TITLE
fix(orchestrator): gate PR stage on commit count — 4 runs error on empty-branch PR creation

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -4809,6 +4809,19 @@ $full_scope_failures
         "$branch" "$branch_scope" "$pipeline_profile" "$max_task_size"
 
     # -------------------------------------------------------------------------
+    # NO-COMMITS GATE: exit before expensive post-implementation stages
+    # If all tasks produced 0 commits, skip deploy-verify, docs, and PR creation.
+    # -------------------------------------------------------------------------
+    local post_impl_commit_count
+    post_impl_commit_count=$(git rev-list --count "${BASE_BRANCH}..${branch}" 2>/dev/null || echo 0)
+    if (( post_impl_commit_count == 0 )); then
+        log "⚠️  No commits on branch after implementation — all tasks failed without producing changes."
+        comment_issue "Pipeline: No Changes" "⚠️ No commits on branch \`${branch}\` relative to \`${BASE_BRANCH}\` — all tasks failed without producing changes. No PR created." ""
+        set_final_state "no_changes"
+        exit 0
+    fi
+
+    # -------------------------------------------------------------------------
     # STAGE: DEPLOY VERIFY
     # Deploys to a configured target environment (test/nas/staging) and polls
     # the health URL until the service is live, then runs a verification prompt
@@ -5000,16 +5013,6 @@ Add comprehensive JSDoc/TSDoc comments and commit with message: docs(issue-$ISSU
         fi
         log "Using existing PR #$pr_number"
     else
-        # Gate: skip PR if no commits on branch
-        local commit_count
-        commit_count=$(git -C "$LOOP_DIR" rev-list "${BASE_BRANCH}...${branch}" --count 2>/dev/null || echo 0)
-        if (( commit_count == 0 )); then
-            log "⚠️  No commits on branch relative to $BASE_BRANCH — all tasks may have failed without producing changes. Skipping PR creation."
-            comment_issue "Pipeline: No Changes" "⚠️ No commits on branch \`${branch}\` relative to \`${BASE_BRANCH}\` — all tasks may have failed without producing changes. No PR created." "default"
-            set_final_state "no_changes"
-            exit 0
-        fi
-
         set_stage_started "pr"
 
         local pr_prompt="Create a merge request for issue #$ISSUE_NUMBER.


### PR DESCRIPTION
## Summary
- Before `set_stage_started("pr")`, check `git rev-list ${BASE_BRANCH}...${branch} --count`
- If 0 commits: log warning, post explanatory issue comment, set `state: "no_changes"`, exit 0
- Turns `"error"` terminal state (failed `gh pr create`) into clean `"no_changes"` state

Companion change in `claude-spend` repo (branch `feature/issue-114`): adds `no_changes` to `failureBreakdown` in `parser.js` and `index.html`, with distinct chart bar (color `#94A3B8`).

## Test plan
- [ ] AC1: Run where all tasks fail with no commits exits `no_changes` (not `error`) with issue comment
- [ ] AC2: Run where ≥1 task committed proceeds to PR creation unchanged
- [ ] AC3: claude-spend dashboard shows `no_changes` as distinct bar (verify in claude-spend repo)
- [ ] AC4: The 4 Hubspot runs (#90, #95, #108) would have shown `no_changes` under new logic

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)