### PR TITLE
feat(issue-238): copy timeout fixture to tests directory

### DIFF
--- a/tests/fixtures/escalation-policy/timeout-first-attempt.json
+++ b/tests/fixtures/escalation-policy/timeout-first-attempt.json
@@ -1,0 +1,15 @@
+{
+  "status": "error",
+  "output": null,
+  "raw": "",
+  "denials": [],
+  "model": "haiku",
+  "error_kind": "timeout",
+  "elapsed_ms": 1800000,
+  "_fixture_meta": {
+    "stage": "implement",
+    "attempt": 1,
+    "max_attempts": 3,
+    "description": "First attempt at implement stage hit the wall-clock timeout. Expected escalation to sonnet."
+  }
+}


### PR DESCRIPTION
Closes #238