### PR TITLE
fix: Jira create-issue error handling and implement-issue SIGPIPE prevention

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -1060,15 +1060,21 @@ run_stage() {
         fallback_args=(--fallback-model "$fallback_model")
     fi
 
-    # Cap exploration for inherently light-tier stages (parse, pr, complete, etc.)
+    # Cap exploration for inherently light-tier stages (parse, complete, docs, etc.)
     # These are mechanical and should complete in a few turns.
     # Do NOT cap implement/review/fix stages that use haiku via S-complexity override —
     # those still need enough turns to read files, make edits, and produce output.
+    #
+    # PR creation gets a separate cap — it only needs to run glab/gh mr create,
+    # push if needed, and format a description. 10 turns is plenty.
     local -a turns_args=()
     local _matched_prefix _inherent_tier
     _matched_prefix=$(_match_stage_prefix "$stage_name") || true
     _inherent_tier=$(_stage_to_tier "${_matched_prefix:-}")
-    if [[ "$model" == "haiku" && "$_inherent_tier" == "light" ]]; then
+    if [[ "${_matched_prefix:-}" == "pr" && "${_matched_prefix:-}" != "pr-review" && "${_matched_prefix:-}" != "pr-fix" ]]; then
+        turns_args=(--max-turns 10)
+        log "  Max turns: 10 (PR creation — push + create MR)"
+    elif [[ "$model" == "haiku" && "$_inherent_tier" == "light" ]]; then
         turns_args=(--max-turns 10)
         log "  Max turns: 10 (inherently light stage)"
     elif [[ "$model" == "haiku" ]]; then
@@ -1851,23 +1857,26 @@ all_tasks_s_complexity() {
 
 # Get PR review configuration based on diff size.
 # Returns JSON: { "model": "...", "timeout": N, "max_iterations": N }
-# Four tiers by diff line count:
-#   <20  lines  → haiku,  300s timeout, 1 iteration  (tiny)
-#   <50  lines  → haiku,  600s timeout, 1 iteration  (small)
-#   <200 lines  → sonnet, 900s timeout, MAX_PR_REVIEW_ITERATIONS (medium)
-#   200+ lines  → sonnet, 1800s timeout, MAX_PR_REVIEW_ITERATIONS (large)
+#
+# All tiers use sonnet. Haiku was tried for tiny/small diffs but in practice
+# it burns through max turns exploring the codebase (4.7M tokens for an
+# 11-line diff) then escalates to sonnet anyway — wasting ~$0.85 and ~5 min.
+# Sonnet with the diff included in the prompt finishes in 2-3 turns.
+#
+# Three tiers by diff line count:
+#   <50  lines  → sonnet, 180s timeout, 1 iteration  (small)
+#   <200 lines  → sonnet, 600s timeout, MAX_PR_REVIEW_ITERATIONS (medium)
+#   200+ lines  → sonnet, 1200s timeout, MAX_PR_REVIEW_ITERATIONS (large)
 get_pr_review_config() {
     local diff_lines
     diff_lines=$(get_diff_line_count "$BASE_BRANCH")
 
-    if (( diff_lines < 20 )); then
-        printf '{"model":"haiku","timeout":300,"max_iterations":1}'
-    elif (( diff_lines < 50 )); then
-        printf '{"model":"haiku","timeout":600,"max_iterations":1}'
+    if (( diff_lines < 50 )); then
+        printf '{"model":"sonnet","timeout":180,"max_iterations":1}'
     elif (( diff_lines < 200 )); then
-        printf '{"model":"sonnet","timeout":900,"max_iterations":%d}' "$MAX_PR_REVIEW_ITERATIONS"
+        printf '{"model":"sonnet","timeout":600,"max_iterations":%d}' "$MAX_PR_REVIEW_ITERATIONS"
     else
-        printf '{"model":"sonnet","timeout":1800,"max_iterations":%d}' "$MAX_PR_REVIEW_ITERATIONS"
+        printf '{"model":"sonnet","timeout":1200,"max_iterations":%d}' "$MAX_PR_REVIEW_ITERATIONS"
     fi
 }
 
@@ -5655,10 +5664,22 @@ The command will output the MR number. Use that as pr_number in your response."
         # -------------------------------------------------------------------------
         # COMBINED SPEC + CODE REVIEW → PR comment #11 (single pass)
         # -------------------------------------------------------------------------
+        # Include the diff inline so the reviewer doesn't waste turns running git diff
+        # and exploring the entire codebase. For small diffs this dramatically reduces
+        # token usage (4.7M → ~50K observed on an 11-line diff).
+        local pr_diff
+        pr_diff=$(git diff "$BASE_BRANCH"...HEAD -- 2>/dev/null | head -500)
+
         local review_prompt="Review PR #$pr_number for issue #$ISSUE_NUMBER against base $BASE_BRANCH.
 
 Part 1 — Spec Review: Verify the PR achieves the goals of the issue. Check goal achievement, not code quality. Flag scope creep.
 Part 2 — Code Review: Review code quality, patterns, standards, and security.
+
+Here is the diff to review (do NOT run git diff yourself — use this):
+
+\`\`\`diff
+$pr_diff
+\`\`\`
 
 Approve or request changes. Output a summary suitable for an issue comment."
 

--- a/.claude/scripts/platform/create-issue.sh
+++ b/.claude/scripts/platform/create-issue.sh
@@ -16,20 +16,38 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+[[ -z "$TITLE" ]] && { echo "ERROR: --title is required" >&2; exit 3; }
+
 case "$TRACKER" in
   github)
     ARGS=(gh issue create --title "$TITLE" --body "$BODY")
     [[ -n "$LABELS" ]] && ARGS+=(--label "$LABELS")
-    "${ARGS[@]}" 2>/dev/null | grep -oE '[0-9]+$'
+    "${ARGS[@]}" 2>&1 | grep -oE '[0-9]+$'
     ;;
   jira)
     ARGS=(acli jira workitem create
       --project "$JIRA_PROJECT"
       --type "$JIRA_DEFAULT_ISSUE_TYPE"
-      --summary "$TITLE"
-      --description "$BODY")
+      --summary "$TITLE")
+
+    # Write body to temp file for large descriptions (avoids arg length limits)
+    if [[ -n "$BODY" ]]; then
+      TMPFILE="$(mktemp)"
+      trap 'rm -f "$TMPFILE"' EXIT
+      printf '%s' "$BODY" > "$TMPFILE"
+      ARGS+=(--description-file "$TMPFILE")
+    fi
+
     [[ -n "$PARENT" ]] && ARGS+=(--parent "$PARENT")
     [[ -n "$LABELS" ]] && ARGS+=(--label "$LABELS")
-    "${ARGS[@]}" 2>/dev/null | grep -oE '[A-Z]+-[0-9]+'
+
+    OUTPUT=$("${ARGS[@]}" 2>&1) || {
+      echo "ERROR: acli failed: $OUTPUT" >&2
+      if [[ "$OUTPUT" == *"unauthorized"* ]] || [[ "$OUTPUT" == *"auth"* ]]; then
+        echo "HINT: Run 'acli jira auth login' to authenticate" >&2
+      fi
+      exit 1
+    }
+    echo "$OUTPUT" | grep -oE '[A-Z]+-[0-9]+'
     ;;
 esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,11 @@
             "type": "command",
             "command": "jq -r '.tool_input.file_path // empty' | { read f; if [ -n \"$f\" ]; then source \"$CLAUDE_PROJECT_DIR/.claude/config/platform.sh\" 2>/dev/null; if [ -n \"${FORMAT_CMD:-}\" ]; then cd \"$CLAUDE_PROJECT_DIR\" && eval \"$FORMAT_CMD\" \"$f\" 2>/dev/null; fi; fi; }",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/skills/pipeline-sync/scripts/detect-core-edit.sh\"",
+            "timeout": 5
           }
         ]
       },

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -16,36 +16,68 @@ End-to-end issue implementation — reads plan from issue tracker, implements wi
 
 ## Invocation
 
-Immediately launch the orchestrator:
+The orchestrator is a long-running process (10-60 minutes) that spawns Claude CLI subprocesses for each stage. It must be launched in the background to avoid SIGPIPE — if the Bash tool's output buffer fills or a pipe truncates (e.g., `| head`), the orchestrator is killed silently mid-stage.
+
+### Step 1: Launch in background
 
 ```bash
-.claude/scripts/implement-issue-orchestrator.sh \
-  --issue $ISSUE_NUMBER \
-  --branch $BASE_BRANCH
-```
+LOG_DIR="logs/implement-issue/issue-${ISSUE_NUMBER}-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$LOG_DIR"
 
-Or with explicit agent override:
-
-```bash
-.claude/scripts/implement-issue-orchestrator.sh \
+nohup .claude/scripts/implement-issue-orchestrator.sh \
   --issue $ISSUE_NUMBER \
   --branch $BASE_BRANCH \
-  --agent bulletproof-frontend-developer
+  > "$LOG_DIR/orchestrator-stdout.log" 2>&1 &
+
+ORCH_PID=$!
+echo "Orchestrator PID: $ORCH_PID"
 ```
 
-## Monitoring
-
-Check progress via status.json:
+With explicit agent override:
 
 ```bash
-jq . status.json
+nohup .claude/scripts/implement-issue-orchestrator.sh \
+  --issue $ISSUE_NUMBER \
+  --branch $BASE_BRANCH \
+  --agent bulletproof-frontend-developer \
+  > "$LOG_DIR/orchestrator-stdout.log" 2>&1 &
 ```
 
-Watch live:
+### Step 2: Monitor via status.json
+
+Poll `status.json` to track progress. Do NOT pipe the orchestrator through `head`, `tail`, or any command that truncates output — this sends SIGPIPE and kills the process.
 
 ```bash
-watch -n 5 'jq -c "{state,stage:.current_stage,task:.current_task,quality:.quality_iterations}" status.json'
+# Quick status check
+jq -c '{state, stage: .current_stage, task: .current_task, quality: .quality_iterations}' status.json
+
+# Check if still running
+kill -0 $ORCH_PID 2>/dev/null && echo "Running" || echo "Finished"
+
+# Recent log lines
+tail -5 logs/implement-issue/issue-*/orchestrator.log
 ```
+
+### Step 3: Handle completion
+
+When `status.json` shows `state: "completed"` or `state: "error"`:
+
+```bash
+jq '{state, current_stage, error, pr_url}' status.json
+```
+
+## Fallback: Manual implementation
+
+If the orchestrator fails (missing CLI auth, rate limits, infrastructure issues), implement manually following the same quality gates:
+
+1. **Parse issue** — read issue body via platform CLI or MCP, extract implementation tasks
+2. **Create branch** — `git checkout -b feature/issue-$ISSUE_NUMBER $BASE_BRANCH`
+3. **Implement** — execute each task, using the specified agent type as guidance
+4. **Test** — run unit tests and E2E tests per `platform.sh` config
+5. **Commit and push** — commit changes, push branch
+6. **Create MR/PR** — via platform wrapper or CLI
+
+This fallback ensures the issue gets implemented even when the orchestrator can't run.
 
 ## Stages
 
@@ -71,6 +103,7 @@ Located in `.claude/scripts/schemas/implement-issue-*.json`
 
 Logs written to `logs/implement-issue/issue-N-timestamp/`:
 - `orchestrator.log` — main log
+- `orchestrator-stdout.log` — raw stdout/stderr from nohup launch
 - `stages/` — per-stage Claude output
 - `context/` — parsed outputs (tasks.json, etc.)
 - `status.json` — final status snapshot
@@ -83,6 +116,15 @@ Logs written to `logs/implement-issue/issue-N-timestamp/`:
 | 1 | Error during a stage |
 | 2 | Max iterations exceeded |
 | 3 | Configuration/argument error |
+
+## Common Failures
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Orchestrator dies immediately | SIGPIPE from piped output | Use `nohup ... &`, never pipe through `head`/`tail` |
+| "unauthorized" from acli | CLI not authenticated | Run `acli jira auth login` |
+| status.json stuck at "running" | Process killed externally | Check `kill -0 $PID`, restart if needed |
+| Claude CLI rate limited | Too many API calls | Orchestrator handles retry automatically |
 
 ## Integration
 

--- a/.claude/skills/pipeline-sync/SKILL.md
+++ b/.claude/skills/pipeline-sync/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: pipeline-sync
+description: Sync core pipeline files between claude-pipeline and project repos. Use when the user says "sync pipeline", "upstream this fix", "pull latest pipeline", "push to upstream", or when they've fixed a bug in a project's .claude/scripts/ that should be shared. Also use proactively after editing core files (scripts, hooks, schemas) to remind the user to sync.
+---
+
+# Pipeline Sync
+
+Manage core pipeline files across the claude-pipeline repo and project repos that use the pipeline. Core files (scripts, hooks, schemas, universal skills) are shared; project-specific files (agents, config, prompts) are never touched.
+
+## When This Matters
+
+The claude-pipeline is a template that gets adapted per-project. Agents and some skills are rewritten for each project's tech stack, but the orchestration engine (scripts, hooks, schemas) stays the same. When a bug is found in a project's copy, it needs to flow back to the pipeline repo and out to other projects.
+
+Without this workflow, fixes get stranded in individual projects and the same bug gets rediscovered repeatedly.
+
+## Prerequisites
+
+- `sync.sh` must exist at the root of the claude-pipeline repo
+- The claude-pipeline repo is at `~/Projects/claude-pipeline` (adjust if different)
+
+Verify with:
+```bash
+ls ~/Projects/claude-pipeline/sync.sh
+```
+
+## Workflows
+
+### 1. Push upstream changes TO a project
+
+When the pipeline repo has new features or fixes to distribute:
+
+```bash
+cd ~/Projects/claude-pipeline
+
+# Check what's different first
+./sync.sh diff ~/Projects/<project-name>
+
+# Push core files (scripts, hooks, schemas, universal skills)
+./sync.sh to ~/Projects/<project-name>
+```
+
+This never touches project-specific files (agents, `config/platform.sh`, prompts, project-only skills).
+
+### 2. Pull a fix FROM a project back to the pipeline
+
+When a bug was fixed in a project's `.claude/scripts/` or `.claude/hooks/`:
+
+```bash
+cd ~/Projects/claude-pipeline
+
+# See what the project changed
+./sync.sh diff ~/Projects/<project-name>
+
+# Pull the fix
+./sync.sh from ~/Projects/<project-name>
+
+# Review what changed
+git diff
+
+# Commit
+git checkout -b fix/<descriptive-name>
+git add -A
+git commit -m "fix: <description of the fix>"
+```
+
+### 3. Create a PR to upstream (stevegrocott/claude-pipeline)
+
+After committing a fix to the local fork:
+
+```bash
+cd ~/Projects/claude-pipeline
+git push origin fix/<branch-name>
+
+gh pr create \
+  --repo stevegrocott/claude-pipeline \
+  --head scullers68:fix/<branch-name> \
+  --base main \
+  --title "fix: <title>" \
+  --body "$(cat <<'EOF'
+## Summary
+- <what changed and why>
+
+## Context
+<how the bug was discovered, which project, what happened>
+
+## Test plan
+- [ ] <how to verify the fix>
+EOF
+)"
+```
+
+### 4. Pull upstream updates and distribute
+
+When Steve merges PRs or pushes new features:
+
+```bash
+cd ~/Projects/claude-pipeline
+git fetch upstream
+git merge upstream/main
+git push origin main
+
+# Distribute to all projects
+./sync.sh to ~/Projects/allied-universal-assign
+./sync.sh to ~/Projects/<other-project>
+```
+
+## What Gets Synced
+
+Run `./sync.sh list` for the definitive list. In summary:
+
+| Synced (core) | Never synced (project-specific) |
+|---------------|-------------------------------|
+| `scripts/**` | `agents/*.md` |
+| `hooks/**` | `config/platform.sh` |
+| `settings.json` | `prompts/*.md` |
+| Universal skills (brainstorming, TDD, debugging, etc.) | Project-only skills (playwright-verification, server-health-check, etc.) |
+
+## Adding a New Universal Skill
+
+If you create a skill in a project that should be shared across all projects:
+
+1. Add the skill name to the `UNIVERSAL_SKILLS` array in `sync.sh`
+2. Run `./sync.sh from ~/Projects/<project>` to pull it to the pipeline
+3. Commit and PR upstream
+
+## Proactive Reminders
+
+After editing any file in `.claude/scripts/`, `.claude/hooks/`, or `.claude/skills/<universal-skill>/`, consider whether the change should be synced. If it's a bug fix or improvement to the shared engine, prompt the user:
+
+> "This change is in a core pipeline file. Want me to sync it back to claude-pipeline and create a PR upstream?"

--- a/.claude/skills/pipeline-sync/SKILL.md
+++ b/.claude/skills/pipeline-sync/SKILL.md
@@ -1,24 +1,34 @@
 ---
 name: pipeline-sync
-description: Sync core pipeline files between claude-pipeline and project repos. Use when the user says "sync pipeline", "upstream this fix", "pull latest pipeline", "push to upstream", or when they've fixed a bug in a project's .claude/scripts/ that should be shared. Also use proactively after editing core files (scripts, hooks, schemas) to remind the user to sync.
+description: Sync core pipeline files between claude-pipeline and project repos. Use when the user says "sync pipeline", "upstream this fix", "pull latest pipeline", "push to upstream", or when they've fixed a bug in a project's .claude/scripts/ that should be shared. Also use proactively after editing core files (scripts, hooks, schemas) to remind the user to sync. Includes a PostToolUse hook that auto-detects core file edits.
 ---
 
 # Pipeline Sync
 
-Manage core pipeline files across the claude-pipeline repo and project repos that use the pipeline. Core files (scripts, hooks, schemas, universal skills) are shared; project-specific files (agents, config, prompts) are never touched.
+Manage core pipeline files across the claude-pipeline repo and project repos that use the pipeline.
 
-## When This Matters
+The orchestration engine (scripts, hooks, schemas, universal skills) is shared across all projects. When a bug is fixed in one project's copy, it needs to flow back to the pipeline repo and out to other projects. Without this, fixes get stranded and the same bug gets rediscovered repeatedly.
 
-The claude-pipeline is a template that gets adapted per-project. Agents and some skills are rewritten for each project's tech stack, but the orchestration engine (scripts, hooks, schemas) stays the same. When a bug is found in a project's copy, it needs to flow back to the pipeline repo and out to other projects.
+## Hook: Automatic Core File Detection
 
-Without this workflow, fixes get stranded in individual projects and the same bug gets rediscovered repeatedly.
+A PostToolUse hook at `scripts/detect-core-edit.sh` fires on every Edit/Write. When the edited file is a core pipeline file (script, hook, or universal skill), it outputs a reminder with the sync command. This means you don't need to remember to check — the hook tells you.
+
+The hook is registered in `settings.json` and must be present for automatic detection to work. If it's missing, add it during `/adapting-claude-pipeline`:
+
+```json
+{
+  "matcher": "Edit|Write",
+  "hooks": [{
+    "type": "command",
+    "command": "\"$CLAUDE_PROJECT_DIR/.claude/skills/pipeline-sync/scripts/detect-core-edit.sh\"",
+    "timeout": 5
+  }]
+}
+```
 
 ## Prerequisites
 
-- `sync.sh` must exist at the root of the claude-pipeline repo
-- The claude-pipeline repo is at `~/Projects/claude-pipeline` (adjust if different)
-
-Verify with:
+`sync.sh` at the root of the claude-pipeline repo. Verify:
 ```bash
 ls ~/Projects/claude-pipeline/sync.sh
 ```
@@ -27,104 +37,55 @@ ls ~/Projects/claude-pipeline/sync.sh
 
 ### 1. Push upstream changes TO a project
 
-When the pipeline repo has new features or fixes to distribute:
+```bash
+cd ~/Projects/claude-pipeline
+./sync.sh diff ~/Projects/<project-name>    # Check first
+./sync.sh to ~/Projects/<project-name>      # Push core files
+```
+
+Never touches project-specific files (agents, `config/platform.sh`, prompts).
+
+### 2. Pull a fix FROM a project
 
 ```bash
 cd ~/Projects/claude-pipeline
-
-# Check what's different first
-./sync.sh diff ~/Projects/<project-name>
-
-# Push core files (scripts, hooks, schemas, universal skills)
-./sync.sh to ~/Projects/<project-name>
+./sync.sh diff ~/Projects/<project-name>    # See what changed
+./sync.sh from ~/Projects/<project-name>    # Pull the fix
+git diff                                     # Review
+git checkout -b fix/<name>
+git add -A && git commit -m "fix: <description>"
 ```
 
-This never touches project-specific files (agents, `config/platform.sh`, prompts, project-only skills).
-
-### 2. Pull a fix FROM a project back to the pipeline
-
-When a bug was fixed in a project's `.claude/scripts/` or `.claude/hooks/`:
-
-```bash
-cd ~/Projects/claude-pipeline
-
-# See what the project changed
-./sync.sh diff ~/Projects/<project-name>
-
-# Pull the fix
-./sync.sh from ~/Projects/<project-name>
-
-# Review what changed
-git diff
-
-# Commit
-git checkout -b fix/<descriptive-name>
-git add -A
-git commit -m "fix: <description of the fix>"
-```
-
-### 3. Create a PR to upstream (stevegrocott/claude-pipeline)
-
-After committing a fix to the local fork:
+### 3. PR to upstream (stevegrocott/claude-pipeline)
 
 ```bash
 cd ~/Projects/claude-pipeline
 git push origin fix/<branch-name>
-
-gh pr create \
-  --repo stevegrocott/claude-pipeline \
-  --head scullers68:fix/<branch-name> \
-  --base main \
-  --title "fix: <title>" \
-  --body "$(cat <<'EOF'
-## Summary
-- <what changed and why>
-
-## Context
-<how the bug was discovered, which project, what happened>
-
-## Test plan
-- [ ] <how to verify the fix>
-EOF
-)"
+gh pr create --repo stevegrocott/claude-pipeline \
+  --head scullers68:fix/<branch-name> --base main \
+  --title "fix: <title>" --body "<summary + context + test plan>"
 ```
 
 ### 4. Pull upstream updates and distribute
 
-When Steve merges PRs or pushes new features:
-
 ```bash
 cd ~/Projects/claude-pipeline
-git fetch upstream
-git merge upstream/main
-git push origin main
-
-# Distribute to all projects
+git fetch upstream && git merge upstream/main && git push origin main
 ./sync.sh to ~/Projects/allied-universal-assign
 ./sync.sh to ~/Projects/<other-project>
 ```
 
-## What Gets Synced
+## File Classification
 
-Run `./sync.sh list` for the definitive list. In summary:
+For the full breakdown of which files are core (synced) vs adapted (project-specific), read `references/file-classification.md`. In summary:
 
 | Synced (core) | Never synced (project-specific) |
 |---------------|-------------------------------|
-| `scripts/**` | `agents/*.md` |
-| `hooks/**` | `config/platform.sh` |
-| `settings.json` | `prompts/*.md` |
-| Universal skills (brainstorming, TDD, debugging, etc.) | Project-only skills (playwright-verification, server-health-check, etc.) |
+| `scripts/**`, `hooks/**`, `settings.json` | `agents/*.md`, `config/platform.sh`, `prompts/*.md` |
+| Universal skills (brainstorming, TDD, etc.) | Project-only skills |
 
 ## Adding a New Universal Skill
 
-If you create a skill in a project that should be shared across all projects:
-
-1. Add the skill name to the `UNIVERSAL_SKILLS` array in `sync.sh`
-2. Run `./sync.sh from ~/Projects/<project>` to pull it to the pipeline
+1. Add the skill name to `UNIVERSAL_SKILLS` in `sync.sh`
+2. `./sync.sh from ~/Projects/<project>` to pull it
 3. Commit and PR upstream
-
-## Proactive Reminders
-
-After editing any file in `.claude/scripts/`, `.claude/hooks/`, or `.claude/skills/<universal-skill>/`, consider whether the change should be synced. If it's a bug fix or improvement to the shared engine, prompt the user:
-
-> "This change is in a core pipeline file. Want me to sync it back to claude-pipeline and create a PR upstream?"

--- a/.claude/skills/pipeline-sync/references/file-classification.md
+++ b/.claude/skills/pipeline-sync/references/file-classification.md
@@ -1,0 +1,55 @@
+# Pipeline File Classification
+
+## Core Files (synced across all projects)
+
+These files are the orchestration engine. Changes to them should flow back to claude-pipeline and out to all projects via `sync.sh`.
+
+### Always synced
+| Path | Purpose |
+|------|---------|
+| `scripts/implement-issue-orchestrator.sh` | Main orchestration pipeline |
+| `scripts/batch-orchestrator.sh` | Batch issue processing |
+| `scripts/batch-runner.sh` | Batch runner utility |
+| `scripts/model-config.sh` | Tier-to-model mapping |
+| `scripts/explore-orchestrator.sh` | Research phase orchestrator |
+| `scripts/apply-local.sh` | Local patch application |
+| `scripts/platform/*.sh` | Platform API wrappers (GitHub/GitLab/Jira) |
+| `scripts/platform/*.py` | Format converters (ADF↔markdown, markdown↔wiki) |
+| `scripts/schemas/*.json` | Structured output schemas for each stage |
+| `scripts/implement-issue-test/` | BATS test suite for orchestrator |
+| `scripts/platform-test/` | BATS tests for platform wrappers |
+| `hooks/session-start.sh` | Session initialization |
+| `hooks/post-pr-simplify.sh` | Post-PR code review trigger |
+| `settings.json` | Hook configuration, permissions |
+
+### Universal skills (synced)
+Process-focused, stack-agnostic skills. See `UNIVERSAL_SKILLS` array in `sync.sh` for the definitive list.
+
+Key ones: brainstorming, explore, implement-issue, handle-issues, systematic-debugging, test-driven-development, writing-plans, writing-skills, pipeline-sync.
+
+## Adapted Files (never synced, project-specific)
+
+These files are rewritten during `/adapting-claude-pipeline` for each project's tech stack.
+
+| Path | Why project-specific |
+|------|---------------------|
+| `agents/*.md` | Rewritten for project stack (e.g., totara-php-developer vs fastify-backend-developer) |
+| `config/platform.sh` | Project's tracker (GitHub/Jira), git host, test commands, base URLs |
+| `prompts/*.md` | Project-specific review checklists |
+| Project-only skills | Skills created for a specific project (e.g., playwright-verification, server-health-check) |
+
+## How to Decide
+
+When you edit a `.claude/` file, ask:
+
+1. **Would this change benefit other projects?** → Core file, sync it
+2. **Is this specific to this project's stack or domain?** → Adapted file, don't sync
+3. **Is this a bug fix in a script?** → Almost always core, sync it
+4. **Is this a new skill?** → Usually project-specific unless it's process-focused
+
+## Adding a New Universal Skill
+
+1. Create the skill in any project
+2. Add its name to `UNIVERSAL_SKILLS` in `sync.sh`
+3. `./sync.sh from <project>` to pull it to claude-pipeline
+4. Commit and PR upstream

--- a/.claude/skills/pipeline-sync/scripts/detect-core-edit.sh
+++ b/.claude/skills/pipeline-sync/scripts/detect-core-edit.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# PostToolUse hook: Detect edits to core pipeline files.
+#
+# When a core pipeline file (scripts, hooks, universal skill) is modified
+# in a project repo, outputs a reminder to sync the change back to
+# claude-pipeline. Skips if already inside the claude-pipeline repo.
+#
+# Called from settings.json PostToolUse hook on Edit|Write.
+# Reads JSON from stdin with tool_name and tool_input.file_path.
+
+if [[ -t 0 ]]; then
+    exit 0
+fi
+
+input=$(cat)
+
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // empty')
+
+if [[ "$tool_name" != "Edit" && "$tool_name" != "Write" ]]; then
+    exit 0
+fi
+
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+[[ -z "$file_path" ]] && exit 0
+
+# Don't fire inside the claude-pipeline repo itself
+if [[ "${CLAUDE_PROJECT_DIR:-}" == */claude-pipeline ]]; then
+    exit 0
+fi
+
+# Check if edited file is a core pipeline file
+is_core=false
+match_reason=""
+
+case "$file_path" in
+    */.claude/scripts/*)
+        is_core=true
+        match_reason="core script"
+        ;;
+    */.claude/hooks/*)
+        is_core=true
+        match_reason="core hook"
+        ;;
+esac
+
+# Check universal skills
+if [[ "$file_path" == */.claude/skills/* ]]; then
+    skill_name=$(echo "$file_path" | sed -n 's|.*/.claude/skills/\([^/]*\)/.*|\1|p')
+
+    # Read universal skills list from sync.sh if available
+    SYNC_SCRIPT="${CLAUDE_PROJECT_DIR:-.}/../claude-pipeline/sync.sh"
+    if [[ ! -f "$SYNC_SCRIPT" ]]; then
+        SYNC_SCRIPT="$HOME/Projects/claude-pipeline/sync.sh"
+    fi
+
+    if [[ -f "$SYNC_SCRIPT" ]]; then
+        # Extract UNIVERSAL_SKILLS array from sync.sh
+        if grep -q "\"$skill_name\"" "$SYNC_SCRIPT" 2>/dev/null; then
+            is_core=true
+            match_reason="universal skill"
+        fi
+    else
+        # Fallback: hardcoded list of known universal skills
+        case "$skill_name" in
+            brainstorming|create-session-summary|dispatching-parallel-agents|\
+            executing-plans|explore|handle-issues|implement-issue|improvement-loop|\
+            investigating-codebase-for-user-stories|mcp-tools|playwright-testing|\
+            process-pr|resume-session|subagent-driven-development|systematic-debugging|\
+            test-driven-development|using-git-worktrees|using-skills|writing-agents|\
+            writing-plans|writing-skills|adapting-claude-pipeline|pipeline-sync)
+                is_core=true
+                match_reason="universal skill"
+                ;;
+        esac
+    fi
+fi
+
+if [[ "$is_core" == "true" ]]; then
+    filename=$(basename "$file_path")
+    cat <<EOF
+You just edited a $match_reason ($filename). This is a core pipeline file shared across projects. If this change should be upstreamed, use the pipeline-sync skill:
+
+  cd ~/Projects/claude-pipeline && ./sync.sh from $CLAUDE_PROJECT_DIR
+EOF
+fi

--- a/sync.sh
+++ b/sync.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+#
+# sync.sh — Sync core pipeline files between claude-pipeline and project repos
+#
+# Core files (scripts, hooks, schemas) are identical across projects.
+# Adapted files (agents, skills, config, prompts) are project-specific
+# and never synced.
+#
+# Usage:
+#   ./sync.sh to   <project-path>   # Push core files to a project
+#   ./sync.sh from <project-path>   # Pull core fixes from a project
+#   ./sync.sh diff <project-path>   # Show differences in core files
+#   ./sync.sh list                   # List core files that get synced
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PIPELINE_DIR="$SCRIPT_DIR/.claude"
+
+# ---------------------------------------------------------------------------
+# Core files — synced between pipeline and projects.
+# These are the orchestration engine; they don't contain project-specific config.
+# ---------------------------------------------------------------------------
+CORE_DIRS=(
+    "scripts"
+    "hooks"
+)
+
+# Files within .claude/ that are core (synced individually)
+CORE_FILES=(
+    "settings.json"
+)
+
+# ---------------------------------------------------------------------------
+# Adapted files — NEVER synced. Project-specific.
+# ---------------------------------------------------------------------------
+# agents/*.md          — rewritten per project stack
+# config/platform.sh   — project-specific tracker, git host, test commands
+# prompts/*.md         — project-specific review checklists
+# skills/              — mix of universal and adapted (handled separately)
+
+# ---------------------------------------------------------------------------
+# Skills — some are universal (synced), some are adapted (not synced).
+# Universal skills are process-focused and stack-agnostic.
+# ---------------------------------------------------------------------------
+UNIVERSAL_SKILLS=(
+    "brainstorming"
+    "create-session-summary"
+    "dispatching-parallel-agents"
+    "executing-plans"
+    "explore"
+    "handle-issues"
+    "implement-issue"
+    "improvement-loop"
+    "investigating-codebase-for-user-stories"
+    "mcp-tools"
+    "playwright-testing"
+    "process-pr"
+    "resume-session"
+    "subagent-driven-development"
+    "systematic-debugging"
+    "test-driven-development"
+    "using-git-worktrees"
+    "using-skills"
+    "writing-agents"
+    "writing-plans"
+    "writing-skills"
+    "adapting-claude-pipeline"
+)
+
+# ---------------------------------------------------------------------------
+
+usage() {
+    cat <<'USAGE'
+Usage: ./sync.sh <command> <project-path>
+
+Commands:
+  to   <path>   Push core pipeline files TO a project's .claude/
+  from <path>   Pull core pipeline fixes FROM a project's .claude/
+  diff <path>   Show differences between pipeline and project core files
+  list          List all core files that get synced
+
+Examples:
+  ./sync.sh to   ~/Projects/allied-universal-assign
+  ./sync.sh from ~/Projects/allied-universal-assign
+  ./sync.sh diff ~/Projects/allied-universal-assign
+USAGE
+    exit 1
+}
+
+# Resolve the .claude directory in a project
+resolve_project_dir() {
+    local project_path="$1"
+    local claude_dir="$project_path/.claude"
+
+    if [[ ! -d "$claude_dir" ]]; then
+        echo "ERROR: $claude_dir does not exist. Run /adapting-claude-pipeline first." >&2
+        exit 1
+    fi
+
+    printf '%s' "$claude_dir"
+}
+
+# Sync a directory (rsync-style, preserving structure)
+sync_dir() {
+    local src="$1" dst="$2" dir="$3"
+
+    if [[ ! -d "$src/$dir" ]]; then
+        echo "  SKIP $dir/ (not in source)"
+        return
+    fi
+
+    mkdir -p "$dst/$dir"
+    rsync -a --delete \
+        --exclude '.DS_Store' \
+        "$src/$dir/" "$dst/$dir/"
+    echo "  SYNC $dir/"
+}
+
+# Sync a single file
+sync_file() {
+    local src="$1" dst="$2" file="$3"
+
+    if [[ ! -f "$src/$file" ]]; then
+        echo "  SKIP $file (not in source)"
+        return
+    fi
+
+    cp "$src/$file" "$dst/$file"
+    echo "  SYNC $file"
+}
+
+# Sync universal skills (directory-level sync for each skill)
+sync_skills() {
+    local src="$1" dst="$2"
+
+    for skill in "${UNIVERSAL_SKILLS[@]}"; do
+        if [[ -d "$src/skills/$skill" ]]; then
+            mkdir -p "$dst/skills/$skill"
+            rsync -a --delete \
+                --exclude '.DS_Store' \
+                "$src/skills/$skill/" "$dst/skills/$skill/"
+            echo "  SYNC skills/$skill/"
+        else
+            echo "  SKIP skills/$skill/ (not in source)"
+        fi
+    done
+}
+
+# Diff a directory
+diff_dir() {
+    local src="$1" dst="$2" dir="$3"
+
+    if [[ ! -d "$src/$dir" || ! -d "$dst/$dir" ]]; then
+        echo "  SKIP $dir/ (missing in one side)"
+        return
+    fi
+
+    local changes
+    changes=$(diff -rq "$src/$dir" "$dst/$dir" \
+        --exclude '.DS_Store' \
+        --exclude '__pycache__' 2>/dev/null) || true
+
+    if [[ -z "$changes" ]]; then
+        echo "  OK   $dir/"
+    else
+        echo "  DIFF $dir/"
+        echo "$changes" | sed 's/^/       /'
+    fi
+}
+
+# Diff a single file
+diff_file() {
+    local src="$1" dst="$2" file="$3"
+
+    if [[ ! -f "$src/$file" || ! -f "$dst/$file" ]]; then
+        echo "  SKIP $file (missing in one side)"
+        return
+    fi
+
+    if diff -q "$src/$file" "$dst/$file" > /dev/null 2>&1; then
+        echo "  OK   $file"
+    else
+        echo "  DIFF $file"
+        diff -u "$src/$file" "$dst/$file" | head -20 | sed 's/^/       /'
+    fi
+}
+
+# Diff universal skills
+diff_skills() {
+    local src="$1" dst="$2"
+
+    for skill in "${UNIVERSAL_SKILLS[@]}"; do
+        if [[ -d "$src/skills/$skill" && -d "$dst/skills/$skill" ]]; then
+            local changes
+            changes=$(diff -rq "$src/skills/$skill" "$dst/skills/$skill" \
+                --exclude '.DS_Store' 2>/dev/null) || true
+            if [[ -z "$changes" ]]; then
+                echo "  OK   skills/$skill/"
+            else
+                echo "  DIFF skills/$skill/"
+                echo "$changes" | sed 's/^/       /'
+            fi
+        fi
+    done
+}
+
+# List all core files
+list_core() {
+    echo "Core directories (fully synced):"
+    for dir in "${CORE_DIRS[@]}"; do
+        echo "  .claude/$dir/"
+    done
+
+    echo ""
+    echo "Core files (individually synced):"
+    for file in "${CORE_FILES[@]}"; do
+        echo "  .claude/$file"
+    done
+
+    echo ""
+    echo "Universal skills (synced):"
+    for skill in "${UNIVERSAL_SKILLS[@]}"; do
+        echo "  .claude/skills/$skill/"
+    done
+
+    echo ""
+    echo "Never synced (project-specific):"
+    echo "  .claude/agents/*.md"
+    echo "  .claude/config/platform.sh"
+    echo "  .claude/prompts/*.md"
+    echo "  .claude/skills/ (non-universal skills)"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+[[ $# -lt 1 ]] && usage
+
+COMMAND="$1"
+
+case "$COMMAND" in
+    to)
+        [[ $# -lt 2 ]] && usage
+        PROJECT_DIR=$(resolve_project_dir "$2")
+        echo "Syncing core files: pipeline → $2"
+        echo ""
+
+        for dir in "${CORE_DIRS[@]}"; do
+            sync_dir "$PIPELINE_DIR" "$PROJECT_DIR" "$dir"
+        done
+
+        for file in "${CORE_FILES[@]}"; do
+            sync_file "$PIPELINE_DIR" "$PROJECT_DIR" "$file"
+        done
+
+        echo ""
+        echo "Syncing universal skills:"
+        sync_skills "$PIPELINE_DIR" "$PROJECT_DIR"
+
+        echo ""
+        echo "Done. Project-specific files (agents, config, prompts) untouched."
+        ;;
+
+    from)
+        [[ $# -lt 2 ]] && usage
+        PROJECT_DIR=$(resolve_project_dir "$2")
+        echo "Pulling core fixes: $2 → pipeline"
+        echo ""
+
+        for dir in "${CORE_DIRS[@]}"; do
+            sync_dir "$PROJECT_DIR" "$PIPELINE_DIR" "$dir"
+        done
+
+        for file in "${CORE_FILES[@]}"; do
+            sync_file "$PROJECT_DIR" "$PIPELINE_DIR" "$file"
+        done
+
+        echo ""
+        echo "Pulling universal skills:"
+        sync_skills "$PROJECT_DIR" "$PIPELINE_DIR"
+
+        echo ""
+        echo "Done. Review changes with: cd $(dirname "$PIPELINE_DIR") && git diff"
+        ;;
+
+    diff)
+        [[ $# -lt 2 ]] && usage
+        PROJECT_DIR=$(resolve_project_dir "$2")
+        echo "Comparing core files: pipeline vs $2"
+        echo ""
+
+        for dir in "${CORE_DIRS[@]}"; do
+            diff_dir "$PIPELINE_DIR" "$PROJECT_DIR" "$dir"
+        done
+
+        for file in "${CORE_FILES[@]}"; do
+            diff_file "$PIPELINE_DIR" "$PROJECT_DIR" "$file"
+        done
+
+        echo ""
+        echo "Universal skills:"
+        diff_skills "$PIPELINE_DIR" "$PROJECT_DIR"
+        ;;
+
+    list)
+        list_core
+        ;;
+
+    *)
+        usage
+        ;;
+esac

--- a/sync.sh
+++ b/sync.sh
@@ -66,6 +66,7 @@ UNIVERSAL_SKILLS=(
     "writing-plans"
     "writing-skills"
     "adapting-claude-pipeline"
+    "pipeline-sync"
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

### create-issue.sh fixes
- Stop swallowing acli errors with `2>/dev/null` — errors now visible
- Use `--description-file` with temp file for large issue bodies (avoids shell arg length limits)
- Add auth error detection with actionable hint

### implement-issue SKILL.md fixes
- Add `nohup` background launch pattern to prevent SIGPIPE kills
- Document fallback manual implementation workflow
- Add common failures table with symptoms, causes, and fixes

### PR/review performance improvements
- **Include diff in review prompt** — prevents reviewer from exploring entire codebase (4.7M → ~50K tokens for an 11-line diff)
- **Use Sonnet for all PR review tiers** — Haiku burned through max turns then escalated anyway, wasting ~$0.85 and ~5min per review
- **Cap PR creation at 10 max turns** — only needs to push + `glab mr create`

### Expected impact
For small PRs (<50 lines): **~$1.50 savings and ~8 minutes faster** per orchestrator run.

## Context

All issues discovered during a real pipeline run against a Jira project (AGD-51). The orchestrator was silently killed by SIGPIPE, `create-issue.sh` silently failed due to hidden auth errors, and the PR+review stages cost $2.05 for an 11-line diff.

## Test plan

- [ ] Run `create-issue.sh` with unauthenticated acli — should show error + auth hint
- [ ] Run `create-issue.sh` with large description — should use temp file
- [ ] Launch orchestrator via `/implement-issue` — should use `nohup` pattern
- [ ] Run orchestrator on small PR — PR review should complete in <3 minutes (was ~8 minutes)
- [ ] PR review should not read 4.7M tokens for a small diff