### PR TITLE
feat(pipeline): sync stage additions from beegee-farm-3

### DIFF
--- a/.claude/scripts/implement-issue-test/test-model-config.bats
+++ b/.claude/scripts/implement-issue-test/test-model-config.bats
@@ -113,6 +113,18 @@ run_with_config() {
 	[[ "$output" == "light" ]]
 }
 
+@test "stage test-iter maps to standard" {
+	run_with_config '_stage_to_tier "test-iter"'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "standard" ]]
+}
+
+@test "resolve_model test-iter-1 resolves to sonnet" {
+	run_with_config 'resolve_model "test-iter-1"'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "sonnet" ]]
+}
+
 @test "stage review maps to standard" {
 	run_with_config '_stage_to_tier "review"'
 	[ "$status" -eq 0 ]

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -45,8 +45,10 @@ _stage_to_tier() {
 		implement)      printf '%s' "standard" ;;
 		task-review)    printf '%s' "standard" ;;
 		fix)            printf '%s' "standard" ;;
+		test-iter)      printf '%s' "standard" ;;
 		test)           printf '%s' "light" ;;
 		review)         printf '%s' "standard" ;;
+		research)       printf '%s' "light" ;;
 		simplify)       printf '%s' "light" ;;
 		pr)             printf '%s' "standard" ;;
 		pr-review)      printf '%s' "standard" ;;
@@ -98,7 +100,7 @@ if [[ -z "${_STAGE_PREFIXES+set}" ]]; then
 	readonly -a _STAGE_PREFIXES=(
 		fix-acceptance-test acceptance-test validate-plan
 		fix-deploy-verify deploy-verify spec-review code-review task-review parse-issue e2e-verify
-		pr-review implement simplify complete pr-fix fix-e2e review test docs fix pr
+		pr-review implement simplify research complete pr-fix fix-e2e review test-iter test docs fix pr
 	)
 fi
 

--- a/.claude/scripts/schemas/implement-issue-implement.json
+++ b/.claude/scripts/schemas/implement-issue-implement.json
@@ -2,6 +2,7 @@
   "type": "object",
   "properties": {
     "status": {"enum": ["success", "error"]},
+    "already_done": {"type": "boolean"},
     "commit": {"type": "string"},
     "files_changed": {
       "type": "array",


### PR DESCRIPTION
## Summary

- `model-config.sh`: adds `test-iter → standard` and `research → light` stage tier mappings, and registers both in `_STAGE_PREFIXES`
- `schemas/implement-issue-implement.json`: adds `already_done: boolean` field (needed for the already-done task guard in the orchestrator)
- `implement-issue-test/test-model-config.bats`: adds tests for `test-iter` stage mapping and `resolve_model test-iter-1` resolution

## What was NOT pulled from beegee

- `platform/comment-issue.sh` / `create-issue.sh`: claude-pipeline already has newer ADF-format versions; beegee is behind on these
- `implement-issue-orchestrator.sh` haiku 4-tier PR review: claude-pipeline deliberately switched to all-sonnet (`5e0ad03`) due to 100% escalation rate
- `implement-issue-parse.json`: claude-pipeline's version is more complete (has `affected_files`); beegee removed it

## Test plan
- [ ] `cd .claude/scripts/implement-issue-test && ./run-tests.sh` — new test-model-config tests pass
- [ ] `test-iter-1` and `research-1` stages resolve to expected models

🤖 Generated with [Claude Code](https://claude.com/claude-code)