### PR TITLE
feat(issue-182): proactive usage polling — skip exhausted models

### DIFF
--- a/.claude/scripts/batch-orchestrator.sh
+++ b/.claude/scripts/batch-orchestrator.sh
@@ -51,6 +51,10 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCHEMA_DIR="$SCRIPT_DIR/schemas"
 source "$SCRIPT_DIR/../config/platform.sh"
+# claude-usage.sh provides is_model_exhausted / model_reset_at for the
+# pre-flight log line. Sourcing is no-op when CLAUDE_USAGE_SESSION_KEY is
+# unset (graceful fallback — see claude-usage.sh).
+source "$SCRIPT_DIR/claude-usage.sh"
 PLATFORM_DIR="$SCRIPT_DIR/platform"
 LOG_BASE="logs/batch-$(date +%Y%m%d-%H%M%S)"
 STATUS_FILE="status.json"
@@ -680,6 +684,24 @@ log "Timeout per issue: ${ISSUE_TIMEOUT}s"
 log "Max consecutive failures: $MAX_CONSECUTIVE_FAILURES"
 
 init_status
+
+# Pre-flight usage check. When the user has configured CLAUDE_USAGE_SESSION_KEY,
+# log current per-model utilization + reset times so operators can see at a
+# glance whether the batch will hit a wall. Per-stage escalation in the
+# subprocess (implement-issue-orchestrator.sh) handles actual routing — this
+# is an observability gate, not a control point.
+if [[ -n "${CLAUDE_USAGE_SESSION_KEY:-}${CLAUDE_USAGE_SESSION_KEY_FILE:-}" ]] \
+        && declare -F is_model_exhausted >/dev/null 2>&1; then
+    for _m in sonnet opus; do
+        _pct=$(usage_for_model "$_m" 2>/dev/null || echo "0")
+        _reset=$(model_reset_at "$_m" 2>/dev/null || echo "unknown")
+        if is_model_exhausted "$_m" 2>/dev/null; then
+            log "Pre-flight: $_m exhausted (utilization ${_pct}%, resets $_reset) — subprocess will escalate"
+        else
+            log "Pre-flight: $_m available (utilization ${_pct}%, resets $_reset)"
+        fi
+    done
+fi
 
 consecutive_failures=0
 exit_code=0

--- a/.claude/scripts/capture-usage-fixture.sh
+++ b/.claude/scripts/capture-usage-fixture.sh
@@ -42,20 +42,15 @@ err() { printf 'error: %s\n' "$*" >&2; }
 command -v curl >/dev/null 2>&1 || { err "curl required"; exit 2; }
 command -v jq >/dev/null 2>&1 || { err "jq required"; exit 2; }
 
+# Source the runtime module so we share its env-var > file resolution
+# (_session_key_value) — keeps both paths in sync if it ever grows.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/claude-usage.sh"
+
 # --- session key (env var > file > prompt) ---------------------------------
 
-session_key="${CLAUDE_USAGE_SESSION_KEY:-}"
-
-if [[ -z "$session_key" && -n "${CLAUDE_USAGE_SESSION_KEY_FILE:-}" ]]; then
-    if [[ ! -r "$CLAUDE_USAGE_SESSION_KEY_FILE" ]]; then
-        err "key file not readable: $CLAUDE_USAGE_SESSION_KEY_FILE"
-        exit 2
-    fi
-    # Strip trailing whitespace; never echo the value.
-    session_key="$(tr -d '[:space:]' < "$CLAUDE_USAGE_SESSION_KEY_FILE")"
-fi
-
-if [[ -z "$session_key" ]]; then
+session_key=""
+if ! session_key=$(_session_key_value 2>/dev/null) || [[ -z "$session_key" ]]; then
     printf 'Paste sessionKey (input hidden, starts with sk-ant-sid01-): ' >&2
     # -s suppresses echo; -r preserves backslashes in the value.
     IFS= read -rs session_key

--- a/.claude/scripts/capture-usage-fixture.sh
+++ b/.claude/scripts/capture-usage-fixture.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# capture-usage-fixture.sh — Capture a real claude.ai usage API response
+#
+# Hits the (private) usage endpoint that Sneaky Penguin and similar menu-bar
+# apps poll, saves the JSON to the test fixtures directory, and prints the
+# bucket field names so we can map them to the menu-bar's display labels
+# (Session 5h / All-models Weekly / Sonnet / Extra Usage).
+#
+# Why: the proactive-usage-polling design needs the real field names from
+# this endpoint before we can implement usage_for_model(). Don't guess.
+#
+# Required input (env var, prompt, or file):
+#   CLAUDE_USAGE_SESSION_KEY        sessionKey cookie from claude.ai
+#   CLAUDE_USAGE_SESSION_KEY_FILE   alternative: path to file containing key (0600)
+#   CLAUDE_USAGE_ORG_ID             organization UUID
+#
+# Output:
+#   .claude/scripts/implement-issue-test/fixtures/usage-response.json
+#
+# Usage:
+#   .claude/scripts/capture-usage-fixture.sh                     # interactive prompts
+#   CLAUDE_USAGE_SESSION_KEY=sk-ant-... CLAUDE_USAGE_ORG_ID=uuid \
+#     .claude/scripts/capture-usage-fixture.sh                   # fully scripted
+#
+# Security notes:
+#   - The sessionKey is a long-lived bearer-equivalent for your claude.ai
+#     account. This script reads it once into a local variable and passes it
+#     to curl via -H (header — not visible in /proc/PID/cmdline) instead of
+#     -b (cookie file path or inline). The key value is never echoed, never
+#     logged, never written to status.json, never appears in the saved
+#     fixture (the response itself contains usage data only).
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="$SCRIPT_DIR/implement-issue-test/fixtures/usage-response.json"
+
+err() { printf 'error: %s\n' "$*" >&2; }
+
+command -v curl >/dev/null 2>&1 || { err "curl required"; exit 2; }
+command -v jq >/dev/null 2>&1 || { err "jq required"; exit 2; }
+
+# --- session key (env var > file > prompt) ---------------------------------
+
+session_key="${CLAUDE_USAGE_SESSION_KEY:-}"
+
+if [[ -z "$session_key" && -n "${CLAUDE_USAGE_SESSION_KEY_FILE:-}" ]]; then
+    if [[ ! -r "$CLAUDE_USAGE_SESSION_KEY_FILE" ]]; then
+        err "key file not readable: $CLAUDE_USAGE_SESSION_KEY_FILE"
+        exit 2
+    fi
+    # Strip trailing whitespace; never echo the value.
+    session_key="$(tr -d '[:space:]' < "$CLAUDE_USAGE_SESSION_KEY_FILE")"
+fi
+
+if [[ -z "$session_key" ]]; then
+    printf 'Paste sessionKey (input hidden, starts with sk-ant-sid01-): ' >&2
+    # -s suppresses echo; -r preserves backslashes in the value.
+    IFS= read -rs session_key
+    printf '\n' >&2
+fi
+
+if [[ -z "$session_key" ]]; then
+    err "no sessionKey provided"
+    exit 2
+fi
+
+# Cheap sanity check — don't log the value, just confirm shape.
+if [[ ! "$session_key" =~ ^sk-ant- ]]; then
+    err "sessionKey doesn't start with 'sk-ant-' — wrong cookie?"
+    err "(get it from claude.ai DevTools → Application → Cookies → sessionKey)"
+    exit 2
+fi
+
+# --- org id (env var > prompt) ---------------------------------------------
+
+org_id="${CLAUDE_USAGE_ORG_ID:-}"
+if [[ -z "$org_id" ]]; then
+    printf 'Organization UUID: ' >&2
+    IFS= read -r org_id
+fi
+
+if [[ -z "$org_id" ]]; then
+    err "no org_id provided"
+    err "(find it in DevTools → Network tab on claude.ai — any /api/organizations/{uuid}/ request)"
+    exit 2
+fi
+
+# --- fetch -----------------------------------------------------------------
+
+url="https://claude.ai/api/organizations/${org_id}/usage"
+printf 'Fetching: %s\n' "$url" >&2
+
+http_status=0
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+http_status=$(curl -sS \
+    --connect-timeout 5 \
+    --max-time 15 \
+    -o "$body_file" \
+    -w '%{http_code}' \
+    -H "Cookie: sessionKey=${session_key}" \
+    -H "Accept: application/json" \
+    "$url" 2>&1) || {
+    err "curl failed: $http_status"
+    exit 1
+}
+
+if [[ "$http_status" != "200" ]]; then
+    err "HTTP $http_status from $url"
+    err "first 200 bytes of response body:"
+    head -c 200 "$body_file" >&2
+    printf '\n' >&2
+    exit 1
+fi
+
+if ! jq empty "$body_file" 2>/dev/null; then
+    err "response is not valid JSON"
+    err "first 200 bytes:"
+    head -c 200 "$body_file" >&2
+    printf '\n' >&2
+    exit 1
+fi
+
+# --- save fixture ----------------------------------------------------------
+
+mkdir -p "$(dirname "$FIXTURE")"
+jq . "$body_file" > "$FIXTURE"
+printf 'Saved fixture: %s (%d bytes)\n' "$FIXTURE" "$(wc -c < "$FIXTURE" | tr -d ' ')" >&2
+
+# --- summarize field structure --------------------------------------------
+
+printf '\n' >&2
+printf 'Top-level field names:\n' >&2
+jq -r 'keys[]' "$FIXTURE" | sed 's/^/  /' >&2
+
+printf '\nBucket-shaped fields (objects with a numeric utilization or limit):\n' >&2
+jq -r '
+  paths(type == "object" and (
+    has("utilization_pct") or has("usage") or has("limit") or
+    has("remaining") or has("resets_at") or has("reset_at")
+  )) | join(".")
+' "$FIXTURE" 2>/dev/null | sed 's/^/  /' >&2 || true
+
+printf '\nReset timestamps found:\n' >&2
+jq -r '
+  paths(type == "string") as $p |
+  getpath($p) as $v |
+  select($p[-1] | test("reset"; "i")) |
+  "  \($p | join(\".\")) = \($v)"
+' "$FIXTURE" 2>/dev/null >&2 || true
+
+printf '\n' >&2
+printf 'Next: paste this fixture (or just the field names) so the design can\n' >&2
+printf 'map each bucket to a model in the v3 polling proposal.\n' >&2

--- a/.claude/scripts/claude-usage.sh
+++ b/.claude/scripts/claude-usage.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+#
+# claude-usage.sh — Proactive usage polling for the Claude.ai usage API
+#
+# Queries the (private) endpoint that Sneaky Penguin and similar menu-bar apps
+# poll. Lets the orchestrator skip a model whose per-model bucket is exhausted
+# by escalating via _next_model_up — without sleeping for the rate-limit reset.
+#
+# This module is sourced by orchestrator scripts. It exposes:
+#   fetch_usage              — populate / refresh the cache (30s TTL)
+#   usage_for_model MODEL    — utilization 0..100 with bucket fallback
+#   model_reset_at MODEL     — ISO8601 timestamp or "unknown"
+#   is_model_exhausted MODEL — 0/1, applies all guards in order
+#
+# Hybrid fallback: if CLAUDE_USAGE_SESSION_KEY is unset OR any fetch fails,
+# is_model_exhausted returns false for everything. Caller behaves as today.
+#
+# Security: sessionKey is treated as a bearer-equivalent secret. Read once
+# into a local variable, passed to curl via -H Cookie:, never echoed, never
+# logged, never written to status.json or any artifact.
+#
+
+# Guard against double-sourcing — orchestrator and batch-orchestrator may
+# both source this. Function definitions are idempotent but the cache-path
+# computation is wasteful to repeat.
+if [[ -n "${_CLAUDE_USAGE_SOURCED:-}" ]]; then
+    return 0 2>/dev/null || true
+fi
+_CLAUDE_USAGE_SOURCED=1
+
+# Cache file under XDG_CACHE_HOME so it's user-scoped (one source of truth
+# across all worktrees / projects) and never accidentally committed.
+_CLAUDE_USAGE_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-pipeline"
+_CLAUDE_USAGE_CACHE_FILE="$_CLAUDE_USAGE_CACHE_DIR/usage.json"
+
+# Defaults (overridable via env). See SKILL.md for semantics.
+: "${CLAUDE_USAGE_CACHE_TTL:=30}"
+: "${CLAUDE_USAGE_SESSION_THRESHOLD:=95}"
+: "${CLAUDE_USAGE_MODEL_THRESHOLD:=95}"
+: "${CLAUDE_USAGE_WEEKLY_THRESHOLD:=98}"
+: "${CLAUDE_USAGE_EXTRA_THRESHOLD:=90}"
+
+# --- internal helpers ------------------------------------------------------
+
+_usage_log() {
+    # Stage-runner ships a `log` function; if not present, fall back to stderr.
+    # All claude-usage messages go to stderr — never stdout (we return values
+    # there).
+    if declare -F log >/dev/null 2>&1; then
+        log "$@"
+    else
+        printf '[%s] %s\n' "$(date -Iseconds 2>/dev/null || date)" "$*" >&2
+    fi
+}
+
+_usage_warn() { _usage_log "WARN claude-usage: $*"; }
+_usage_error() { _usage_log "ERROR claude-usage: $*"; }
+
+_cache_age_seconds() {
+    [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || { printf '999999\n'; return; }
+    local mtime now
+    mtime=$(stat -f %m "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null \
+         || stat -c %Y "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    printf '%s\n' $((now - mtime))
+}
+
+_session_key_value() {
+    # Resolution order: env var > file (with newline strip).
+    if [[ -n "${CLAUDE_USAGE_SESSION_KEY:-}" ]]; then
+        printf '%s' "$CLAUDE_USAGE_SESSION_KEY"
+        return 0
+    fi
+    if [[ -n "${CLAUDE_USAGE_SESSION_KEY_FILE:-}" && -r "${CLAUDE_USAGE_SESSION_KEY_FILE}" ]]; then
+        tr -d '[:space:]' < "$CLAUDE_USAGE_SESSION_KEY_FILE"
+        return 0
+    fi
+    return 1
+}
+
+# --- fetch_usage -----------------------------------------------------------
+# Returns 0 on success (cache populated and valid), non-zero on any failure.
+# Side effect: writes cache file. Failures are logged but never raise.
+
+fetch_usage() {
+    if [[ "${CLAUDE_USAGE_DISABLE:-0}" == "1" ]]; then
+        return 1
+    fi
+
+    # Cache hit?
+    local age
+    age=$(_cache_age_seconds)
+    if (( age <= CLAUDE_USAGE_CACHE_TTL )) && [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]]; then
+        return 0
+    fi
+
+    local session_key
+    if ! session_key=$(_session_key_value); then
+        # Unconfigured — silent no-op so non-users see no churn.
+        return 1
+    fi
+
+    if [[ -z "${CLAUDE_USAGE_ORG_ID:-}" ]]; then
+        _usage_warn "CLAUDE_USAGE_SESSION_KEY set but CLAUDE_USAGE_ORG_ID is not — skipping fetch"
+        return 1
+    fi
+
+    mkdir -p "$_CLAUDE_USAGE_CACHE_DIR"
+
+    # Track whether the cache was previously valid — drives WARN vs ERROR
+    # severity on failure (regression-after-success is louder than first-fail).
+    local had_valid_cache=0
+    if [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] && jq empty "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null; then
+        had_valid_cache=1
+    fi
+
+    local body_file http_status
+    body_file=$(mktemp)
+    # Trap-free cleanup: the function caller may also have traps; we just
+    # rm at end of function.
+
+    # NOTE: the sessionKey is interpolated into a HEADER VALUE (-H), not into
+    # a positional arg. /proc/PID/cmdline shows positional args; headers are
+    # not visible to ps. Read-once into local variable; never logged.
+    http_status=$(curl -sS \
+        --connect-timeout 3 \
+        --max-time 5 \
+        -o "$body_file" \
+        -w '%{http_code}' \
+        -H "Cookie: sessionKey=${session_key}" \
+        -H "Accept: application/json" \
+        "https://claude.ai/api/organizations/${CLAUDE_USAGE_ORG_ID}/usage" 2>/dev/null) \
+        || http_status="000"
+
+    # Clear local references to the secret immediately after the curl call.
+    session_key=""
+
+    if [[ "$http_status" != "200" ]]; then
+        if (( had_valid_cache )); then
+            _usage_error "fetch failed (HTTP $http_status) after prior success — endpoint regression?"
+        else
+            _usage_warn "fetch failed (HTTP $http_status)"
+        fi
+        rm -f "$body_file"
+        return 1
+    fi
+
+    if ! jq empty "$body_file" 2>/dev/null; then
+        if (( had_valid_cache )); then
+            _usage_error "response is not valid JSON after prior success — endpoint shape changed?"
+        else
+            _usage_warn "response is not valid JSON"
+        fi
+        rm -f "$body_file"
+        return 1
+    fi
+
+    # Atomic install (tmp + mv). jq compact would lose the human-readable
+    # form; keep pretty-printed for ad-hoc inspection.
+    jq . "$body_file" > "${_CLAUDE_USAGE_CACHE_FILE}.tmp" && \
+        mv "${_CLAUDE_USAGE_CACHE_FILE}.tmp" "$_CLAUDE_USAGE_CACHE_FILE"
+
+    rm -f "$body_file"
+    return 0
+}
+
+# --- bucket-mapped accessors ----------------------------------------------
+
+_per_model_field() {
+    case "$1" in
+        sonnet) printf 'seven_day_sonnet' ;;
+        opus)   printf 'seven_day_opus' ;;
+        *)      printf '' ;;
+    esac
+}
+
+# Models known to share the seven_day all-models bucket when no per-model
+# field exists. Haiku is here; truly unknown models are NOT — for those we
+# return 0 so the gating logic can't accidentally throttle a model the
+# script doesn't recognize.
+_is_known_model() {
+    case "$1" in
+        sonnet|opus|haiku) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# usage_for_model MODEL → integer 0..100 (or 0 on unknown / no data)
+usage_for_model() {
+    local model="$1"
+    _is_known_model "$model" || { printf '0\n'; return 0; }
+
+    fetch_usage || { printf '0\n'; return 0; }
+    [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || { printf '0\n'; return 0; }
+
+    local field val
+    field=$(_per_model_field "$model")
+
+    if [[ -n "$field" ]]; then
+        val=$(jq -r --arg f "$field" '
+            (.[$f] // empty) | (.utilization // empty)
+        ' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
+    fi
+
+    # Fall back to seven_day (all-models weekly) when per-model bucket is
+    # null or this is a known model with no per-model bucket (haiku).
+    if [[ -z "$val" || "$val" == "null" ]]; then
+        val=$(jq -r '.seven_day.utilization // 0' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
+    fi
+
+    printf '%.0f\n' "${val:-0}"
+}
+
+# model_reset_at MODEL → ISO8601 string or "unknown"
+model_reset_at() {
+    local model="$1"
+    fetch_usage || { printf 'unknown\n'; return 0; }
+
+    [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || { printf 'unknown\n'; return 0; }
+
+    local field val
+    field=$(_per_model_field "$model")
+
+    if [[ -n "$field" ]]; then
+        val=$(jq -r --arg f "$field" '(.[$f] // empty) | (.resets_at // empty)' \
+            "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
+    fi
+
+    if [[ -z "$val" || "$val" == "null" ]]; then
+        val=$(jq -r '.seven_day.resets_at // empty' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
+    fi
+
+    if [[ -z "$val" || "$val" == "null" ]]; then
+        printf 'unknown\n'
+    else
+        printf '%s\n' "$val"
+    fi
+}
+
+# --- is_model_exhausted ----------------------------------------------------
+# Three-gate check, in order of recovery cost:
+#   1. five_hour (shared session) — hard cap, overage cannot absorb a rate
+#      window. Crossing it kills every model.
+#   2. per-model weekly — soft cap; if extra_usage is_enabled and below its
+#      own threshold, calls drain against overage and we should NOT escalate.
+#   3. seven_day (all-models weekly) — treated as hard cap (conservative).
+#      Empirical verification of overage absorption deferred to a follow-up.
+
+is_model_exhausted() {
+    local model="$1"
+
+    if [[ "${CLAUDE_USAGE_DISABLE:-0}" == "1" ]]; then
+        return 1
+    fi
+
+    fetch_usage || return 1   # graceful: no data, treat as not exhausted
+
+    [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || return 1
+
+    local five_hour_pct seven_day_pct extra_enabled extra_pct
+    five_hour_pct=$(jq -r '.five_hour.utilization // 0' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
+    seven_day_pct=$(jq -r '.seven_day.utilization // 0' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
+    extra_enabled=$(jq -r '.extra_usage.is_enabled // false' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
+    extra_pct=$(jq -r '.extra_usage.utilization // 0' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
+
+    # Round to integer for comparison.
+    five_hour_pct=$(printf '%.0f' "$five_hour_pct")
+    seven_day_pct=$(printf '%.0f' "$seven_day_pct")
+    extra_pct=$(printf '%.0f' "$extra_pct")
+
+    # 1. Session gate — overage cannot absorb a rate window.
+    if (( five_hour_pct >= CLAUDE_USAGE_SESSION_THRESHOLD )); then
+        return 0
+    fi
+
+    # 2. Per-model weekly with overage absorption guard.
+    local field per_model_pct
+    field=$(_per_model_field "$model")
+    if [[ -n "$field" ]]; then
+        per_model_pct=$(jq -r --arg f "$field" '
+            (.[$f] // empty) | (.utilization // empty)
+        ' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
+
+        if [[ -n "$per_model_pct" && "$per_model_pct" != "null" ]]; then
+            per_model_pct=$(printf '%.0f' "$per_model_pct")
+            if (( per_model_pct >= CLAUDE_USAGE_MODEL_THRESHOLD )); then
+                # Overage absorbs per-model overflow if enabled and below cap.
+                if [[ "$extra_enabled" == "true" ]] && (( extra_pct < CLAUDE_USAGE_EXTRA_THRESHOLD )); then
+                    : # overage absorbing — fall through
+                else
+                    return 0
+                fi
+            fi
+        fi
+    fi
+
+    # 3. All-models weekly — treated as hard cap (conservative; see SKILL).
+    if (( seven_day_pct >= CLAUDE_USAGE_WEEKLY_THRESHOLD )); then
+        return 0
+    fi
+
+    return 1
+}

--- a/.claude/scripts/claude-usage.sh
+++ b/.claude/scripts/claude-usage.sh
@@ -137,32 +137,34 @@ fetch_usage() {
     session_key=""
 
     if [[ "$http_status" != "200" ]]; then
-        if (( had_valid_cache )); then
-            _usage_error "fetch failed (HTTP $http_status) after prior success — endpoint regression?"
-        else
-            _usage_warn "fetch failed (HTTP $http_status)"
-        fi
+        _log_fetch_failure "$had_valid_cache" "fetch failed (HTTP $http_status)" "endpoint regression?"
         rm -f "$body_file"
         return 1
     fi
 
     if ! jq empty "$body_file" 2>/dev/null; then
-        if (( had_valid_cache )); then
-            _usage_error "response is not valid JSON after prior success — endpoint shape changed?"
-        else
-            _usage_warn "response is not valid JSON"
-        fi
+        _log_fetch_failure "$had_valid_cache" "response is not valid JSON" "endpoint shape changed?"
         rm -f "$body_file"
         return 1
     fi
 
-    # Atomic install (tmp + mv). jq compact would lose the human-readable
-    # form; keep pretty-printed for ad-hoc inspection.
+    # Atomic install (tmp + mv). Pretty-printed for ad-hoc inspection.
     jq . "$body_file" > "${_CLAUDE_USAGE_CACHE_FILE}.tmp" && \
         mv "${_CLAUDE_USAGE_CACHE_FILE}.tmp" "$_CLAUDE_USAGE_CACHE_FILE"
 
     rm -f "$body_file"
     return 0
+}
+
+# Cache-was-valid escalates WARN to ERROR — a regression-after-success is
+# louder than first-time failure (which usually means unconfigured / new user).
+_log_fetch_failure() {
+    local had_valid="$1" msg="$2" regression_suffix="$3"
+    if (( had_valid )); then
+        _usage_error "$msg after prior success — $regression_suffix"
+    else
+        _usage_warn "$msg"
+    fi
 }
 
 # --- bucket-mapped accessors ----------------------------------------------
@@ -186,6 +188,18 @@ _is_known_model() {
     esac
 }
 
+# Pick PER_MODEL_FIELD.PROP if non-null, else seven_day.PROP, else DEFAULT.
+# One jq invocation, returns the resolved value via stdout.
+_bucket_pick() {
+    local field="$1" prop="$2" default="$3"
+    jq -r --arg f "$field" --arg p "$prop" --arg d "$default" '
+        def pick(p): . as $o | if $o[p] == null or $o[p] == "" then null else $o[p] end;
+        (if $f != "" then (.[$f] // {}) | pick($p) else null end) //
+        ((.seven_day // {}) | pick($p)) //
+        $d
+    ' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null
+}
+
 # usage_for_model MODEL → integer 0..100 (or 0 on unknown / no data)
 usage_for_model() {
     local model="$1"
@@ -194,21 +208,8 @@ usage_for_model() {
     fetch_usage || { printf '0\n'; return 0; }
     [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || { printf '0\n'; return 0; }
 
-    local field val
-    field=$(_per_model_field "$model")
-
-    if [[ -n "$field" ]]; then
-        val=$(jq -r --arg f "$field" '
-            (.[$f] // empty) | (.utilization // empty)
-        ' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
-    fi
-
-    # Fall back to seven_day (all-models weekly) when per-model bucket is
-    # null or this is a known model with no per-model bucket (haiku).
-    if [[ -z "$val" || "$val" == "null" ]]; then
-        val=$(jq -r '.seven_day.utilization // 0' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
-    fi
-
+    local val
+    val=$(_bucket_pick "$(_per_model_field "$model")" utilization 0)
     printf '%.0f\n' "${val:-0}"
 }
 
@@ -216,26 +217,11 @@ usage_for_model() {
 model_reset_at() {
     local model="$1"
     fetch_usage || { printf 'unknown\n'; return 0; }
-
     [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || { printf 'unknown\n'; return 0; }
 
-    local field val
-    field=$(_per_model_field "$model")
-
-    if [[ -n "$field" ]]; then
-        val=$(jq -r --arg f "$field" '(.[$f] // empty) | (.resets_at // empty)' \
-            "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
-    fi
-
-    if [[ -z "$val" || "$val" == "null" ]]; then
-        val=$(jq -r '.seven_day.resets_at // empty' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
-    fi
-
-    if [[ -z "$val" || "$val" == "null" ]]; then
-        printf 'unknown\n'
-    else
-        printf '%s\n' "$val"
-    fi
+    local val
+    val=$(_bucket_pick "$(_per_model_field "$model")" resets_at unknown)
+    printf '%s\n' "${val:-unknown}"
 }
 
 # --- is_model_exhausted ----------------------------------------------------
@@ -255,19 +241,27 @@ is_model_exhausted() {
     fi
 
     fetch_usage || return 1   # graceful: no data, treat as not exhausted
-
     [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || return 1
 
-    local five_hour_pct seven_day_pct extra_enabled extra_pct
-    five_hour_pct=$(jq -r '.five_hour.utilization // 0' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
-    seven_day_pct=$(jq -r '.seven_day.utilization // 0' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
-    extra_enabled=$(jq -r '.extra_usage.is_enabled // false' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
-    extra_pct=$(jq -r '.extra_usage.utilization // 0' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
+    # One jq, five fields, TSV. Empty string for missing per-model bucket
+    # (haiku, unknowns) — bash arithmetic later treats it as 0 / not-exhausted.
+    local field five_hour_pct seven_day_pct extra_enabled extra_pct per_model_pct
+    field=$(_per_model_field "$model")
+    IFS=$'\t' read -r five_hour_pct seven_day_pct extra_enabled extra_pct per_model_pct < <(
+        jq -r --arg f "$field" '
+            [
+                (.five_hour.utilization // 0),
+                (.seven_day.utilization // 0),
+                (.extra_usage.is_enabled // false),
+                (.extra_usage.utilization // 0),
+                (if $f != "" then (.[$f] // {}) | (.utilization // "") else "" end)
+            ] | @tsv
+        ' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null
+    )
 
-    # Round to integer for comparison.
-    five_hour_pct=$(printf '%.0f' "$five_hour_pct")
-    seven_day_pct=$(printf '%.0f' "$seven_day_pct")
-    extra_pct=$(printf '%.0f' "$extra_pct")
+    five_hour_pct=$(printf '%.0f' "${five_hour_pct:-0}")
+    seven_day_pct=$(printf '%.0f' "${seven_day_pct:-0}")
+    extra_pct=$(printf '%.0f' "${extra_pct:-0}")
 
     # 1. Session gate — overage cannot absorb a rate window.
     if (( five_hour_pct >= CLAUDE_USAGE_SESSION_THRESHOLD )); then
@@ -275,22 +269,13 @@ is_model_exhausted() {
     fi
 
     # 2. Per-model weekly with overage absorption guard.
-    local field per_model_pct
-    field=$(_per_model_field "$model")
-    if [[ -n "$field" ]]; then
-        per_model_pct=$(jq -r --arg f "$field" '
-            (.[$f] // empty) | (.utilization // empty)
-        ' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null)
-
-        if [[ -n "$per_model_pct" && "$per_model_pct" != "null" ]]; then
-            per_model_pct=$(printf '%.0f' "$per_model_pct")
-            if (( per_model_pct >= CLAUDE_USAGE_MODEL_THRESHOLD )); then
-                # Overage absorbs per-model overflow if enabled and below cap.
-                if [[ "$extra_enabled" == "true" ]] && (( extra_pct < CLAUDE_USAGE_EXTRA_THRESHOLD )); then
-                    : # overage absorbing — fall through
-                else
-                    return 0
-                fi
+    if [[ -n "$per_model_pct" ]]; then
+        per_model_pct=$(printf '%.0f' "$per_model_pct")
+        if (( per_model_pct >= CLAUDE_USAGE_MODEL_THRESHOLD )); then
+            if [[ "$extra_enabled" == "true" ]] && (( extra_pct < CLAUDE_USAGE_EXTRA_THRESHOLD )); then
+                : # overage absorbing — fall through to weekly check
+            else
+                return 0
             fi
         fi
     fi

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -1049,26 +1049,15 @@ run_stage() {
     local schema
     schema=$(jq -c . "$SCHEMA_DIR/$schema_file")
 
-    # Resolve model and fallback from stage name + complexity hint.
-    # When model_override is set, the caller has expressed an explicit intent
-    # (e.g. PR creation hard-codes opus) — usage-aware escalation is bypassed
-    # so we don't silently demote/promote against operator wishes.
-    local model fallback_model resolved_pre_escalate=""
+    # Resolve model and fallback. model_override (e.g. PR stage pinned to opus)
+    # bypasses usage gating — explicit caller intent overrides the auto-skip.
+    local model fallback_model
     if [[ -n "$model_override" ]]; then
         model="$model_override"
         fallback_model=$(_next_model_up "$model")
     else
-        resolved_pre_escalate=$(resolve_model "$stage_name" "$complexity")
         model=$(effective_model "$stage_name" "$complexity")
         fallback_model=$(effective_fallback "$model")
-        # Surface usage-driven escalation explicitly so operators can correlate
-        # cost spikes with bucket exhaustion.
-        if [[ -n "$resolved_pre_escalate" && "$model" != "$resolved_pre_escalate" ]] \
-                && declare -F model_reset_at >/dev/null 2>&1; then
-            local _reset
-            _reset=$(model_reset_at "$resolved_pre_escalate")
-            log "Usage gate: $resolved_pre_escalate exhausted (resets ${_reset}) — escalating to $model"
-        fi
     fi
 
     # Record resolved model in status.json stage entry for export_metrics()
@@ -1254,9 +1243,6 @@ run_stage() {
     output_subtype=$(printf '%s' "$output" | jq -r '.subtype // empty' 2>/dev/null)
     if [[ "$output_subtype" == "error_max_turns" ]]; then
         local escalated_model
-        # effective_fallback walks the chain skipping exhausted tiers — so if
-        # the next-up model is also rate-limited, we go straight to one that
-        # isn't. Falls back to plain _next_model_up when usage polling is off.
         escalated_model=$(effective_fallback "$model")
 
         if [[ "$escalated_model" == "$model" ]]; then
@@ -1402,7 +1388,6 @@ for m in re.finditer(r'\[\s*\{', t):
         log "Diagnostic fallback failure — First 500 characters: $output_preview"
 
         # Empty/unparseable output — escalate to next model before failing.
-        # effective_fallback skips exhausted tiers (no-op when usage polling off).
         local empty_escalated_model
         empty_escalated_model=$(effective_fallback "$model")
 
@@ -1483,7 +1468,6 @@ for m in re.finditer(r'\[\s*\{', t):
             log "WARN: $stage_name blocked by permission hook (tools: $permission_denials) — skipping escalation"
         else
             # No permission denial — escalate to the next model tier and retry once.
-            # effective_fallback skips exhausted tiers (no-op when usage polling off).
             local struct_err_escalated_model
             struct_err_escalated_model=$(effective_fallback "$model")
 

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -21,6 +21,10 @@ set -uo pipefail  # Note: not -e, we handle errors explicitly
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCHEMA_DIR="$SCRIPT_DIR/schemas"
 source "$SCRIPT_DIR/model-config.sh"
+# claude-usage.sh provides is_model_exhausted, used by effective_model in
+# model-config.sh. Sourcing is no-op when CLAUDE_USAGE_SESSION_KEY is unset
+# (graceful fallback to today's behavior — see claude-usage.sh).
+source "$SCRIPT_DIR/claude-usage.sh"
 source "$SCRIPT_DIR/../config/platform.sh"
 PLATFORM_DIR="$SCRIPT_DIR/platform"
 
@@ -1045,14 +1049,27 @@ run_stage() {
     local schema
     schema=$(jq -c . "$SCHEMA_DIR/$schema_file")
 
-    # Resolve model and fallback from stage name + complexity hint
-    local model fallback_model
+    # Resolve model and fallback from stage name + complexity hint.
+    # When model_override is set, the caller has expressed an explicit intent
+    # (e.g. PR creation hard-codes opus) — usage-aware escalation is bypassed
+    # so we don't silently demote/promote against operator wishes.
+    local model fallback_model resolved_pre_escalate=""
     if [[ -n "$model_override" ]]; then
         model="$model_override"
+        fallback_model=$(_next_model_up "$model")
     else
-        model=$(resolve_model "$stage_name" "$complexity")
+        resolved_pre_escalate=$(resolve_model "$stage_name" "$complexity")
+        model=$(effective_model "$stage_name" "$complexity")
+        fallback_model=$(effective_fallback "$model")
+        # Surface usage-driven escalation explicitly so operators can correlate
+        # cost spikes with bucket exhaustion.
+        if [[ -n "$resolved_pre_escalate" && "$model" != "$resolved_pre_escalate" ]] \
+                && declare -F model_reset_at >/dev/null 2>&1; then
+            local _reset
+            _reset=$(model_reset_at "$resolved_pre_escalate")
+            log "Usage gate: $resolved_pre_escalate exhausted (resets ${_reset}) — escalating to $model"
+        fi
     fi
-    fallback_model=$(_next_model_up "$model")
 
     # Record resolved model in status.json stage entry for export_metrics()
     if [[ -f "$STATUS_FILE" ]]; then
@@ -1237,7 +1254,10 @@ run_stage() {
     output_subtype=$(printf '%s' "$output" | jq -r '.subtype // empty' 2>/dev/null)
     if [[ "$output_subtype" == "error_max_turns" ]]; then
         local escalated_model
-        escalated_model=$(_next_model_up "$model")
+        # effective_fallback walks the chain skipping exhausted tiers — so if
+        # the next-up model is also rate-limited, we go straight to one that
+        # isn't. Falls back to plain _next_model_up when usage polling is off.
+        escalated_model=$(effective_fallback "$model")
 
         if [[ "$escalated_model" == "$model" ]]; then
             # Already at ceiling (opus) — can't escalate further
@@ -1254,7 +1274,7 @@ run_stage() {
 
         # Retry with escalated model and no --max-turns cap
         local escalated_fallback
-        escalated_fallback=$(_next_model_up "$escalated_model")
+        escalated_fallback=$(effective_fallback "$escalated_model")
         local -a escalated_fallback_args=()
         if [[ "$escalated_fallback" != "$escalated_model" ]]; then
             escalated_fallback_args=(--fallback-model "$escalated_fallback")
@@ -1381,9 +1401,10 @@ for m in re.finditer(r'\[\s*\{', t):
         log "Diagnostic fallback failure — Output byte count: $output_byte_count"
         log "Diagnostic fallback failure — First 500 characters: $output_preview"
 
-        # Empty/unparseable output — escalate to next model before failing
+        # Empty/unparseable output — escalate to next model before failing.
+        # effective_fallback skips exhausted tiers (no-op when usage polling off).
         local empty_escalated_model
-        empty_escalated_model=$(_next_model_up "$model")
+        empty_escalated_model=$(effective_fallback "$model")
 
         if [[ "$empty_escalated_model" != "$model" ]]; then
             log "WARN: No structured output from $stage_name with $model — escalating to $empty_escalated_model"
@@ -1393,7 +1414,7 @@ for m in re.finditer(r'\[\s*\{', t):
 
             local -a empty_esc_fallback_args=()
             local empty_esc_fallback
-            empty_esc_fallback=$(_next_model_up "$empty_escalated_model")
+            empty_esc_fallback=$(effective_fallback "$empty_escalated_model")
             if [[ "$empty_esc_fallback" != "$empty_escalated_model" ]]; then
                 empty_esc_fallback_args=(--fallback-model "$empty_esc_fallback")
             fi
@@ -1462,8 +1483,9 @@ for m in re.finditer(r'\[\s*\{', t):
             log "WARN: $stage_name blocked by permission hook (tools: $permission_denials) — skipping escalation"
         else
             # No permission denial — escalate to the next model tier and retry once.
+            # effective_fallback skips exhausted tiers (no-op when usage polling off).
             local struct_err_escalated_model
-            struct_err_escalated_model=$(_next_model_up "$model")
+            struct_err_escalated_model=$(effective_fallback "$model")
 
             if [[ "$struct_err_escalated_model" != "$model" ]]; then
                 log "WARN: $stage_name returned status:error with $model — escalating to $struct_err_escalated_model"
@@ -1473,7 +1495,7 @@ for m in re.finditer(r'\[\s*\{', t):
 
                 local -a struct_err_esc_fallback_args=()
                 local struct_err_esc_fallback
-                struct_err_esc_fallback=$(_next_model_up "$struct_err_escalated_model")
+                struct_err_esc_fallback=$(effective_fallback "$struct_err_escalated_model")
                 if [[ "$struct_err_esc_fallback" != "$struct_err_escalated_model" ]]; then
                     struct_err_esc_fallback_args=(--fallback-model "$struct_err_esc_fallback")
                 fi

--- a/.claude/scripts/implement-issue-test/fixtures/usage-response.json
+++ b/.claude/scripts/implement-issue-test/fixtures/usage-response.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Real claude.ai /api/organizations/{org}/usage response captured 2026-05-02. Org UUID redacted. Field names ARE production; values are illustrative.",
+  "five_hour": {
+    "utilization": 2,
+    "resets_at": "2026-05-02T07:09:59.992712+00:00"
+  },
+  "seven_day": {
+    "utilization": 88,
+    "resets_at": "2026-05-02T05:59:59.992784+00:00"
+  },
+  "seven_day_oauth_apps": null,
+  "seven_day_opus": null,
+  "seven_day_sonnet": {
+    "utilization": 100,
+    "resets_at": "2026-05-02T05:59:59.992795+00:00"
+  },
+  "seven_day_cowork": null,
+  "seven_day_omelette": {
+    "utilization": 0,
+    "resets_at": null
+  },
+  "tangelo": null,
+  "iguana_necktie": null,
+  "omelette_promotional": null,
+  "extra_usage": {
+    "is_enabled": true,
+    "monthly_limit": 31000,
+    "used_credits": 366,
+    "utilization": 1.1806451612903226,
+    "currency": "AUD"
+  }
+}

--- a/.claude/scripts/implement-issue-test/test-claude-usage.bats
+++ b/.claude/scripts/implement-issue-test/test-claude-usage.bats
@@ -1,0 +1,363 @@
+#!/usr/bin/env bats
+#
+# test-claude-usage.bats
+#
+# Tests for the proactive usage-polling module (claude-usage.sh).
+#
+# Module under test exposes:
+#   fetch_usage()              - reads cache (30s TTL) or curls the API
+#   usage_for_model(model)     - 0..100 with bucket fallback (per-model -> seven_day)
+#   model_reset_at(model)      - ISO8601 string or "unknown" if null
+#   is_model_exhausted(model)  - applies session/per-model/weekly thresholds + overage guard
+#
+# Mocking strategy: install a mock `curl` in PATH that reads its response body
+# from $MOCK_CURL_BODY_FILE and exit code from $MOCK_CURL_EXIT_CODE. Tests
+# control the cache file directly to test TTL boundaries without wall-clock.
+#
+
+load 'helpers/test-helper.bash'
+
+setup() {
+    setup_test_env
+
+    REAL_SCRIPT_DIR="$SCRIPT_DIR"
+    FIXTURE="$REAL_SCRIPT_DIR/implement-issue-test/fixtures/usage-response.json"
+
+    # Install mock curl into the test PATH.
+    local mock_bin="$TEST_TMP/bin"
+    mkdir -p "$mock_bin"
+    cat > "$mock_bin/curl" <<'CURL_MOCK'
+#!/usr/bin/env bash
+# Mock curl: writes body from $MOCK_CURL_BODY_FILE to -o output, prints
+# $MOCK_CURL_HTTP_STATUS for -w '%{http_code}', exits with $MOCK_CURL_EXIT_CODE.
+out_file=""
+write_format=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o) out_file="$2"; shift 2 ;;
+        -w) write_format="$2"; shift 2 ;;
+        *)  shift ;;
+    esac
+done
+if [[ -n "${MOCK_CURL_BODY_FILE:-}" && -r "$MOCK_CURL_BODY_FILE" ]]; then
+    if [[ -n "$out_file" ]]; then
+        cat "$MOCK_CURL_BODY_FILE" > "$out_file"
+    else
+        cat "$MOCK_CURL_BODY_FILE"
+    fi
+fi
+if [[ "$write_format" == *"%{http_code}"* ]]; then
+    printf '%s' "${MOCK_CURL_HTTP_STATUS:-200}"
+fi
+# Track invocation count so tests can assert TTL behavior.
+ctr_file="${MOCK_CURL_COUNTER_FILE:-/tmp/mock_curl_ctr.$$}"
+n=0
+[[ -f "$ctr_file" ]] && n=$(cat "$ctr_file")
+echo $((n + 1)) > "$ctr_file"
+exit "${MOCK_CURL_EXIT_CODE:-0}"
+CURL_MOCK
+    chmod +x "$mock_bin/curl"
+
+    # Per-test cache directory (override XDG_CACHE_HOME).
+    export XDG_CACHE_HOME="$TEST_TMP/cache"
+    mkdir -p "$XDG_CACHE_HOME"
+
+    # Per-test mock state.
+    export MOCK_CURL_BODY_FILE="$FIXTURE"
+    export MOCK_CURL_HTTP_STATUS=200
+    export MOCK_CURL_EXIT_CODE=0
+    export MOCK_CURL_COUNTER_FILE="$TEST_TMP/curl-ctr"
+    rm -f "$MOCK_CURL_COUNTER_FILE"
+
+    # Default config — set after helper sources to avoid leaking to other tests.
+    export CLAUDE_USAGE_SESSION_KEY="sk-ant-sid01-test-fake-key-do-not-leak"
+    export CLAUDE_USAGE_ORG_ID="00000000-0000-0000-0000-000000000000"
+    export CLAUDE_USAGE_CACHE_TTL=30
+    export CLAUDE_USAGE_SESSION_THRESHOLD=95
+    export CLAUDE_USAGE_MODEL_THRESHOLD=95
+    export CLAUDE_USAGE_WEEKLY_THRESHOLD=98
+    export CLAUDE_USAGE_EXTRA_THRESHOLD=90
+    unset CLAUDE_USAGE_DISABLE CLAUDE_USAGE_SESSION_KEY_FILE || true
+
+    # Mock binary path takes precedence.
+    export PATH="$mock_bin:$PATH"
+
+    # Source the module under test.
+    # shellcheck disable=SC1091
+    source "$REAL_SCRIPT_DIR/claude-usage.sh"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+# Helper: write a usage JSON to a temp file and point the mock at it.
+make_usage_response() {
+    local file="$TEST_TMP/usage-resp.json"
+    cat > "$file"
+    export MOCK_CURL_BODY_FILE="$file"
+}
+
+# ============================================================================
+# fetch_usage / cache TTL
+# ============================================================================
+
+@test "01 fetch_usage returns 0 and writes cache file on first call" {
+    run fetch_usage
+    [ "$status" -eq 0 ]
+    [ -f "$XDG_CACHE_HOME/claude-pipeline/usage.json" ]
+    # Cache must contain the FULL response (not just computed pcts).
+    cached_pct=$(jq -r '.seven_day_sonnet.utilization' "$XDG_CACHE_HOME/claude-pipeline/usage.json")
+    [ "$cached_pct" = "100" ]
+}
+
+@test "02 fetch_usage uses cache within TTL — second call doesn't curl again" {
+    fetch_usage  # first call populates cache
+    fetch_usage  # second call within TTL
+    n=$(cat "$MOCK_CURL_COUNTER_FILE")
+    [ "$n" -eq 1 ]
+}
+
+@test "03 fetch_usage re-curls when cache is older than TTL" {
+    fetch_usage
+    # Backdate the cache file to 1h ago (well past 30s TTL).
+    touch -t "$(date -v-1H +%Y%m%d%H%M.%S 2>/dev/null || date -d '1 hour ago' +%Y%m%d%H%M.%S)" \
+        "$XDG_CACHE_HOME/claude-pipeline/usage.json"
+    fetch_usage
+    n=$(cat "$MOCK_CURL_COUNTER_FILE")
+    [ "$n" -eq 2 ]
+}
+
+# ============================================================================
+# usage_for_model — bucket mapping (per real fixture)
+# ============================================================================
+
+@test "10 usage_for_model sonnet → seven_day_sonnet utilization (100)" {
+    run usage_for_model sonnet
+    [ "$status" -eq 0 ]
+    [ "$output" = "100" ]
+}
+
+@test "11 usage_for_model opus → seven_day_opus is null in fixture → falls back to seven_day (88)" {
+    run usage_for_model opus
+    [ "$status" -eq 0 ]
+    [ "$output" = "88" ]
+}
+
+@test "12 usage_for_model haiku → no per-model bucket → uses seven_day (88)" {
+    run usage_for_model haiku
+    [ "$status" -eq 0 ]
+    [ "$output" = "88" ]
+}
+
+@test "13 usage_for_model unknown model → returns 0 (don't gate the unknown)" {
+    run usage_for_model nonsense
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]
+}
+
+# ============================================================================
+# model_reset_at — null guard
+# ============================================================================
+
+@test "20 model_reset_at sonnet returns the seven_day_sonnet timestamp" {
+    run model_reset_at sonnet
+    [ "$status" -eq 0 ]
+    [[ "$output" == "2026-05-02T05:59:59"* ]]
+}
+
+@test "21 model_reset_at gracefully handles null resets_at" {
+    make_usage_response <<'JSON'
+{
+  "five_hour": {"utilization": 0, "resets_at": null},
+  "seven_day": {"utilization": 0, "resets_at": null},
+  "seven_day_sonnet": {"utilization": 0, "resets_at": null},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": false, "utilization": 0}
+}
+JSON
+    run model_reset_at sonnet
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+# ============================================================================
+# is_model_exhausted — threshold ordering and overage guard
+# ============================================================================
+
+@test "30 sonnet at 100% (per fixture) AND extra_usage NOT enabled → exhausted" {
+    make_usage_response <<'JSON'
+{
+  "five_hour": {"utilization": 2, "resets_at": "2026-05-02T07:09:59+00:00"},
+  "seven_day": {"utilization": 88, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_sonnet": {"utilization": 100, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": false, "utilization": 0}
+}
+JSON
+    run is_model_exhausted sonnet
+    [ "$status" -eq 0 ]
+}
+
+@test "31 sonnet at 100% AND extra_usage enabled at 1% → NOT exhausted (overage absorbs)" {
+    # This is the fixture's actual state — 100% sonnet, extra_usage enabled,
+    # 1.18% used. Overage absorbs the per-model overflow; no escalation.
+    run is_model_exhausted sonnet
+    [ "$status" -ne 0 ]
+}
+
+@test "32 sonnet at 100% AND extra_usage enabled but at 95% → exhausted (overage near cap)" {
+    make_usage_response <<'JSON'
+{
+  "five_hour": {"utilization": 2, "resets_at": "2026-05-02T07:09:59+00:00"},
+  "seven_day": {"utilization": 88, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_sonnet": {"utilization": 100, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": true, "utilization": 95, "monthly_limit": 31000, "used_credits": 29450, "currency": "AUD"}
+}
+JSON
+    run is_model_exhausted sonnet
+    [ "$status" -eq 0 ]
+}
+
+@test "33 five_hour at 99% → ALL models exhausted regardless of weekly state" {
+    make_usage_response <<'JSON'
+{
+  "five_hour": {"utilization": 99, "resets_at": "2026-05-02T07:09:59+00:00"},
+  "seven_day": {"utilization": 5, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_sonnet": {"utilization": 5, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": true, "utilization": 0}
+}
+JSON
+    run is_model_exhausted sonnet; [ "$status" -eq 0 ]
+    run is_model_exhausted opus;   [ "$status" -eq 0 ]
+    run is_model_exhausted haiku;  [ "$status" -eq 0 ]
+}
+
+@test "34 five_hour rate cap is NOT absorbed by extra_usage (rate window != token budget)" {
+    make_usage_response <<'JSON'
+{
+  "five_hour": {"utilization": 99, "resets_at": "2026-05-02T07:09:59+00:00"},
+  "seven_day": {"utilization": 5, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_sonnet": {"utilization": 5, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": true, "utilization": 1}
+}
+JSON
+    run is_model_exhausted sonnet
+    [ "$status" -eq 0 ]
+}
+
+@test "35 seven_day at 99% → exhausted (above weekly threshold 98)" {
+    make_usage_response <<'JSON'
+{
+  "five_hour": {"utilization": 5, "resets_at": "2026-05-02T07:09:59+00:00"},
+  "seven_day": {"utilization": 99, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_sonnet": {"utilization": 5, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": false, "utilization": 0}
+}
+JSON
+    run is_model_exhausted opus
+    [ "$status" -eq 0 ]
+}
+
+@test "36 all-clear state (per fixture five_hour=2, seven_day=88) → opus NOT exhausted" {
+    run is_model_exhausted opus
+    [ "$status" -ne 0 ]
+}
+
+# ============================================================================
+# Configuration / hybrid fallback
+# ============================================================================
+
+@test "40 CLAUDE_USAGE_DISABLE=1 → is_model_exhausted always returns false" {
+    export CLAUDE_USAGE_DISABLE=1
+    # Even with the exhausted fixture, opt-out makes us return false.
+    run is_model_exhausted sonnet
+    [ "$status" -ne 0 ]
+}
+
+@test "41 missing CLAUDE_USAGE_SESSION_KEY → graceful: returns false, never curls" {
+    unset CLAUDE_USAGE_SESSION_KEY
+    run is_model_exhausted sonnet
+    [ "$status" -ne 0 ]
+    # Mock curl counter must be zero — we should never have invoked curl.
+    n=$(cat "$MOCK_CURL_COUNTER_FILE" 2>/dev/null || echo 0)
+    [ "$n" -eq 0 ]
+}
+
+@test "42 sessionKey can come from CLAUDE_USAGE_SESSION_KEY_FILE (0600)" {
+    unset CLAUDE_USAGE_SESSION_KEY
+    local key_file="$TEST_TMP/.session-key"
+    printf 'sk-ant-sid01-from-file\n' > "$key_file"
+    chmod 600 "$key_file"
+    export CLAUDE_USAGE_SESSION_KEY_FILE="$key_file"
+
+    run fetch_usage
+    [ "$status" -eq 0 ]
+    [ -f "$XDG_CACHE_HOME/claude-pipeline/usage.json" ]
+}
+
+# ============================================================================
+# Failure modes
+# ============================================================================
+
+@test "50 HTTP non-200 → returns false, logs WARN" {
+    export MOCK_CURL_HTTP_STATUS=401
+    run fetch_usage 2>&1
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"WARN"* || "$output" == *"warn"* ]]
+}
+
+@test "51 invalid JSON body → returns false, logs WARN" {
+    local bad="$TEST_TMP/bad-body.txt"
+    printf 'not json at all\n' > "$bad"
+    export MOCK_CURL_BODY_FILE="$bad"
+    run fetch_usage 2>&1
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"WARN"* || "$output" == *"warn"* ]]
+}
+
+@test "52 cache-was-valid then fetch fails → ERROR log (regression detected)" {
+    # First call succeeds → cache valid.
+    fetch_usage
+    [ -f "$XDG_CACHE_HOME/claude-pipeline/usage.json" ]
+    # Backdate cache so it expires; next fetch returns 500.
+    touch -t "$(date -v-1H +%Y%m%d%H%M.%S 2>/dev/null || date -d '1 hour ago' +%Y%m%d%H%M.%S)" \
+        "$XDG_CACHE_HOME/claude-pipeline/usage.json"
+    export MOCK_CURL_HTTP_STATUS=500
+    run fetch_usage 2>&1
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"ERROR"* || "$output" == *"error"* ]]
+}
+
+@test "53 graceful: failure path → is_model_exhausted returns false" {
+    export MOCK_CURL_HTTP_STATUS=503
+    run is_model_exhausted sonnet
+    [ "$status" -ne 0 ]   # not exhausted (graceful fallback to today's behavior)
+}
+
+# ============================================================================
+# Security: sessionKey must NEVER appear in any log output
+# ============================================================================
+
+@test "60 sessionKey value never appears in stdout, stderr, or any log line" {
+    # Trigger every code path that touches the key.
+    fetch_usage 2>&1 > "$TEST_TMP/stdout.txt"
+    is_model_exhausted sonnet 2>&1 > "$TEST_TMP/stdout2.txt" || true
+    model_reset_at sonnet 2>&1 > "$TEST_TMP/stdout3.txt" || true
+
+    # Trigger failure path too.
+    export MOCK_CURL_HTTP_STATUS=401
+    fetch_usage 2>&1 >> "$TEST_TMP/stdout.txt" || true
+
+    # The sessionKey must not appear in ANY captured output.
+    if grep -q "$CLAUDE_USAGE_SESSION_KEY" "$TEST_TMP/stdout.txt" \
+                                             "$TEST_TMP/stdout2.txt" \
+                                             "$TEST_TMP/stdout3.txt"; then
+        echo "LEAK: sessionKey appeared in script output" >&2
+        return 1
+    fi
+}

--- a/.claude/scripts/implement-issue-test/test-model-config.bats
+++ b/.claude/scripts/implement-issue-test/test-model-config.bats
@@ -1043,13 +1043,16 @@ _setup_usage_cache() {
 	cat > "$XDG_CACHE_HOME/claude-pipeline/usage.json"
 }
 
-# Source both modules in a subshell with cache pre-seeded.
+# Source both modules in a subshell with cache pre-seeded. Stderr suppressed
+# so $output captures the function's return value cleanly — _usage_aware_escalate
+# logs to stderr when it escalates, which is correct production behavior but
+# noise in these tests.
 run_with_usage() {
 	local cmd="$1"
 	run bash -c "
 		source '$SCRIPT_DIR/model-config.sh'
 		source '$SCRIPT_DIR/claude-usage.sh'
-		$cmd
+		$cmd 2>/dev/null
 	"
 }
 

--- a/.claude/scripts/implement-issue-test/test-model-config.bats
+++ b/.claude/scripts/implement-issue-test/test-model-config.bats
@@ -1022,3 +1022,127 @@ run_with_config() {
 	[ "$status" -eq 0 ]
 	[[ "$output" == "opus" ]]
 }
+
+# =============================================================================
+# effective_model — usage-aware escalation
+# =============================================================================
+#
+# These tests source claude-usage.sh (which model-config.sh's effective_model
+# delegates to). To exercise behavior without hitting the network we set up
+# a fake cache file at $XDG_CACHE_HOME/claude-pipeline/usage.json before
+# calling effective_model.
+#
+
+# Helper: configure usage env so claude-usage.sh treats us as authenticated.
+_setup_usage_cache() {
+	export XDG_CACHE_HOME="$TEST_TMP/cache"
+	export CLAUDE_USAGE_SESSION_KEY="sk-ant-sid01-fake"
+	export CLAUDE_USAGE_ORG_ID="00000000-0000-0000-0000-000000000000"
+	export CLAUDE_USAGE_CACHE_TTL=300
+	mkdir -p "$XDG_CACHE_HOME/claude-pipeline"
+	cat > "$XDG_CACHE_HOME/claude-pipeline/usage.json"
+}
+
+# Source both modules in a subshell with cache pre-seeded.
+run_with_usage() {
+	local cmd="$1"
+	run bash -c "
+		source '$SCRIPT_DIR/model-config.sh'
+		source '$SCRIPT_DIR/claude-usage.sh'
+		$cmd
+	"
+}
+
+@test "effective_model defaults to resolve_model when no cooldown applies" {
+	_setup_usage_cache <<'JSON'
+{
+  "five_hour": {"utilization": 2, "resets_at": "2026-05-02T07:09:59+00:00"},
+  "seven_day": {"utilization": 5, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_sonnet": {"utilization": 5, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": false, "utilization": 0}
+}
+JSON
+	run_with_usage 'effective_model implement M'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "sonnet" ]]
+}
+
+@test "effective_model escalates sonnet to opus when seven_day_sonnet >= threshold (no overage)" {
+	_setup_usage_cache <<'JSON'
+{
+  "five_hour": {"utilization": 2, "resets_at": "2026-05-02T07:09:59+00:00"},
+  "seven_day": {"utilization": 50, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_sonnet": {"utilization": 100, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": false, "utilization": 0}
+}
+JSON
+	run_with_usage 'effective_model implement M'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "opus" ]]
+}
+
+@test "effective_model returns opus (ceiling) when sonnet AND seven_day are exhausted" {
+	_setup_usage_cache <<'JSON'
+{
+  "five_hour": {"utilization": 5, "resets_at": "2026-05-02T07:09:59+00:00"},
+  "seven_day": {"utilization": 99, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_sonnet": {"utilization": 100, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": false, "utilization": 0}
+}
+JSON
+	run_with_usage 'effective_model implement M'
+	[ "$status" -eq 0 ]
+	# Both sonnet and (via fallback to seven_day at 99%) opus are exhausted.
+	# Loop should hit the ceiling and return opus rather than spinning.
+	[[ "$output" == "opus" ]]
+}
+
+@test "effective_model honors CLAUDE_USAGE_DISABLE=1 (no escalation)" {
+	export CLAUDE_USAGE_DISABLE=1
+	_setup_usage_cache <<'JSON'
+{
+  "five_hour": {"utilization": 2, "resets_at": "2026-05-02T07:09:59+00:00"},
+  "seven_day": {"utilization": 5, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_sonnet": {"utilization": 100, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": false, "utilization": 0}
+}
+JSON
+	run_with_usage 'effective_model implement M'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "sonnet" ]]
+}
+
+@test "effective_model handles missing CLAUDE_USAGE_SESSION_KEY gracefully (no escalation)" {
+	unset CLAUDE_USAGE_SESSION_KEY || true
+	# No cache, no key → effective_model must not escalate.
+	run bash -c "
+		unset CLAUDE_USAGE_SESSION_KEY
+		export XDG_CACHE_HOME='$TEST_TMP/cache-empty'
+		source '$SCRIPT_DIR/model-config.sh'
+		source '$SCRIPT_DIR/claude-usage.sh'
+		effective_model implement M
+	"
+	[ "$status" -eq 0 ]
+	[[ "$output" == "sonnet" ]]
+}
+
+@test "effective_fallback also walks the escalation loop" {
+	_setup_usage_cache <<'JSON'
+{
+  "five_hour": {"utilization": 2, "resets_at": "2026-05-02T07:09:59+00:00"},
+  "seven_day": {"utilization": 50, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_sonnet": {"utilization": 100, "resets_at": "2026-05-02T05:59:59+00:00"},
+  "seven_day_opus": null,
+  "extra_usage": {"is_enabled": false, "utilization": 0}
+}
+JSON
+	# fallback for haiku would normally be sonnet — but sonnet is exhausted,
+	# so effective_fallback should escalate to opus.
+	run_with_usage 'effective_fallback haiku'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "opus" ]]
+}

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -214,17 +214,17 @@ _next_model_up() {
 #
 
 _usage_aware_escalate() {
-	local model="$1" next
-	# is_model_exhausted is provided by claude-usage.sh. If it isn't loaded
-	# (or the user opted out / hasn't configured), treat as not exhausted.
+	local model="$1" original="$1" next
+	# is_model_exhausted comes from claude-usage.sh. When it isn't sourced
+	# (or polling is unconfigured), treat all models as not exhausted.
 	if ! declare -F is_model_exhausted >/dev/null 2>&1; then
-		printf '%s' "$model"
+		printf '%s\n' "$model"
 		return 0
 	fi
 
-	# Walk the chain. _next_model_up returns the same model at the ceiling,
-	# which terminates the loop unconditionally — no infinite spin even if
-	# every tier is exhausted.
+	# _next_model_up returns the same model at the opus ceiling, which
+	# terminates the loop unconditionally — no infinite spin if every
+	# tier is exhausted.
 	while is_model_exhausted "$model"; do
 		next=$(_next_model_up "$model")
 		if [[ "$next" == "$model" ]]; then
@@ -232,22 +232,26 @@ _usage_aware_escalate() {
 		fi
 		model="$next"
 	done
-	printf '%s' "$model"
+
+	# Surface the escalation so operators can correlate cost spikes with
+	# bucket exhaustion. Logged via the orchestrator's `log` if available,
+	# else stderr — see _usage_log in claude-usage.sh.
+	if [[ "$model" != "$original" ]] && declare -F model_reset_at >/dev/null 2>&1; then
+		local _reset
+		_reset=$(model_reset_at "$original")
+		_usage_log "Usage gate: $original exhausted (resets ${_reset}) — escalating to $model"
+	fi
+
+	printf '%s\n' "$model"
 }
 
 # effective_model(stage, complexity) — resolve_model with usage gating.
 effective_model() {
-	local resolved
-	resolved=$(resolve_model "$@")
-	_usage_aware_escalate "$resolved"
-	printf '\n'
+	_usage_aware_escalate "$(resolve_model "$@")"
 }
 
 # effective_fallback(model) — _next_model_up with usage gating.
 # Used to compute the --fallback-model arg for the Claude CLI.
 effective_fallback() {
-	local fallback
-	fallback=$(_next_model_up "$1")
-	_usage_aware_escalate "$fallback"
-	printf '\n'
+	_usage_aware_escalate "$(_next_model_up "$1")"
 }

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -197,3 +197,57 @@ _next_model_up() {
 		*)      printf '%s' "opus" ;;
 	esac
 }
+
+# =============================================================================
+# USAGE-AWARE MODEL SELECTION (effective_model / effective_fallback)
+# =============================================================================
+#
+# Wraps resolve_model with a check against claude-usage.sh's
+# is_model_exhausted. When the picked model is exhausted (per-model bucket
+# full and overage isn't absorbing), escalate via _next_model_up until we
+# find one that isn't exhausted or hit the opus ceiling.
+#
+# When claude-usage.sh isn't loaded OR no sessionKey is configured,
+# is_model_exhausted returns false for everything and these wrappers
+# behave identically to resolve_model / _next_model_up — zero regression
+# for users who haven't opted into usage polling.
+#
+
+_usage_aware_escalate() {
+	local model="$1" next
+	# is_model_exhausted is provided by claude-usage.sh. If it isn't loaded
+	# (or the user opted out / hasn't configured), treat as not exhausted.
+	if ! declare -F is_model_exhausted >/dev/null 2>&1; then
+		printf '%s' "$model"
+		return 0
+	fi
+
+	# Walk the chain. _next_model_up returns the same model at the ceiling,
+	# which terminates the loop unconditionally — no infinite spin even if
+	# every tier is exhausted.
+	while is_model_exhausted "$model"; do
+		next=$(_next_model_up "$model")
+		if [[ "$next" == "$model" ]]; then
+			break
+		fi
+		model="$next"
+	done
+	printf '%s' "$model"
+}
+
+# effective_model(stage, complexity) — resolve_model with usage gating.
+effective_model() {
+	local resolved
+	resolved=$(resolve_model "$@")
+	_usage_aware_escalate "$resolved"
+	printf '\n'
+}
+
+# effective_fallback(model) — _next_model_up with usage gating.
+# Used to compute the --fallback-model arg for the Claude CLI.
+effective_fallback() {
+	local fallback
+	fallback=$(_next_model_up "$1")
+	_usage_aware_escalate "$fallback"
+	printf '\n'
+}

--- a/.claude/skills/handle-issues/SKILL.md
+++ b/.claude/skills/handle-issues/SKILL.md
@@ -160,6 +160,130 @@ Two test layers protect the triage system. Both must stay green:
   triage tier model. Run monthly to catch model drift.** Do NOT
   auto-update the manifest when fixtures flip — investigate first.
 
+## Proactive Usage Polling (skip exhausted models)
+
+When `seven_day_sonnet` hits 100% but the all-models weekly cap still has
+headroom, opus/haiku are still usable. Without this feature the orchestrator
+would sleep ~1h waiting for sonnet to reset. With it, the orchestrator polls
+the same private endpoint that menu-bar apps like Sneaky Penguin use, and
+escalates sonnet → opus on the fly.
+
+### How to enable
+
+1. **Get your sessionKey.** Open `https://claude.ai` in any browser logged
+   in to your account. Open DevTools (F12) → Console tab and paste:
+
+   ```js
+   document.cookie  // search the output for "sessionKey="
+   ```
+
+   If `sessionKey` isn't visible there (HttpOnly), use the Application tab →
+   Cookies → `https://claude.ai` → row named `sessionKey`. Copy the long
+   value starting `sk-ant-sid01-...`.
+
+2. **Get your org UUID.** In DevTools Console, paste:
+
+   ```js
+   fetch('/api/organizations', {credentials: 'include'}).then(r => r.json()).then(o => console.log(o[0]?.uuid))
+   ```
+
+3. **Configure the env vars** (e.g. in `~/.zshrc`):
+
+   ```bash
+   export CLAUDE_USAGE_SESSION_KEY="sk-ant-sid01-..."
+   export CLAUDE_USAGE_ORG_ID="your-org-uuid"
+   ```
+
+   For CI / shared boxes, prefer a 0600 file:
+
+   ```bash
+   echo "sk-ant-sid01-..." > ~/.claude-session-key && chmod 600 ~/.claude-session-key
+   export CLAUDE_USAGE_SESSION_KEY_FILE=~/.claude-session-key
+   ```
+
+### Configuration env vars
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `CLAUDE_USAGE_SESSION_KEY` | (required to enable) | sessionKey cookie from claude.ai |
+| `CLAUDE_USAGE_SESSION_KEY_FILE` | (alternative) | Path to 0600 file containing the key |
+| `CLAUDE_USAGE_ORG_ID` | (required) | Organization UUID |
+| `CLAUDE_USAGE_DISABLE` | `0` | `1` opts out — script behaves exactly as today |
+| `CLAUDE_USAGE_SESSION_THRESHOLD` | `95` | `five_hour` cap (5-hour rate window — overage cannot absorb) |
+| `CLAUDE_USAGE_MODEL_THRESHOLD` | `95` | `seven_day_sonnet` / `seven_day_opus` cap (per-model weekly) |
+| `CLAUDE_USAGE_WEEKLY_THRESHOLD` | `98` | `seven_day` all-models weekly cap (last-resort circuit-breaker) |
+| `CLAUDE_USAGE_EXTRA_THRESHOLD` | `90` | When `extra_usage.utilization` exceeds this, stop letting overage absorb |
+| `CLAUDE_USAGE_CACHE_TTL` | `30` | Seconds — cache one response per 30s ≈ one API call per ~30 stages |
+
+### Bucket-to-model mapping (verified against captured fixture)
+
+| Model | Per-model bucket | Falls back to | Session gate |
+|-------|------------------|---------------|--------------|
+| sonnet | `seven_day_sonnet` | `seven_day` if null | `five_hour` |
+| opus | `seven_day_opus` (often null) | `seven_day` if null | `five_hour` |
+| haiku | _none_ | `seven_day` | `five_hour` |
+| unknown | (not gated; returns 0) | — | — |
+
+### Behavior
+
+- **Hybrid fallback**: if `CLAUDE_USAGE_SESSION_KEY` is unset OR a fetch
+  fails, `is_model_exhausted` returns false for everything. The reactive
+  rate-limit handler (`handle_rate_limit`, sleeps for parsed wait time)
+  remains as the safety net — no regression for users without a key.
+- **Overage absorption**: paid plans with `extra_usage.is_enabled: true`
+  have per-model exhaustion absorbed by overage billing. The script does
+  NOT escalate when overage is below `EXTRA_THRESHOLD` — escalating
+  prematurely would burn opus when sonnet calls would still have succeeded
+  (just billed against overage).
+- **Mid-run model oscillation**: each stage is a fresh Claude CLI
+  invocation with no shared conversation context. If sonnet at 96%
+  triggers escalation in stage 1, then resets mid-run and stage 3 sees
+  it at 5%, stage 3 will use sonnet. This is expected and benign.
+- **Cache location**: `${XDG_CACHE_HOME:-$HOME/.cache}/claude-pipeline/usage.json`.
+  User-scoped, single source of truth across all worktrees and projects.
+  Never accidentally committed.
+- **`model_override` callsites bypass the gate**: stages with hard-coded
+  models (e.g. PR creation pinned to opus) honor the explicit caller
+  intent. If opus is exhausted in that case, the call surfaces an error
+  rather than silently demoting.
+
+### Security
+
+- sessionKey is a long-lived bearer-equivalent for your claude.ai account.
+- Read once into a local variable; passed to curl via `-H Cookie:` (header,
+  not visible in `ps`); never echoed; never logged; never written to
+  status.json or any artifact.
+- The `test-claude-usage.bats` suite includes an explicit grep-the-key-out
+  check on every code path's output.
+- Known limitation: child process environment may show the value in
+  `/proc/PID/environ` on some Linux configurations during the curl call.
+  Acceptable on a single-user box; use the file-based alternative on shared
+  hosts.
+
+### Known limitations
+
+- The endpoint at `https://claude.ai/api/organizations/{org}/usage` is
+  undocumented. If it changes shape, parse failure → graceful fallback to
+  reactive behavior + WARN log (ERROR if previous cache was valid, so the
+  regression is visible).
+- The double-timeout escalation path in `run_stage` (lines ~1188–1198)
+  bypasses `effective_model`. Rare edge case; addressed in a follow-up.
+- Empirical verification of whether `extra_usage` absorbs `five_hour` or
+  `seven_day` exhaustion is pending — current code treats both as hard
+  caps (conservative). Can be relaxed later if observed.
+
+### Re-capturing the API fixture
+
+If the response shape changes:
+
+```bash
+.claude/scripts/capture-usage-fixture.sh
+```
+
+(prompts for sessionKey + org UUID, writes to
+`.claude/scripts/implement-issue-test/fixtures/usage-response.json`,
+prints the discovered field names so the bucket mapping can be updated).
+
 ## Process
 
 ```dot


### PR DESCRIPTION
## Summary

Closes #182.

Replaces reactive rate-limit handling (sleep ~1h on detection) with proactive pre-flight polling of the claude.ai usage API. When a per-model bucket is exhausted (e.g. `seven_day_sonnet` at 100%) AND overage isn't absorbing, the orchestrator escalates sonnet → opus instead of sleeping.

- New `claude-usage.sh` module: `fetch_usage`, `usage_for_model`, `model_reset_at`, `is_model_exhausted` with three-threshold gating + overage absorption guard
- New `effective_model` / `effective_fallback` in `model-config.sh` (loop `_next_model_up` while exhausted; no-op when usage polling unconfigured)
- Wired into 4 CLI invocation sites in `implement-issue-orchestrator.sh` (initial dispatch + max-turns + empty-output + struct-error escalations); `model_override` callsites bypass per design
- `batch-orchestrator.sh` pre-flight observability log
- 24 new bats tests (mock curl + real captured fixture); 6 new `effective_model` tests in `test-model-config.bats` — all GREEN
- Hybrid fallback: no `CLAUDE_USAGE_SESSION_KEY` configured → script behaves exactly as today

## Test plan

- [x] `bats test-claude-usage.bats` — 24/24
- [x] `bats test-model-config.bats` — 138/141 (3 baseline failures pre-existing on main, unchanged)
- [x] `bats test-stage-runner.bats` — 47/52 (5 baseline failures pre-existing on main, unchanged)
- [x] `bats test-surgical-fast-path.bats` — 24/24 (no regressions)
- [x] Full suite swept across 26 files; only pre-existing baseline failures, zero new regressions
- [x] Real API fixture captured against live endpoint (`.claude/scripts/implement-issue-test/fixtures/usage-response.json`)
- [ ] Manual smoke: set `CLAUDE_USAGE_SESSION_KEY` + `_ORG_ID`, run a stage on a pipeline where sonnet is at 100% — confirm escalation log line appears and stage succeeds via opus
- [ ] Sync to downstream projects via `./sync.sh to <project>` once merged

## Out of scope (per issue)

- Double-timeout escalation path at `run_stage:1188-1198` bypasses `effective_model` (rare edge case; documented as known limitation in SKILL.md)
- Org auto-discovery (rejected per design — explicit `CLAUDE_USAGE_ORG_ID` required)
- Empirical verification of overage absorbing `five_hour` or `seven_day` exhaustion (currently treated as hard caps; can relax if observed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)