### PR TITLE
chore: sync pipeline update — watchdog fd-inheritance fix (#310)

### DIFF
--- a/.claude/hooks/pre-commit-skill-validate.sh
+++ b/.claude/hooks/pre-commit-skill-validate.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# pre-commit-skill-validate.sh — PreToolUse hook that validates SKILL.md
+# YAML frontmatter against the schema BEFORE an Edit or Write tool call
+# is allowed to apply.
+#
+# Wiring (settings.json):
+#   PreToolUse / matcher "Edit|Write" — fires for every Edit/Write call.
+#   The hook itself filters to paths ending in "/SKILL.md".
+#
+# Hook stdin format:
+#   {"tool_name":"Edit"|"Write","tool_input":{...},...}
+#
+# Behaviour:
+#   - tool_name not Edit/Write          → exit 0 (allow, silent)
+#   - file_path not "*/SKILL.md"        → exit 0 (allow, silent)
+#   - skill-validate.sh missing         → exit 0 (fail open — never block
+#                                        on missing tooling)
+#   - post-edit frontmatter passes      → exit 0 (allow)
+#   - post-edit frontmatter fails       → exit 2 (block, stderr explains)
+#
+# Post-edit content is reconstructed in a temporary skill directory so
+# that skill-validate.sh can be invoked unmodified via SKILLS_DIR + the
+# resolved skill name.
+#
+
+set -u
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+
+# ---------------------------------------------------------------------------
+# Resolve the project root and the skill-validate.sh script. Honour
+# CLAUDE_PROJECT_DIR (set by the harness) and a SKILL_VALIDATE_SCRIPT
+# override (used by tests) before falling back to a path relative to this
+# script.
+# ---------------------------------------------------------------------------
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve to the project root: CLAUDE_PROJECT_DIR when set by the harness,
+# otherwise two levels up from this hook (hooks/ → .claude/ → project root).
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$HOOK_DIR/../.." && pwd)}"
+SKILL_VALIDATE="${SKILL_VALIDATE_SCRIPT:-$PROJECT_DIR/.claude/scripts/skill-validate.sh}"
+
+# ---------------------------------------------------------------------------
+# Python helper that does the JSON parsing, post-edit reconstruction, and
+# materialisation. Stored once and invoked via `python3 -c "$PY_BUILD"` so
+# the hook's stdin (the original PreToolUse JSON) flows through to python
+# unmodified — using a heredoc here would steal stdin.
+# ---------------------------------------------------------------------------
+read -r -d '' PY_BUILD <<'PY' || true
+import json
+import os
+import sys
+
+tmp_root = sys.argv[1]
+
+try:
+    payload = json.loads(sys.stdin.read())
+except Exception:
+    sys.exit(0)
+
+tool = payload.get("tool_name", "")
+if tool not in ("Edit", "Write"):
+    sys.exit(0)
+
+ti = payload.get("tool_input") or {}
+file_path = ti.get("file_path") or ""
+if not file_path or not file_path.endswith("/SKILL.md"):
+    sys.exit(0)
+
+# Skill name = directory containing SKILL.md
+skill_name = os.path.basename(os.path.dirname(file_path))
+if not skill_name:
+    sys.exit(0)
+
+# Compute the post-edit content
+if tool == "Write":
+    new_content = ti.get("content", "") or ""
+else:  # Edit
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            existing = f.read()
+    except OSError:
+        # Edit on a non-existent file — let Claude Code surface that
+        # error; nothing useful for us to validate.
+        sys.exit(0)
+
+    old = ti.get("old_string", "") or ""
+    new = ti.get("new_string", "") or ""
+    replace_all = bool(ti.get("replace_all"))
+
+    if old == "":
+        # Edit semantics require a non-empty old_string; if it is
+        # empty there's nothing meaningful to simulate.
+        sys.exit(0)
+
+    if replace_all:
+        new_content = existing.replace(old, new)
+    else:
+        new_content = existing.replace(old, new, 1)
+
+# Materialise the post-edit content under a private skills tree so that
+# skill-validate.sh can be invoked unmodified via SKILLS_DIR.
+skills_dir = os.path.join(tmp_root, "skills")
+target_dir = os.path.join(skills_dir, skill_name)
+os.makedirs(target_dir, exist_ok=True)
+
+target = os.path.join(target_dir, "SKILL.md")
+with open(target, "w", encoding="utf-8") as f:
+    f.write(new_content)
+
+print(skills_dir)
+print(skill_name)
+print(file_path)
+PY
+
+# ---------------------------------------------------------------------------
+# build_post_edit_state <tmp_root>
+#
+# Reads PreToolUse JSON from stdin. When the call is an Edit or Write on
+# a "*/SKILL.md" path, computes the post-edit content and materialises it
+# at <tmp_root>/skills/<skill_name>/SKILL.md.
+#
+# On success, prints three lines to stdout:
+#   1. SKILLS_DIR (i.e. <tmp_root>/skills)
+#   2. <skill_name> (the parent directory of SKILL.md)
+#   3. <file_path> (the original path, for error messages)
+#
+# Prints nothing and exits 0 when the call should be ignored.
+# ---------------------------------------------------------------------------
+build_post_edit_state() {
+	local tmp_root="$1"
+
+	python3 -c "$PY_BUILD" "$tmp_root"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	# If skill-validate.sh isn't available, fail open. We never want this
+	# hook to block edits because of missing tooling.
+	[[ -f "$SKILL_VALIDATE" ]] || exit 0
+
+	local tmp_root
+	tmp_root=$(mktemp -d 2>/dev/null) || exit 0
+	trap 'rm -rf "$tmp_root"' EXIT
+
+	local info
+	info=$(build_post_edit_state "$tmp_root") || exit 0
+	[[ -n "$info" ]] || exit 0
+
+	local skills_dir skill_name file_path
+	{
+		IFS= read -r skills_dir
+		IFS= read -r skill_name
+		IFS= read -r file_path
+	} <<< "$info"
+
+	[[ -n "$skills_dir" && -n "$skill_name" ]] || exit 0
+
+	# Run skill-validate.sh against the simulated post-edit state.
+	local validate_output
+	if validate_output=$(SKILLS_DIR="$skills_dir" \
+		bash "$SKILL_VALIDATE" --skill "$skill_name" 2>&1); then
+		exit 0
+	fi
+
+	# Validation failed — block and surface the error.
+	{
+		printf '%s: SKILL.md frontmatter validation failed\n' \
+			"$SCRIPT_NAME"
+		printf '  file:  %s\n' "$file_path"
+		printf '  skill: %s\n' "$skill_name"
+		printf '\n'
+		printf '%s\n' "$validate_output"
+		printf '\n'
+		printf 'Edit blocked. Fix the frontmatter to match '
+		printf '.claude/scripts/schemas/skill-frontmatter.json '
+		printf 'and try again.\n'
+	} >&2
+	exit 2
+}
+
+main "$@"

--- a/.claude/scripts/batch-orchestrator.sh
+++ b/.claude/scripts/batch-orchestrator.sh
@@ -494,6 +494,121 @@ extract_wait_time() {
 }
 
 # =============================================================================
+# COMPOSITION ROUTING
+# =============================================================================
+#
+# dispatch_composition routes a claude invocation to one of two subprocess
+# paths:
+#
+#   1. isolated  (isolated=true)  — worktree-isolated subprocess with
+#      --dangerously-skip-permissions.  Used for implementation tasks that
+#      need to modify files in a fresh git worktree.
+#
+#   2. standard  (isolated=false) — plain subprocess WITHOUT
+#      --dangerously-skip-permissions.  Used for decision/review tasks like
+#      process-pr that orchestrate via interactive tools.
+#
+# ARCHITECTURAL CONSTRAINT: bash cannot invoke the Skill tool.
+# The Skill tool is a Claude Code API feature available only inside a Claude
+# session; it cannot be called from a bash subprocess.  Both paths therefore
+# call `claude -p` as a child process — the distinction is only in which
+# permission flags are forwarded.  Any "skill-tool path" naming in prior
+# versions of this file was aspirational and has been removed to avoid
+# confusion.
+#
+# Usage:
+#   dispatch_composition "<prompt>" [isolated] [extra claude args...]
+#
+# Arguments:
+#   prompt   — slash-command prompt (e.g. "/process-pr 1 2 main")
+#   isolated — "true" for isolated subprocess, "false"/omitted for standard
+#   ...      — additional flags forwarded to the claude invocation
+#
+# Kill-switch: COMPOSITION_BACKEND env var overrides auto-routing.
+#   subprocess — always use isolated subprocess path
+#   skill      — always use standard (non-sandboxed) subprocess path
+#                NOTE: "skill" is a legacy name; it does NOT invoke the Skill
+#                tool.  It selects the standard subprocess without
+#                --dangerously-skip-permissions.
+#   (unset)    — auto-route based on the isolated argument
+
+dispatch_composition() {
+	local prompt="$1"
+	local isolated="${2:-false}"
+	local -a extra_args=()
+	if (( $# > 2 )); then
+		shift 2
+		extra_args=("$@")
+	fi
+
+	local backend
+	if [[ -n "${COMPOSITION_BACKEND:-}" ]]; then
+		case "$COMPOSITION_BACKEND" in
+			subprocess|skill)
+				backend="$COMPOSITION_BACKEND"
+				;;
+			*)
+				printf 'ERROR: unknown COMPOSITION_BACKEND value: %s\n' \
+					"$COMPOSITION_BACKEND" >&2
+				return 1
+				;;
+		esac
+	elif [[ "$isolated" == "true" ]]; then
+		backend="subprocess"
+	else
+		backend="skill"
+	fi
+
+	case "$backend" in
+		subprocess)
+			run_composition_subprocess "$prompt" "${extra_args[@]+"${extra_args[@]}"}"
+			;;
+		# "skill" is the legacy kill-switch value; routes to the standard
+		# (non-sandboxed) subprocess path.  See ARCHITECTURAL CONSTRAINT note
+		# above.
+		skill)
+			run_composition_standard "$prompt" "${extra_args[@]+"${extra_args[@]}"}"
+			;;
+	esac
+}
+
+# run_composition_subprocess — invoke a skill as a worktree-isolated subprocess.
+# Used for skills that require git worktree isolation (e.g. implement-issue).
+run_composition_subprocess() {
+	local prompt="$1"
+	shift
+	log "Composition dispatch → subprocess: $prompt"
+	timeout "$ISSUE_TIMEOUT" env -u CLAUDECODE claude -p "$prompt" \
+		--dangerously-skip-permissions \
+		--output-format json \
+		"$@" \
+		2>&1
+}
+
+# run_composition_standard — invoke claude as a standard (non-sandboxed) subprocess.
+# Used for decision/review skills that do not require worktree isolation
+# (e.g. process-pr, plan, review).
+#
+# ARCHITECTURAL CONSTRAINT: bash cannot invoke the Skill tool.
+# This function is the successor to the former run_composition_skill(); it was
+# renamed because the old name implied a Skill-tool invocation, which bash
+# subprocesses cannot perform.  The implementation is a plain `claude -p`
+# call — identical to run_composition_subprocess() except that it omits
+# --dangerously-skip-permissions, allowing the spawned session to use
+# interactive tools and AskUserQuestion.
+#
+# Output format is not forced here — callers that need structured JSON must
+# pass --output-format json (and --json-schema) explicitly.
+run_composition_standard() {
+	local prompt="$1"
+	shift
+	log "Composition dispatch → standard: $prompt"
+	timeout "$ISSUE_TIMEOUT" env -u CLAUDECODE claude -p "$prompt" \
+		"$@" \
+		2>&1
+}
+
+# =============================================================================
 # ISSUE PROCESSING
 # =============================================================================
 
@@ -643,12 +758,11 @@ process_issue() {
     local proc_exit=0
 
     printf '%s\n' "=== process-pr output ===" >> "$issue_log"
-    timeout "$ISSUE_TIMEOUT" env -u CLAUDECODE claude -p "/process-pr $pr_number $issue_num $BRANCH" \
+    dispatch_composition "/process-pr $pr_number $issue_num $BRANCH" "false" \
         --agent code-reviewer \
-        --dangerously-skip-permissions \
         --output-format json \
         --json-schema "$PROCESS_SCHEMA" \
-        2>&1 | tee -a "$issue_log"
+        | tee -a "$issue_log"
     proc_exit=${PIPESTATUS[0]}
     printf '%s\n' "=== exit code: $proc_exit ===" >> "$issue_log"
 
@@ -677,26 +791,16 @@ process_issue() {
 
         set_rate_limit "false" "" ""
 
-        # Resume
+        # Resume — retry-with-backoff: parent already slept for the rate-limit
+        # window; restart fresh rather than resuming with "please continue"
+        # (the --resume subprocess is replaced by a clean retry here).
         printf '%s\n' "=== process-pr resume output ===" >> "$issue_log"
-        if [[ -n "$session_id" ]]; then
-            timeout "$ISSUE_TIMEOUT" env -u CLAUDECODE claude -p "please continue" \
-                --resume "$session_id" \
-                --agent code-reviewer \
-                --dangerously-skip-permissions \
-                --output-format json \
-                --json-schema "$PROCESS_SCHEMA" \
-                2>&1 | tee -a "$issue_log"
-            proc_exit=${PIPESTATUS[0]}
-        else
-            timeout "$ISSUE_TIMEOUT" env -u CLAUDECODE claude -p "/process-pr $pr_number $issue_num $BRANCH" \
-                --agent code-reviewer \
-                --dangerously-skip-permissions \
-                --output-format json \
-                --json-schema "$PROCESS_SCHEMA" \
-                2>&1 | tee -a "$issue_log"
-            proc_exit=${PIPESTATUS[0]}
-        fi
+        dispatch_composition "/process-pr $pr_number $issue_num $BRANCH" "false" \
+            --agent code-reviewer \
+            --output-format json \
+            --json-schema "$PROCESS_SCHEMA" \
+            | tee -a "$issue_log"
+        proc_exit=${PIPESTATUS[0]}
         proc_last_json=$(grep -E '^\{' "$issue_log" | tail -1)
     fi
 

--- a/.claude/scripts/canary-measure.sh
+++ b/.claude/scripts/canary-measure.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+#
+# canary-measure.sh
+# Aggregate wall-clock and token usage per issue across a canary run.
+#
+# Used to gate AC5 of issue #179: tokens-per-issue regression ≤ 10%,
+# wall-clock-per-issue regression ≤ 25%. The script reads metrics.json files
+# emitted by implement-issue-orchestrator and matches them against transcript
+# JSONL files in ~/.claude/projects/ to compute per-issue token totals.
+#
+# Usage (measurement mode):
+#   canary-measure.sh --logs-dir <dir> [--transcripts-dir <dir>]
+#                     [--label <name>] [--format json|markdown]
+#                     [--limit N]
+#
+# Usage (delta mode):
+#   canary-measure.sh --compute-deltas --before <json> --after <json>
+#                     [--format json|markdown]
+#
+# Defaults:
+#   --transcripts-dir  ~/.claude/projects
+#   --format           json
+#
+# Issue→transcript matching:
+#   A transcript JSONL record is attributed to issue N if its `cwd` field
+#   equals the issue's log directory or any descendant path (e.g. worktrees/).
+#
+# Exit codes:
+#   0 - success
+#   1 - validation failure (missing args, bad inputs)
+#
+
+set -euo pipefail
+
+# =============================================================================
+# DEFAULTS / ARGUMENT PARSING
+# =============================================================================
+
+LOGS_DIR=""
+TRANSCRIPTS_DIR="${HOME}/.claude/projects"
+LABEL=""
+FORMAT="json"
+LIMIT=0
+COMPUTE_DELTAS=0
+BEFORE=""
+AFTER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --logs-dir)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            LOGS_DIR="$2"; shift 2;;
+        --transcripts-dir)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            TRANSCRIPTS_DIR="$2"; shift 2;;
+        --label)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            LABEL="$2"; shift 2;;
+        --format)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            FORMAT="$2"; shift 2;;
+        --limit)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            LIMIT="$2"; shift 2;;
+        --compute-deltas)
+            COMPUTE_DELTAS=1; shift;;
+        --before)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            BEFORE="$2"; shift 2;;
+        --after)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            AFTER="$2"; shift 2;;
+        -h|--help)
+            sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+        *)
+            printf 'ERROR: unknown option: %s\n' "$1" >&2; exit 1;;
+    esac
+done
+
+case "$FORMAT" in
+    json|markdown) ;;
+    *) printf 'ERROR: --format must be json or markdown\n' >&2; exit 1;;
+esac
+
+# =============================================================================
+# DELTA MODE
+# =============================================================================
+
+if [[ "$COMPUTE_DELTAS" -eq 1 ]]; then
+    [[ -f "$BEFORE" ]] || { printf 'ERROR: --before file not found: %s\n' "$BEFORE" >&2; exit 1; }
+    [[ -f "$AFTER"  ]] || { printf 'ERROR: --after file not found: %s\n'  "$AFTER"  >&2; exit 1; }
+
+    deltas=$(jq -n \
+        --slurpfile b "$BEFORE" \
+        --slurpfile a "$AFTER" \
+        '
+        def pct(before; after):
+            if before == 0 or before == null then null
+            else (((after - before) * 100) / before) | floor end;
+
+        ($b[0].summary // {}) as $bs
+        | ($a[0].summary // {}) as $as
+        | {
+            before_label: ($b[0].label // null),
+            after_label:  ($a[0].label // null),
+            before_summary: $bs,
+            after_summary:  $as,
+            deltas: {
+                wall_clock_total_pct:  pct($bs.wall_clock_total;  $as.wall_clock_total),
+                wall_clock_median_pct: pct($bs.wall_clock_median; $as.wall_clock_median),
+                tokens_total_pct:      pct($bs.tokens_total;      $as.tokens_total),
+                tokens_median_pct:     pct($bs.tokens_median;     $as.tokens_median)
+            },
+            gates: {
+                tokens_pct_limit:     10,
+                wall_clock_pct_limit: 25,
+                tokens_within_limit:
+                    ((pct($bs.tokens_median; $as.tokens_median) // 0) <= 10),
+                wall_clock_within_limit:
+                    ((pct($bs.wall_clock_median; $as.wall_clock_median) // 0) <= 25)
+            }
+        }
+        ')
+
+    if [[ "$FORMAT" = "json" ]]; then
+        printf '%s\n' "$deltas"
+    else
+        printf '## Canary deltas: %s → %s\n\n' \
+            "$(printf '%s' "$deltas" | jq -r '.before_label // "before"')" \
+            "$(printf '%s' "$deltas" | jq -r '.after_label  // "after"')"
+        printf '| Metric | Before | After | Δ%% | Gate |\n'
+        printf '|---|---:|---:|---:|:---:|\n'
+        printf '%s\n' "$deltas" | jq -r '
+            "| Wall-clock total (s)  | \(.before_summary.wall_clock_total)  | \(.after_summary.wall_clock_total)  | \(.deltas.wall_clock_total_pct  // "n/a") | — |",
+            "| Wall-clock median (s) | \(.before_summary.wall_clock_median) | \(.after_summary.wall_clock_median) | \(.deltas.wall_clock_median_pct // "n/a") | \(if .gates.wall_clock_within_limit then "PASS" else "FAIL" end) |",
+            "| Tokens total          | \(.before_summary.tokens_total)      | \(.after_summary.tokens_total)      | \(.deltas.tokens_total_pct      // "n/a") | — |",
+            "| Tokens median         | \(.before_summary.tokens_median)     | \(.after_summary.tokens_median)     | \(.deltas.tokens_median_pct     // "n/a") | \(if .gates.tokens_within_limit then "PASS" else "FAIL" end) |"
+        '
+    fi
+    exit 0
+fi
+
+# =============================================================================
+# MEASUREMENT MODE
+# =============================================================================
+
+[[ -n "$LOGS_DIR" ]] || { printf 'ERROR: --logs-dir is required\n' >&2; exit 1; }
+[[ -d "$LOGS_DIR" ]] || { printf 'ERROR: --logs-dir not found: %s\n' "$LOGS_DIR" >&2; exit 1; }
+
+# Discover metrics.json files (bash 3.2 compatible — no mapfile)
+METRICS_FILES=()
+while IFS= read -r _f; do
+    [[ -n "$_f" ]] && METRICS_FILES+=("$_f")
+done < <(find "$LOGS_DIR" -mindepth 2 -maxdepth 3 -name metrics.json -type f 2>/dev/null | sort)
+
+if [[ "$LIMIT" -gt 0 && "${#METRICS_FILES[@]}" -gt "$LIMIT" ]]; then
+    _start=$(( ${#METRICS_FILES[@]} - LIMIT ))
+    METRICS_FILES=("${METRICS_FILES[@]:$_start}")
+fi
+
+if [[ "${#METRICS_FILES[@]}" -eq 0 ]]; then
+    printf 'ERROR: no metrics.json files found under %s\n' "$LOGS_DIR" >&2
+    exit 1
+fi
+
+# Sum tokens from transcripts whose cwd matches the issue's log directory
+# (or any descendant path, e.g. worktrees/task-N).
+#
+# Transcripts in ~/.claude/projects/ are organized by directory whose name is
+# the cwd with `/` replaced by `-` (e.g. /a/b/c → -a-b-c). To avoid loading all
+# 10k+ transcript files, we pre-filter by parent-dir name; if that yields
+# nothing (e.g. test fixtures with arbitrary names), we fall back to scanning
+# all transcripts under TRANSCRIPTS_DIR. We always verify the cwd field inside
+# each record matches log_dir (or a descendant).
+sum_tokens_for_issue() {
+    local log_dir="$1"
+    local empty='{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"sessions":0}'
+
+    if [[ ! -d "$TRANSCRIPTS_DIR" ]]; then
+        printf '%s' "$empty"; return
+    fi
+
+    # Mangled directory prefix used by ~/.claude/projects/.
+    local prefix="${log_dir//\//-}"
+
+    local files=()
+    while IFS= read -r _f; do
+        [[ -n "$_f" ]] && files+=("$_f")
+    done < <(find "$TRANSCRIPTS_DIR" -name '*.jsonl' -type f \
+                  -path "*${prefix}*" 2>/dev/null)
+
+    # Fallback: small test fixtures often don't follow the mangled-name scheme.
+    # If the prefix filter found nothing, scan all and rely on cwd verification.
+    if [[ "${#files[@]}" -eq 0 ]]; then
+        while IFS= read -r _f; do
+            [[ -n "$_f" ]] && files+=("$_f")
+        done < <(find "$TRANSCRIPTS_DIR" -name '*.jsonl' -type f 2>/dev/null)
+    fi
+
+    if [[ "${#files[@]}" -eq 0 ]]; then
+        printf '%s' "$empty"; return
+    fi
+
+    # Stream-process per file, verifying cwd in each record. Avoids loading
+    # everything into a single jq slurp.
+    local sessions=0
+    local seen_session
+    local stream_output
+    stream_output=$(for f in "${files[@]}"; do
+        jq -c --arg root "$log_dir" '
+            select(.cwd != null and .message.usage != null
+                   and (.cwd == $root or (.cwd | startswith($root + "/"))))
+            | .message.usage
+            | {input_tokens: (.input_tokens // 0),
+               output_tokens: (.output_tokens // 0),
+               cache_creation_input_tokens: (.cache_creation_input_tokens // 0),
+               cache_read_input_tokens: (.cache_read_input_tokens // 0)}' \
+            "$f" 2>/dev/null \
+        && { seen_session=1; printf '%s\n' "__SESSION__"; }
+    done)
+
+    sessions=$(printf '%s\n' "$stream_output" | grep -c '^__SESSION__$' || true)
+    local records
+    records=$(printf '%s\n' "$stream_output" | grep -v '^__SESSION__$')
+
+    if [[ -z "$records" ]]; then
+        printf '{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"sessions":%d}' "$sessions"
+        return
+    fi
+
+    local agg
+    agg=$(printf '%s\n' "$records" | jq -s --argjson n "$sessions" '
+        {
+            input_tokens:               (map(.input_tokens               // 0) | add // 0),
+            output_tokens:              (map(.output_tokens              // 0) | add // 0),
+            cache_creation_input_tokens:(map(.cache_creation_input_tokens // 0) | add // 0),
+            cache_read_input_tokens:    (map(.cache_read_input_tokens     // 0) | add // 0),
+            sessions: $n
+        }')
+    if [[ -n "$agg" ]]; then
+        printf '%s' "$agg"
+    else
+        printf '%s' "$empty"
+    fi
+}
+
+# Build per-issue rows
+ISSUE_ROWS=()
+for mf in "${METRICS_FILES[@]}"; do
+    log_dir="$(dirname "$mf")"
+    issue=$(jq -r '.issue // empty' "$mf")
+    duration=$(jq -r '.total_duration_seconds // 0' "$mf")
+    started=$(jq -r '.started_at // empty' "$mf")
+    completed=$(jq -r '.completed_at // empty' "$mf")
+    state=$(jq -r '.state // empty' "$mf")
+
+    [[ -n "$issue" ]] || continue
+
+    tokens_json=$(sum_tokens_for_issue "$log_dir")
+
+    row=$(jq -n \
+        --arg issue "$issue" \
+        --arg log_dir "$log_dir" \
+        --arg started "$started" \
+        --arg completed "$completed" \
+        --arg state "$state" \
+        --argjson duration "$duration" \
+        --argjson tok "$tokens_json" \
+        '{
+            issue: $issue,
+            log_dir: $log_dir,
+            state: $state,
+            started_at: $started,
+            completed_at: $completed,
+            wall_clock_seconds: $duration,
+            input_tokens:                $tok.input_tokens,
+            output_tokens:               $tok.output_tokens,
+            cache_creation_input_tokens: $tok.cache_creation_input_tokens,
+            cache_read_input_tokens:     $tok.cache_read_input_tokens,
+            transcript_sessions:         $tok.sessions,
+            total_tokens: ($tok.input_tokens + $tok.output_tokens
+                          + $tok.cache_creation_input_tokens
+                          + $tok.cache_read_input_tokens)
+         }')
+    ISSUE_ROWS+=("$row")
+done
+
+# Aggregate summary
+ALL_ROWS_JSON=$(printf '%s\n' "${ISSUE_ROWS[@]}" | jq -s '.')
+
+SUMMARY=$(printf '%s' "$ALL_ROWS_JSON" | jq '
+    def median: sort | if length == 0 then 0
+        elif length % 2 == 1 then .[length/2|floor]
+        else ((.[length/2 - 1] + .[length/2]) / 2 | floor) end;
+
+    {
+        count: length,
+        wall_clock_total:  ([.[].wall_clock_seconds] | add // 0),
+        wall_clock_median: ([.[].wall_clock_seconds] | median),
+        tokens_total:      ([.[].total_tokens]       | add // 0),
+        tokens_median:     ([.[].total_tokens]       | median),
+        input_tokens_total:  ([.[].input_tokens]                | add // 0),
+        output_tokens_total: ([.[].output_tokens]               | add // 0),
+        cache_creation_total:([.[].cache_creation_input_tokens] | add // 0),
+        cache_read_total:    ([.[].cache_read_input_tokens]     | add // 0)
+    }
+')
+
+REPORT=$(jq -n \
+    --arg label "$LABEL" \
+    --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg logs_dir "$LOGS_DIR" \
+    --arg transcripts_dir "$TRANSCRIPTS_DIR" \
+    --argjson issues "$ALL_ROWS_JSON" \
+    --argjson summary "$SUMMARY" \
+    '{
+        label: (if $label == "" then null else $label end),
+        generated_at: $generated_at,
+        logs_dir: $logs_dir,
+        transcripts_dir: $transcripts_dir,
+        summary: $summary,
+        issues: $issues
+     }')
+
+if [[ "$FORMAT" = "json" ]]; then
+    printf '%s\n' "$REPORT"
+    exit 0
+fi
+
+# Markdown output
+{
+    label_disp=$(printf '%s' "$REPORT" | jq -r '.label // "unlabeled"')
+    printf '## Canary measurement: %s\n\n' "$label_disp"
+    printf 'Generated: %s\n' "$(printf '%s' "$REPORT" | jq -r '.generated_at')"
+    printf 'Logs dir: `%s`\n' "$(printf '%s' "$REPORT" | jq -r '.logs_dir')"
+    printf 'Issues: %s\n\n' "$(printf '%s' "$REPORT" | jq -r '.summary.count')"
+
+    printf '### Per-issue\n\n'
+    printf '| Issue | State | Wall-clock (s) | Total tokens | Input | Output | Cache create | Cache read | Sessions |\n'
+    printf '|---|---|---:|---:|---:|---:|---:|---:|---:|\n'
+    printf '%s' "$REPORT" | jq -r '.issues[] |
+        "| \(.issue) | \(.state // "?") | \(.wall_clock_seconds) | \(.total_tokens) | \(.input_tokens) | \(.output_tokens) | \(.cache_creation_input_tokens) | \(.cache_read_input_tokens) | \(.transcript_sessions) |"'
+
+    printf '\n### Summary\n\n'
+    printf '| Metric | Value |\n|---|---:|\n'
+    printf '%s' "$REPORT" | jq -r '.summary |
+        "| Issues counted | \(.count) |",
+        "| Wall-clock total (s) | \(.wall_clock_total) |",
+        "| Median wall-clock (s) | \(.wall_clock_median) |",
+        "| Tokens total | \(.tokens_total) |",
+        "| Median tokens | \(.tokens_median) |",
+        "| Input tokens total | \(.input_tokens_total) |",
+        "| Output tokens total | \(.output_tokens_total) |",
+        "| Cache-creation tokens | \(.cache_creation_total) |",
+        "| Cache-read tokens | \(.cache_read_total) |"'
+}

--- a/.claude/scripts/decide-action.sh
+++ b/.claude/scripts/decide-action.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+#
+# decide-action.sh — glue between orchestrator and escalation-policy skill
+#
+# Usage: decide-action.sh <stage_result_json> <history_json>
+#
+# Routes stage completion by composing two specialist decisions:
+#   - decide-retry.sh         (retry-policy skill)    — retry vs escalate vs bail
+#   - decide-model-fallback.sh (model-fallback skill) — next model on escalate
+#
+# Falls back to an inline bash decision tree on composition failure or when
+# ESCALATION_POLICY_BACKEND=bash.
+#
+# Environment:
+#   ESCALATION_POLICY_BACKEND — set to "bash" to bypass composition and use
+#                               the inline decision tree directly
+#   RETRY_POLICY_BACKEND      — forwarded to decide-retry.sh (default: bash)
+#   MODEL_FALLBACK_BACKEND    — forwarded to decide-model-fallback.sh
+#                               (default: bash)
+#
+# Output (stdout):
+#   {"action":"<accept|escalate|bail|retry_same>",
+#    "model":"<tier>",    # present only when action == "escalate"
+#    "reason":"<string>"}
+#
+# Exit codes:
+#   0 — action decided (composition or bash fallback)
+#   1 — bad arguments
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 1
+}
+
+# ---------------------------------------------------------------------------
+# _next_model <model>
+# Print the next escalation tier.  haiku→sonnet, sonnet/other→opus.
+# Used by _bash_decide; model selection for the composition path is
+# delegated to decide-model-fallback.sh.
+# ---------------------------------------------------------------------------
+_next_model() {
+	local model="$1"
+	case "$model" in
+		haiku)  printf 'sonnet' ;;
+		sonnet) printf 'opus'   ;;
+		*)      printf 'opus'   ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# _bash_decide <stage_result_json> <history_json>
+# Inline decision tree matching escalation-policy SKILL.md.
+# Prints action JSON to stdout; never calls external scripts.
+# ---------------------------------------------------------------------------
+_bash_decide() {
+	local stage_result="$1"
+	local history="$2"
+
+	local status error_kind model
+	status=$(printf '%s' "$stage_result" | jq -r '.status')
+	error_kind=$(printf '%s' "$stage_result" | jq -r '.error_kind')
+	model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+
+	# success at top level → accept regardless of .output.status presence
+	if [[ "$status" == "success" ]]; then
+		printf '%s\n' \
+			'{"action":"accept","reason":"stage completed successfully"}'
+		return 0
+	fi
+
+	# unrecoverable configuration or permission error → bail
+	if [[ "$error_kind" == "permission_denied" || \
+	      "$error_kind" == "schema_not_found" ]]; then
+		printf \
+			'{"action":"bail","reason":"%s: unrecoverable error"}\n' \
+			"$error_kind"
+		return 0
+	fi
+
+	# explicitly flagged as ceiling-exhausted → bail
+	if [[ "$error_kind" == "max_turns_exhausted_at_ceiling" ]]; then
+		printf '%s\n' \
+			'{"action":"bail","reason":"max_turns_exhausted_at_ceiling: already at opus ceiling"}'
+		return 0
+	fi
+
+	# quality_stall → escalate, or bail if already at opus ceiling
+	if [[ "$error_kind" == "quality_stall" ]]; then
+		if [[ "$model" == "opus" ]]; then
+			printf '%s\n' \
+				'{"action":"bail","reason":"quality_stall: already at opus ceiling"}'
+		else
+			local next_model
+			next_model=$(_next_model "$model")
+			printf '{"action":"escalate","model":"%s","reason":"quality_stall: escalating from %s to %s"}\n' \
+				"$next_model" "$model" "$next_model"
+		fi
+		return 0
+	fi
+
+	# double_timeout → escalate, or bail if already at opus ceiling
+	if [[ "$error_kind" == "double_timeout" ]]; then
+		if [[ "$model" == "opus" ]]; then
+			printf '%s\n' \
+				'{"action":"bail","reason":"double_timeout"}'
+		else
+			local next_model
+			next_model=$(_next_model "$model")
+			printf '{"action":"escalate","model":"%s","reason":"double_timeout"}\n' \
+				"$next_model"
+		fi
+		return 0
+	fi
+
+	# already at opus → bail (cannot escalate further)
+	if [[ "$model" == "opus" ]]; then
+		printf '%s\n' \
+			'{"action":"bail","reason":"at opus ceiling: cannot escalate further"}'
+		return 0
+	fi
+
+	# rate_limit + no prior attempt at same model → retry_same
+	if [[ "$error_kind" == "rate_limit" ]]; then
+		local prior_count
+		prior_count=$(printf '%s' "$history" | \
+			jq --arg m "$model" \
+			   '[.[] | select(.from_model == $m)] | length')
+		if (( prior_count == 0 )); then
+			printf '%s\n' \
+				'{"action":"retry_same","reason":"rate_limit: transient throttle, retrying with same model"}'
+			return 0
+		fi
+	fi
+
+	# default: escalate to next tier
+	local next_model reason
+	next_model=$(_next_model "$model")
+	reason="${error_kind:-unknown}: escalating from $model to $next_model"
+	printf '{"action":"escalate","model":"%s","reason":"%s"}\n' \
+		"$next_model" "$reason"
+}
+
+# ---------------------------------------------------------------------------
+# _valid_retry_schema <json>
+# Return 0 if json has a valid retry-policy output schema.
+# ---------------------------------------------------------------------------
+_valid_retry_schema() {
+	local json="$1"
+	local action reason
+	action=$(printf '%s' "$json" | jq -r '.action // empty' 2>/dev/null)
+	reason=$(printf '%s' "$json" | jq -r '.reason // empty' 2>/dev/null)
+	case "$action" in
+		retry|escalate|bail) ;;
+		*) return 1 ;;
+	esac
+	[[ -n "$reason" ]]
+}
+
+# ---------------------------------------------------------------------------
+# _valid_fallback_schema <json>
+# Return 0 if json has a valid model-fallback output schema.
+# Uses != null rather than // empty to handle at_ceiling=false correctly:
+# jq's // operator triggers on false as well as null.
+# ---------------------------------------------------------------------------
+_valid_fallback_schema() {
+	local json="$1"
+	printf '%s' "$json" | \
+		jq -e '.at_ceiling != null' >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# _compose_decide <stage_result_json> <history_json>
+# Delegate retry decisions to decide-retry.sh (retry-policy skill) and
+# model upgrade decisions to decide-model-fallback.sh (model-fallback skill).
+# Falls back to _bash_decide on composition failure.
+# ---------------------------------------------------------------------------
+_compose_decide() {
+	local stage_result="$1"
+	local history="$2"
+
+	local status error_kind model
+	status=$(printf '%s' "$stage_result" | jq -r '.status')
+	error_kind=$(printf '%s' "$stage_result" | jq -r '.error_kind')
+	model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+
+	# success at top level → accept regardless of .output.status presence
+	if [[ "$status" == "success" ]]; then
+		printf '%s\n' \
+			'{"action":"accept","reason":"stage completed successfully"}'
+		return 0
+	fi
+
+	# Derive retry_count from escalation history — count prior same-model
+	# attempts recorded as from_model entries.
+	local retry_count
+	retry_count=$(printf '%s' "$history" | \
+		jq --arg m "$model" \
+		   '[.[] | select(.from_model == $m)] | length')
+
+	# Delegate retry decision to decide-retry.sh (retry-policy skill).
+	# Escalation history lacks per-error-kind records; pass an empty
+	# error_history array so retry-policy uses retry_count for threshold
+	# checks.  Defaults to bash backend unless RETRY_POLICY_BACKEND is set.
+	#
+	# NOTE: the inline ${RETRY_POLICY_BACKEND:-bash} default means callers
+	# MUST use `export RETRY_POLICY_BACKEND=claude` (not a bare assignment)
+	# to reach the live Claude path in decide-retry.sh.  A bare assignment
+	# (e.g. RETRY_POLICY_BACKEND=claude; decide-action.sh) without export
+	# leaves the variable unexported, so $RETRY_POLICY_BACKEND is empty
+	# inside this script and the :-bash default forces the bash path.
+	local retry_out
+	retry_out=$(
+		RETRY_POLICY_BACKEND="${RETRY_POLICY_BACKEND:-bash}" \
+		"$SCRIPT_DIR/decide-retry.sh" \
+		"$stage_result" "$retry_count" '[]' \
+		2>/dev/null
+	) || true
+
+	if ! _valid_retry_schema "$retry_out"; then
+		printf \
+			'%s: warning: retry-policy output invalid; using bash fallback\n' \
+			"$SCRIPT_NAME" >&2
+		_bash_decide "$stage_result" "$history"
+		return 0
+	fi
+
+	local retry_action
+	retry_action=$(printf '%s' "$retry_out" | jq -r '.action')
+
+	case "$retry_action" in
+		retry)
+			# retry-policy wants same-tier retry; map to retry_same
+			printf '%s' "$retry_out" | \
+				jq -c '{action:"retry_same",reason:.reason}'
+			return 0
+			;;
+		bail)
+			printf '%s' "$retry_out" | \
+				jq -c '{action:"bail",reason:.reason}'
+			return 0
+			;;
+		escalate)
+			# Delegate model selection to decide-model-fallback.sh.
+			# Defaults to bash backend unless MODEL_FALLBACK_BACKEND is set.
+			local retry_reason fallback_out
+			retry_reason=$(printf '%s' "$retry_out" | jq -r '.reason')
+			fallback_out=$(
+				MODEL_FALLBACK_BACKEND="${MODEL_FALLBACK_BACKEND:-bash}" \
+				"$SCRIPT_DIR/decide-model-fallback.sh" \
+				"$stage_result" \
+				2>/dev/null
+			) || true
+
+			if ! _valid_fallback_schema "$fallback_out"; then
+				printf \
+					'%s: warning: model-fallback output invalid; using bash fallback\n' \
+					"$SCRIPT_NAME" >&2
+				_bash_decide "$stage_result" "$history"
+				return 0
+			fi
+
+			local at_ceiling next_model fallback_reason
+			at_ceiling=$(printf '%s' "$fallback_out" \
+				| jq -r '.at_ceiling')
+			next_model=$(printf '%s' "$fallback_out" \
+				| jq -r '.next_model')
+			fallback_reason=$(printf '%s' "$fallback_out" \
+				| jq -r '.reason')
+
+			if [[ "$at_ceiling" == "true" || \
+			      "$next_model" == "null" ]]; then
+				printf '%s' "$fallback_out" | \
+					jq -c '{action:"bail",reason:.reason}'
+			else
+				jq -cn \
+					--arg model "$next_model" \
+					--arg reason "$retry_reason; $fallback_reason" \
+					'{action:"escalate",model:$model,reason:$reason}'
+			fi
+			return 0
+			;;
+		*) printf '%s: error: unexpected retry_action: %s\n' \
+			"$SCRIPT_NAME" "$retry_action" >&2; return 1 ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	[[ $# -ge 2 ]] \
+		|| die "usage: $SCRIPT_NAME <stage_result_json> <history_json>"
+
+	local stage_result="$1"
+	local history="$2"
+
+	# Kill-switch: bypass composition and use inline bash directly
+	if [[ "${ESCALATION_POLICY_BACKEND:-}" == "bash" ]]; then
+		_bash_decide "$stage_result" "$history"
+		return 0
+	fi
+
+	# Delegate to retry-policy and model-fallback skills via composition
+	_compose_decide "$stage_result" "$history"
+}
+
+main "$@"

--- a/.claude/scripts/decide-model-fallback.sh
+++ b/.claude/scripts/decide-model-fallback.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+#
+# decide-model-fallback.sh — glue between orchestrator and model-fallback
+#
+# Usage: decide-model-fallback.sh <stage_result_json>
+#
+# Given a failed stage_result, decides whether the next attempt should run
+# at a higher model tier.  Inputs are read from .model and .error_kind on
+# the stage_result; output is a JSON object describing the next-model
+# decision and whether the model ceiling has been reached.
+#
+# Environment:
+#   MODEL_FALLBACK_BACKEND — controls backend selection.
+#     "bash"   — bypass skill invocation; use inline decision tree (testing).
+#     "claude" — invoke model-fallback skill via Claude (default when unset).
+#
+# Output (stdout):
+#   {"next_model": "<tier>"|null,
+#    "at_ceiling": <bool>,
+#    "reason": "<string>"}
+#
+# Exit codes:
+#   0 — decision produced
+#   1 — bad arguments
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 1
+}
+
+# Source model-config.sh for _next_model_up().  The file uses readonly
+# arrays guarded by [[ -z "${_STAGE_PREFIXES+set}" ]], so re-sourcing in
+# the same shell is idempotent.
+# shellcheck source=./model-config.sh
+. "$SCRIPT_DIR/model-config.sh"
+
+# ---------------------------------------------------------------------------
+# _is_upgrade_trigger <error_kind>
+# Return 0 when error_kind is one of the recognised upgrade triggers, 1
+# otherwise.  Conservative by design: unknown classes do not upgrade.
+# ---------------------------------------------------------------------------
+_is_upgrade_trigger() {
+	# rate_limit is an upgrade trigger only after same-tier retry limits
+	# are met — see retry-policy.  The orchestrator is responsible for
+	# exhausting per-tier retries before calling this script.
+	case "$1" in
+		timeout|double_timeout|max_turns_exhausted|no_structured_output|\
+		structured_error|rate_limit)
+			return 0
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# _bash_model_fallback <stage_result_json>
+# Inline decision tree for the model-fallback skill.  Prints decision
+# JSON to stdout; never calls claude.
+# ---------------------------------------------------------------------------
+_bash_model_fallback() {
+	local stage_result="$1"
+
+	local model error_kind
+	model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+	error_kind=$(printf '%s' "$stage_result" \
+		| jq -r '.error_kind // "null"')
+
+	# Non-escalatable errors: a higher model cannot fix these regardless of
+	# the current tier.  Must be checked before the opus ceiling test so
+	# haiku/sonnet also return at_ceiling=true for these error kinds.
+	case "$error_kind" in
+		permission_denied|schema_not_found|\
+		max_turns_exhausted_at_ceiling)
+			local reason
+			reason="${error_kind}: non-escalatable, no model can fix this"
+			jq -nc --argjson next_model null \
+				--arg reason "$reason" \
+				--argjson at_ceiling true \
+				'{next_model: $next_model, at_ceiling: $at_ceiling, reason: $reason}'
+			return 0
+			;;
+	esac
+
+	# At ceiling: opus has no higher tier to upgrade to.
+	if [[ "$model" == "opus" ]]; then
+		local reason
+		reason="at opus ceiling: no higher tier available"
+		jq -nc --argjson next_model null \
+			--arg reason "$reason" \
+			--argjson at_ceiling true \
+			'{next_model: $next_model, at_ceiling: $at_ceiling, reason: $reason}'
+		return 0
+	fi
+
+	# Recognised upgrade trigger: bump to the next tier up.
+	if _is_upgrade_trigger "$error_kind"; then
+		local next reason
+		next=$(_next_model_up "$model")
+		reason="${error_kind}: upgrading ${model} → ${next}"
+		jq -nc --arg next_model "$next" \
+			--arg reason "$reason" \
+			--argjson at_ceiling false \
+			'{next_model: $next_model, at_ceiling: $at_ceiling, reason: $reason}'
+		return 0
+	fi
+
+	# Unrecognised error_kind: conservative no-upgrade.
+	local reason
+	reason="${error_kind}: not a recognised upgrade trigger, no-upgrade"
+	jq -nc --argjson next_model null \
+		--arg reason "$reason" \
+		--argjson at_ceiling false \
+		'{next_model: $next_model, at_ceiling: $at_ceiling, reason: $reason}'
+}
+
+# ---------------------------------------------------------------------------
+# _run_with_timeout <seconds> <command> [args...]
+# Run a command with a wall-clock timeout.  Uses GNU timeout when available;
+# falls back to direct execution on systems where timeout is not installed
+# (e.g. macOS without coreutils).
+# ---------------------------------------------------------------------------
+_run_with_timeout() {
+	local secs="$1"
+	shift
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$secs" "$@"
+	else
+		"$@"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# _claude_model_fallback <stage_result_json>
+# Live Claude skill invocation via /model-fallback.
+# Prints decision JSON to stdout; exits non-zero on invocation failure.
+# ---------------------------------------------------------------------------
+_claude_model_fallback() {
+	local stage_result="$1"
+
+	local schema_file="$SCRIPT_DIR/schemas/model-fallback-output.json"
+	local skill_file="$SCRIPT_DIR/../skills/model-fallback/SKILL.md"
+
+	if [[ ! -f "$skill_file" ]]; then
+		printf '%s: model-fallback SKILL.md not found: %s\n' \
+			"$SCRIPT_NAME" "$skill_file" >&2
+		return 1
+	fi
+	if [[ ! -f "$schema_file" ]]; then
+		printf '%s: model-fallback schema not found: %s\n' \
+			"$SCRIPT_NAME" "$schema_file" >&2
+		return 1
+	fi
+
+	local schema_compact
+	schema_compact=$(jq -c . "$schema_file" 2>&1) || {
+		printf '%s: failed to compact schema: %s\n' \
+			"$SCRIPT_NAME" "$schema_compact" >&2
+		return 1
+	}
+
+	local current_model error_kind
+	current_model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+	error_kind=$(printf '%s' "$stage_result" | jq -r '.error_kind // "null"')
+
+	local prompt
+	prompt=$(printf '/model-fallback\n\nINPUTS:\ncurrent_model: %s\nerror_kind: %s\n' \
+		"$current_model" "$error_kind")
+
+	local output rc
+	output=$(_run_with_timeout "${CLAUDE_SKILL_TIMEOUT:-120}" \
+		env -u CLAUDECODE claude -p "$prompt" \
+		--dangerously-skip-permissions \
+		--output-format json \
+		--json-schema "$schema_compact" 2>&1)
+	rc=$?
+
+	if (( rc != 0 )); then
+		printf '%s: claude invocation failed (exit %d): %s\n' \
+			"$SCRIPT_NAME" "$rc" "$output" >&2
+		return 1
+	fi
+
+	# Extract the structured payload from the claude output envelope.
+	# Mirrors sg_extract_payload() in skill-golden-lib.sh and run_stage() in
+	# implement-issue-orchestrator.sh — keep these in sync.
+	local payload
+	payload=$(printf '%s' "$output" | jq -c '
+		.structured_output
+		// (.result | if type == "string" then fromjson? else . end)
+		// .
+	' 2>/dev/null)
+
+	if [[ -z "$payload" ]] || ! printf '%s' "$payload" \
+		| jq -e 'has("next_model")' >/dev/null 2>&1; then
+		printf '%s: no valid next_model in claude output\n' \
+			"$SCRIPT_NAME" >&2
+		return 1
+	fi
+
+	printf '%s\n' "$payload"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	[[ $# -ge 1 ]] \
+		|| die "usage: $SCRIPT_NAME <stage_result_json>"
+
+	local stage_result="$1"
+
+	case "${MODEL_FALLBACK_BACKEND:-claude}" in
+		bash)
+			_bash_model_fallback "$stage_result"
+			;;
+		claude)
+			_claude_model_fallback "$stage_result" \
+				|| _bash_model_fallback "$stage_result"
+			;;
+		*)
+			die "unknown MODEL_FALLBACK_BACKEND" \
+				"'${MODEL_FALLBACK_BACKEND}'; valid values: bash, claude"
+			;;
+	esac
+}
+
+main "$@"

--- a/.claude/scripts/decide-retry.sh
+++ b/.claude/scripts/decide-retry.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+#
+# decide-retry.sh — glue between orchestrator and retry-policy skill
+#
+# Usage: decide-retry.sh <stage_result_json> <retry_count> <error_history_json>
+#
+# Applies the retry-policy skill decision tree: given a failed stage_result,
+# the number of retries already attempted at the current model tier, and the
+# per-tier error history, decides whether to retry the stage, escalate to a
+# higher tier, or bail permanently.
+#
+# Environment:
+#   RETRY_POLICY_BACKEND — unset or "claude": invoke retry-policy skill via Claude (default)
+#                          "bash": bypass Claude and use the inline decision tree (for testing)
+#
+# Output (stdout):
+#   {"action":"<retry|escalate|bail>",
+#    "reason":"<string>",
+#    "backoff_ms": N}   # present only when action==retry and error_kind==rate_limit
+#
+# Exit codes:
+#   0 — action decided (skill or bash fallback)
+#   1 — bad arguments or Claude invocation failure
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 1
+}
+
+# ---------------------------------------------------------------------------
+# _run_with_timeout <seconds> <command> [args...]
+# Run a command with a wall-clock timeout.  Uses GNU timeout when available;
+# falls back to direct execution on systems where timeout is not installed
+# (e.g. macOS without coreutils).
+# ---------------------------------------------------------------------------
+_run_with_timeout() {
+	local secs="$1"
+	shift
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$secs" "$@"
+	else
+		"$@"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# _next_model <model>
+# Print the next escalation tier.  haiku→sonnet, sonnet/other→opus.
+# ---------------------------------------------------------------------------
+_next_model() {
+	local model="$1"
+	case "$model" in
+		haiku) printf 'sonnet' ;;
+		*)     printf 'opus'   ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# _max_retries <error_kind>
+# Print the maximum same-tier retry count for the given error class.
+# ---------------------------------------------------------------------------
+_max_retries() {
+	local error_kind="$1"
+	case "$error_kind" in
+		rate_limit)           printf '3' ;;
+		no_structured_output) printf '1' ;;
+		timeout)              printf '1' ;;
+		structured_error)     printf '1' ;;
+		# Known non-retriable errors: escalate or bail immediately.
+		# Listed explicitly so new error_kinds don't silently inherit 0-retry
+		# behaviour — add an entry here when extending the error_kind enum.
+		max_turns_exhausted|quality_stall|double_timeout) printf '0' ;;
+		# Unknown error_kind: fail closed — 0 retries causes immediate bail.
+		# This prevents silent retries when the policy table has no entry for
+		# an unrecognised class.
+		*)                    printf '0' ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# _bash_retry_decide <stage_result_json> <retry_count> <error_history_json>
+# Inline decision tree matching retry-policy SKILL.md.
+# Prints action JSON to stdout; never calls claude.
+# ---------------------------------------------------------------------------
+_bash_retry_decide() {
+	local stage_result="$1"
+	local retry_count="$2"
+	local error_history="$3"
+
+	local error_kind model
+	error_kind=$(printf '%s' "$stage_result" | jq -r '.error_kind // "null"')
+	model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+
+	# Unretryable configuration/permission errors → bail immediately
+	case "$error_kind" in
+		permission_denied|schema_not_found|max_turns_exhausted_at_ceiling)
+			local reason
+			reason="${error_kind}: configuration error, retrying cannot fix this"
+			printf '{"action":"bail","reason":"%s"}\n' "$reason"
+			return 0
+			;;
+	esac
+
+	# max_turns_exhausted at non-ceiling model → escalate immediately
+	if [[ "$error_kind" == "max_turns_exhausted" ]]; then
+		if [[ "$model" == "opus" ]]; then
+			printf '%s\n' \
+				'{"action":"bail","reason":"max_turns_exhausted: at opus ceiling, cannot escalate"}'
+		else
+			local next_model
+			next_model=$(_next_model "$model")
+			printf \
+				'{"action":"escalate","reason":"max_turns_exhausted: escalating %s → %s"}\n' \
+				"$model" "$next_model"
+		fi
+		return 0
+	fi
+
+	# quality_stall at non-ceiling model → escalate immediately
+	if [[ "$error_kind" == "quality_stall" ]]; then
+		if [[ "$model" == "opus" ]]; then
+			printf '%s\n' \
+				'{"action":"bail","reason":"quality_stall: at opus ceiling, cannot escalate"}'
+		else
+			printf '%s\n' \
+				'{"action":"escalate","reason":"quality_stall: fix made no commits"}'
+		fi
+		return 0
+	fi
+
+	local max
+	max=$(_max_retries "$error_kind")
+
+	# Count prior failures of same error_kind at same model in error_history
+	local history_count
+	history_count=$(printf '%s' "$error_history" | \
+		jq --arg m "$model" --arg ek "$error_kind" \
+		   '[.[] | select(.model == $m and .error_kind == $ek)] | length')
+
+	# Threshold exceeded or history shows same error at same model
+	if (( retry_count >= max )) || (( history_count > 0 )); then
+		if [[ "$model" == "opus" ]]; then
+			local reason
+			reason="${error_kind}: retry_count=${retry_count} meets threshold"
+			reason+=" and at opus ceiling"
+			printf '{"action":"bail","reason":"%s"}\n' "$reason"
+		else
+			local next_model reason
+			next_model=$(_next_model "$model")
+			reason="${error_kind}: retry_count=${retry_count} meets threshold"
+			reason+="; escalating ${model} → ${next_model}"
+			printf '{"action":"escalate","reason":"%s"}\n' "$reason"
+		fi
+		return 0
+	fi
+
+	# Retry — include backoff_ms for rate_limit errors
+	if [[ "$error_kind" == "rate_limit" ]]; then
+		local backoff_ms
+		backoff_ms=$(( 30000 * (1 << retry_count) ))
+		if (( backoff_ms > 120000 )); then
+			backoff_ms=120000
+		fi
+		local reason
+		reason="rate_limit: transient throttle, retry_count=${retry_count}"
+		reason+=", waiting ${backoff_ms}ms"
+		printf '{"action":"retry","reason":"%s","backoff_ms":%d}\n' \
+			"$reason" "$backoff_ms"
+	else
+		local reason
+		reason="${error_kind}: first retry at ${model}, retry_count=${retry_count}"
+		printf '{"action":"retry","reason":"%s"}\n' "$reason"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# _claude_retry_decide <stage_result_json> <retry_count> <error_history_json>
+# Live Claude skill invocation via /retry-policy.
+# Prints action JSON to stdout; exits non-zero on invocation failure.
+# ---------------------------------------------------------------------------
+_claude_retry_decide() {
+	local stage_result="$1"
+	local retry_count="$2"
+	local error_history="$3"
+
+	local schema_file="$SCRIPT_DIR/schemas/retry-policy.json"
+	local skill_file="$SCRIPT_DIR/../skills/retry-policy/SKILL.md"
+
+	if [[ ! -f "$skill_file" ]]; then
+		printf '%s: retry-policy SKILL.md not found: %s\n' \
+			"$SCRIPT_NAME" "$skill_file" >&2
+		return 1
+	fi
+	if [[ ! -f "$schema_file" ]]; then
+		printf '%s: retry-policy schema not found: %s\n' \
+			"$SCRIPT_NAME" "$schema_file" >&2
+		return 1
+	fi
+
+	local schema_compact
+	schema_compact=$(jq -c . "$schema_file" 2>&1) || {
+		printf '%s: failed to compact schema: %s\n' "$SCRIPT_NAME" "$schema_compact" >&2
+		return 1
+	}
+
+	local prompt
+	prompt=$(printf '/retry-policy\n\nINPUTS:\nstage_result: %s\nretry_count: %s\nerror_history: %s\n' \
+		"$stage_result" "$retry_count" "$error_history")
+
+	local output rc
+	output=$(_run_with_timeout "${CLAUDE_SKILL_TIMEOUT:-120}" \
+		env -u CLAUDECODE claude -p "$prompt" \
+		--dangerously-skip-permissions \
+		--output-format json \
+		--json-schema "$schema_compact" 2>&1)
+	rc=$?
+
+	if (( rc != 0 )); then
+		printf '%s: claude invocation failed (exit %d): %s\n' \
+			"$SCRIPT_NAME" "$rc" "$output" >&2
+		return 1
+	fi
+
+	# Extract the structured payload from the claude output envelope.
+	# Mirrors sg_extract_payload() in skill-golden-lib.sh and run_stage() in
+	# implement-issue-orchestrator.sh — keep these in sync.
+	local payload
+	payload=$(printf '%s' "$output" | jq -c '
+		.structured_output
+		// (.result | if type == "string" then fromjson? else . end)
+		// .
+	' 2>/dev/null)
+
+	if [[ -z "$payload" ]] || ! printf '%s' "$payload" \
+		| jq -e '.action' >/dev/null 2>&1; then
+		printf '%s: no valid action in claude output\n' "$SCRIPT_NAME" >&2
+		return 1
+	fi
+
+	printf '%s\n' "$payload"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	[[ $# -ge 3 ]] || die \
+		"usage: $SCRIPT_NAME <stage_result_json> <retry_count> <error_history_json>"
+
+	local stage_result="$1"
+	local retry_count="$2"
+	local error_history="$3"
+
+	if [[ "${RETRY_POLICY_BACKEND:-}" == "bash" ]]; then
+		_bash_retry_decide "$stage_result" "$retry_count" "$error_history"
+		return 0
+	fi
+
+	_claude_retry_decide "$stage_result" "$retry_count" "$error_history"
+}
+
+main "$@"

--- a/.claude/scripts/event-emit.sh
+++ b/.claude/scripts/event-emit.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# event-emit.sh — Append one structured JSON event to the run's event stream
+#
+# Usage: event-emit.sh '<json-event>'
+#
+# Validates the JSON event against schemas/pipeline-event.json using jq,
+# then appends it as one JSONL line to ${LOG_DIR}/events.jsonl.
+# Uses flock(1) for concurrent-safe writes; falls back to mkdir-based
+# advisory locking when flock is unavailable (e.g. macOS without
+# util-linux).
+#
+# Environment:
+#   LOG_DIR   Directory where events.jsonl lives (required)
+#
+# Exit codes:
+#   0   Event appended successfully
+#   1   Schema validation failed (event NOT appended)
+#   2   Usage / argument error
+#   3   Environment / system error (LOG_DIR unset, unwritable, lock timeout)
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly SCHEMA_FILE="${SCRIPT_DIR}/schemas/pipeline-event.json"
+
+_err() {
+	printf '%s: %s\n' "$SCRIPT_NAME" "$*" >&2
+}
+
+_validate_json() {
+	local json="$1"
+	if ! jq -e . <<< "$json" > /dev/null 2>&1; then
+		_err "event is not valid JSON"
+		return 1
+	fi
+}
+
+_check_required() {
+	local event="$1" schema="$2"
+	local -a missing=()
+	while IFS= read -r field; do
+		[[ -n "$field" ]] && missing+=("$field")
+	done < <(jq -r --argjson ev "$event" \
+		'.required[]? | select(in($ev) | not)' \
+		<<< "$schema" 2>/dev/null)
+	if (( ${#missing[@]} > 0 )); then
+		_err "schema validation failed: missing required field(s): ${missing[*]}"
+		return 1
+	fi
+}
+
+_check_event_enum() {
+	local event="$1" schema="$2"
+	local value in_enum
+
+	value=$(jq -r '.event // empty' <<< "$event")
+	[[ -z "$value" ]] && return 0  # absent — caught by _check_required
+
+	in_enum=$(jq -r \
+		--arg v "$value" \
+		'.properties.event.enum
+		| if . != null then (index($v) != null) else true end' \
+		<<< "$schema" 2>/dev/null)
+
+	if [[ "$in_enum" != "true" ]]; then
+		_err "schema validation failed: \"event\" value \"$value\" not in enum"
+		return 1
+	fi
+}
+
+_check_oneof_required() {
+	local event="$1" schema="$2"
+	local event_type
+	event_type=$(jq -r '.event // empty' <<< "$event")
+	[[ -z "$event_type" ]] && return 0  # absent — caught by _check_required
+
+	local -a missing=()
+	while IFS= read -r field; do
+		[[ -n "$field" ]] && missing+=("$field")
+	done < <(jq -r --argjson ev "$event" --arg et "$event_type" \
+		'.oneOf[]?
+		| select(.properties.event.const == $et)
+		| .required[]?
+		| select(in($ev) | not)' \
+		<<< "$schema" 2>/dev/null)
+
+	if (( ${#missing[@]} > 0 )); then
+		_err "schema validation failed: \"$event_type\" event" \
+			"missing required field(s): ${missing[*]}"
+		return 1
+	fi
+}
+
+validate_event() {
+	local event="$1"
+
+	_validate_json "$event" || return 1
+
+	if [[ ! -f "$SCHEMA_FILE" ]]; then
+		_err "warning: schema not found at $SCHEMA_FILE;" \
+			"skipping deep validation"
+		return 0
+	fi
+
+	local schema
+	schema=$(< "$SCHEMA_FILE")
+	_check_required "$event" "$schema" || return 1
+	_check_event_enum "$event" "$schema" || return 1
+	_check_oneof_required "$event" "$schema" || return 1
+}
+
+_mkdir_locked_append() {
+	local file="$1"
+	local data="$2"
+	local lockdir="${file}.lock"
+	local pidfile="${lockdir}/pid"
+	local attempts=0
+
+	while ! mkdir "$lockdir" 2>/dev/null; do
+		if [[ -f "$pidfile" ]]; then
+			local lock_pid
+			lock_pid=$(cat "$pidfile" 2>/dev/null)
+			if [[ -n "$lock_pid" ]] \
+				&& ! kill -0 "$lock_pid" 2>/dev/null; then
+				rm -rf "$lockdir" 2>/dev/null || true
+				continue
+			fi
+		fi
+
+		if (( attempts >= 10 )); then
+			_err "timed out waiting for lock on $file"
+			return 1
+		fi
+		sleep 1
+		(( attempts++ )) || true
+	done
+
+	# Record our PID so stale-lock cleanup works if this process dies
+	printf '%d\n' "$$" > "$pidfile" 2>/dev/null || true
+
+	printf '%s\n' "$data" >> "$file"
+	local rc=$?
+	rm -rf "$lockdir" 2>/dev/null || true
+	return $rc
+}
+
+append_event() {
+	local event="$1"
+	local events_file="${LOG_DIR}/events.jsonl"
+
+	if ! mkdir -p "$LOG_DIR" 2>/dev/null; then
+		_err "cannot create directory: $LOG_DIR"
+		return 3
+	fi
+
+	if command -v flock > /dev/null 2>&1; then
+		(
+			flock -x -w 10 9 || {
+				_err "timed out waiting for lock on $events_file"
+				exit 1
+			}
+			printf '%s\n' "$event" >&9
+		) 9>> "$events_file"
+	else
+		# flock unavailable (e.g. macOS without util-linux)
+		_mkdir_locked_append "$events_file" "$event"
+	fi
+}
+
+main() {
+	if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+		cat <<EOF
+Usage: $SCRIPT_NAME '<json-event>'
+
+Validate a JSON event against the pipeline-event schema and append it as
+one JSONL line to \${LOG_DIR}/events.jsonl under flock.
+
+Environment:
+  LOG_DIR   Directory where events.jsonl lives (required)
+
+Exit codes:
+  0   Event appended successfully
+  1   Schema validation failed
+  2   Usage / argument error
+  3   Environment / system error
+EOF
+		return 0
+	fi
+
+	if [[ $# -ne 1 ]]; then
+		_err "expected 1 argument, got $#"
+		_err "Usage: $SCRIPT_NAME '<json-event>'"
+		return 2
+	fi
+
+	local event="$1"
+
+	if [[ -z "${LOG_DIR:-}" ]]; then
+		_err "LOG_DIR is not set"
+		return 3
+	fi
+
+	validate_event "$event" || return 1
+	append_event "$event" || return 3
+}
+
+main "$@"

--- a/.claude/scripts/feedback-record.sh
+++ b/.claude/scripts/feedback-record.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# feedback-record.sh
+# Append a structured JSONL feedback record to logs/feedback/<kind>.jsonl
+#
+# Invoked by the pipeline-feedback skill to record structured observations
+# about classification or routing errors for offline analysis.
+#
+# Usage:
+#   ./feedback-record.sh --kind <kind> --issue <issue> --observed <text> \
+#       --expected <text> [--evidence <path>] [--notes <text>]
+#
+# Required:
+#   --kind      One of: triage_misclassification prompt_regression
+#               criterion_drift agent_misroute escalation_loop
+#   --issue     Issue number or identifier (string)
+#   --observed  What the pipeline actually did
+#   --expected  What the pipeline should have done
+#
+# Optional:
+#   --evidence  Relative path to a supporting log or artifact
+#   --notes     Free-form context or reproduction steps
+#
+# Output:
+#   logs/feedback/<kind>.jsonl  — one JSONL line appended per unique record
+#
+# Exit codes:
+#   0 - Success (record appended, or duplicate skipped within 60s window)
+#   1 - Validation failure (invalid kind, missing required field, write error)
+#
+
+set -euo pipefail
+
+# =============================================================================
+# CONSTANTS
+# =============================================================================
+
+readonly -a VALID_KINDS=(
+	triage_misclassification
+	prompt_regression
+	criterion_drift
+	agent_misroute
+	escalation_loop
+)
+
+readonly IDEMPOTENT_WINDOW=60
+
+# Schema file — used for jq validation before append
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+	SCHEMA_FILE="${CLAUDE_PROJECT_DIR}/.claude/scripts/schemas/pipeline-feedback.json"
+else
+	SCHEMA_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/schemas/pipeline-feedback.json"
+fi
+readonly SCHEMA_FILE
+
+# =============================================================================
+# ARGUMENT PARSING
+# =============================================================================
+
+KIND=""
+ISSUE=""
+OBSERVED=""
+EXPECTED=""
+EVIDENCE=""
+NOTES=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--kind)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			KIND="$2"
+			shift 2
+			;;
+		--issue)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			ISSUE="$2"
+			shift 2
+			;;
+		--observed)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			OBSERVED="$2"
+			shift 2
+			;;
+		--expected)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			EXPECTED="$2"
+			shift 2
+			;;
+		--evidence)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			EVIDENCE="$2"
+			shift 2
+			;;
+		--notes)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			NOTES="$2"
+			shift 2
+			;;
+		*)
+			printf 'ERROR: Unknown option: %s\n' "$1" >&2
+			exit 1
+			;;
+	esac
+done
+
+# =============================================================================
+# VALIDATION
+# =============================================================================
+
+if [[ -z "$KIND" ]]; then
+	printf 'ERROR: --kind is required\n' >&2
+	exit 1
+fi
+
+if [[ -z "$ISSUE" ]]; then
+	printf 'ERROR: --issue is required\n' >&2
+	exit 1
+fi
+
+if [[ -z "$OBSERVED" ]]; then
+	printf 'ERROR: --observed is required\n' >&2
+	exit 1
+fi
+
+if [[ -z "$EXPECTED" ]]; then
+	printf 'ERROR: --expected is required\n' >&2
+	exit 1
+fi
+
+# Validate kind against enum
+kind_valid=false
+for k in "${VALID_KINDS[@]}"; do
+	if [[ "$KIND" == "$k" ]]; then
+		kind_valid=true
+		break
+	fi
+done
+
+if [[ "$kind_valid" != "true" ]]; then
+	printf 'ERROR: Invalid kind "%s". Valid kinds: %s\n' \
+		"$KIND" "${VALID_KINDS[*]}" >&2
+	exit 1
+fi
+
+# =============================================================================
+# BUILD RECORD
+# =============================================================================
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+JSONL_DIR="logs/feedback"
+JSONL_FILE="${JSONL_DIR}/${KIND}.jsonl"
+
+# Build compact JSON record; omit optional fields if empty
+RECORD=$(jq -cn \
+	--arg ts       "$TIMESTAMP" \
+	--arg kind     "$KIND" \
+	--arg issue    "$ISSUE" \
+	--arg observed "$OBSERVED" \
+	--arg expected "$EXPECTED" \
+	--arg evidence "$EVIDENCE" \
+	--arg notes    "$NOTES" \
+	'{
+		timestamp: $ts,
+		kind:      $kind,
+		issue:     $issue,
+		observed:  $observed,
+		expected:  $expected
+	}
+	+ (if $evidence != "" then {evidence_path: $evidence} else {} end)
+	+ (if $notes    != "" then {notes: $notes}            else {} end)')
+
+# =============================================================================
+# SCHEMA VALIDATION
+# =============================================================================
+
+if [[ -f "$SCHEMA_FILE" ]]; then
+	while IFS= read -r _req_field; do
+		_field_val=$(printf '%s' "$RECORD" | jq -r ".${_req_field} // empty" 2>/dev/null)
+		if [[ -z "$_field_val" ]]; then
+			printf 'ERROR: schema validation failed — required field "%s" missing or empty\n' \
+				"$_req_field" >&2
+			exit 1
+		fi
+	done < <(jq -r '.required[]' "$SCHEMA_FILE" 2>/dev/null)
+fi
+
+# =============================================================================
+# IDEMPOTENCY CHECK
+# =============================================================================
+
+if [[ -f "$JSONL_FILE" ]]; then
+	now_epoch=$(date -u +%s)
+
+	while IFS= read -r existing; do
+		[[ -n "$existing" ]] || continue
+
+		rec_kind=$(printf '%s' "$existing" | jq -r '.kind     // empty' 2>/dev/null)
+		rec_issue=$(printf '%s' "$existing" | jq -r '.issue    // empty' 2>/dev/null)
+		rec_observed=$(printf '%s' "$existing" | jq -r '.observed // empty' 2>/dev/null)
+		rec_expected=$(printf '%s' "$existing" | jq -r '.expected // empty' 2>/dev/null)
+		rec_ts=$(printf '%s' "$existing" | jq -r '.timestamp // empty' 2>/dev/null)
+
+		if [[ "$rec_kind"     == "$KIND"     && \
+		      "$rec_issue"    == "$ISSUE"    && \
+		      "$rec_observed" == "$OBSERVED" && \
+		      "$rec_expected" == "$EXPECTED" ]]; then
+
+			if [[ -n "$rec_ts" ]]; then
+				# Parse timestamp to epoch — GNU date first, BSD date (macOS) fallback
+				rec_epoch=$(date -u -d "$rec_ts" +%s 2>/dev/null \
+					|| date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$rec_ts" +%s 2>/dev/null \
+					|| printf '%s' '0')
+				age=$(( now_epoch - rec_epoch ))
+				if (( age >= 0 && age <= IDEMPOTENT_WINDOW )); then
+					# Duplicate within window — exit without appending
+					exit 0
+				fi
+			fi
+		fi
+	done < "$JSONL_FILE"
+fi
+
+# =============================================================================
+# APPEND RECORD
+# =============================================================================
+
+mkdir -p "$JSONL_DIR"
+printf '%s\n' "$RECORD" >> "$JSONL_FILE"

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -11,6 +11,32 @@
 #   - status.json: Real-time progress
 #   - logs/implement-issue/<timestamp>/: Per-stage logs
 #
+# Stage Execution Contract:
+#   run_stage <name> <prompt_file> [options]
+#     Runs a single pipeline stage and emits a stage_result JSON envelope on
+#     stdout (schema: schemas/stage-result.json).  Callers must capture this
+#     value and pass it to _apply_stage_action for routing — never inspect the
+#     raw exit code or attempt to parse stage output directly.
+#
+#   _apply_stage_action <stage_result> <action> [reason]
+#     The single dispatch point for all post-stage outcome handling.  The
+#     caller (run_stage) inspects the stage_result envelope (.error_kind /
+#     .output.status) to determine which action to take, then passes both the
+#     envelope and the action string as arguments — the action is NOT embedded
+#     in the stage_result envelope (schema: schemas/stage-result.json).
+#     Actions: "accept" | "bail" | "escalate" | "retry_same"
+#     All new escalation or retry logic belongs here, not in run_stage callers.
+#
+#   Typical call pattern:
+#     result=$(run_stage "implement" "$prompt_file" ...)
+#     # Caller inspects .error_kind / .output.status to decide the action:
+#     _apply_stage_action "$result" "accept"   # or "bail" / "escalate" / "retry_same"
+#
+# Triage Routing:
+#   Issue classification (fast-path vs. full pipeline) is performed by invoking
+#   the triage-classify skill via _run_triage_composition(), following the
+#   dispatch_composition(isolated=false) pattern — no filesystem writes required.
+#
 
 set -uo pipefail  # Note: not -e, we handle errors explicitly
 
@@ -25,6 +51,8 @@ source "$SCRIPT_DIR/model-config.sh"
 # model-config.sh. Sourcing is no-op when CLAUDE_USAGE_SESSION_KEY is unset
 # (graceful fallback to today's behavior — see claude-usage.sh).
 source "$SCRIPT_DIR/claude-usage.sh"
+# shellcheck source=prompts/triage-prompt.sh
+source "$SCRIPT_DIR/prompts/triage-prompt.sh"
 source "$SCRIPT_DIR/../config/platform.sh"
 PLATFORM_DIR="$SCRIPT_DIR/platform"
 
@@ -60,6 +88,13 @@ MAX_PR_REVIEW_ITERATIONS="${MAX_PR_REVIEW_ITERATIONS:-2}"
 MAX_VALIDATION_FIX_ITERATIONS="${MAX_VALIDATION_FIX_ITERATIONS:-2}"
 MAX_ORCHESTRATOR_WALL_TIME="${MAX_ORCHESTRATOR_WALL_TIME:-3600}"
 MAX_TASK_WALL_TIME_SECS="${MAX_TASK_WALL_TIME_SECS:-1800}"
+
+# Kill-switch for emergency bash fallback.  The escalation-policy skill is
+# now the default routing backend.  Set ESCALATION_POLICY_BACKEND=bash to
+# force the inline bash decision tree instead.
+#   Unset / empty  → use escalation-policy skill (skill-native default)
+#   "bash"         → always use inline bash escalation branches
+ESCALATION_POLICY_BACKEND="${ESCALATION_POLICY_BACKEND:-}"
 ORCHESTRATOR_START_EPOCH=$(date +%s)
 declare -a DEGRADED_STAGES=()
 readonly RATE_LIMIT_BUFFER=60
@@ -299,6 +334,88 @@ next_stage_log() {
 }
 
 # =============================================================================
+# STRUCTURED EVENT EMISSION
+# =============================================================================
+#
+# emit_event <event_type> [key=value ...]
+#
+# Builds a JSON envelope with ts/run_id/event/stage and forwards it to
+# event-emit.sh, which validates against schemas/pipeline-event.json and
+# appends one JSONL line to $LOG_BASE/events.jsonl under flock.
+#
+# Design notes:
+#   - Parallel to existing text logs: every text-log call site that maps to one
+#     of the 8 event types (stage_start, stage_end, escalation, retry,
+#     model_call, rate_limit_hit, schema_validation_fail, status_change) gets
+#     a parallel emit_event call.  Text logs are retained verbatim for human
+#     debugging — see issue #180.
+#   - Safe-by-default: silently no-ops when event-emit.sh is missing or
+#     LOG_BASE is unset (e.g. during early init or when the helper has not yet
+#     landed in this branch).  A schema-invalid emit exits non-zero from
+#     event-emit.sh but never crashes the orchestrator (stderr-redirected,
+#     `|| true`).
+#   - run_id is derived from the LOG_BASE basename which already encodes
+#     issue+timestamp (e.g. "issue-180-20260502-183541").
+emit_event() {
+    local event_type="$1"
+    shift
+
+    # Parallel-task safety: if the helper hasn't been added yet (sub-issue
+    # tasks land out of order), skip silently rather than break the pipeline.
+    local emit_script="$SCRIPT_DIR/event-emit.sh"
+    if [[ ! -x "$emit_script" ]]; then
+        return 0
+    fi
+
+    # Skip if LOG_BASE isn't established yet (very early init paths).
+    if [[ -z "${LOG_BASE:-}" ]]; then
+        return 0
+    fi
+
+    local run_id="${LOG_BASE##*/}"
+
+    local -a jq_args=(
+        --arg ts "$(date -Iseconds)"
+        --arg run_id "$run_id"
+        --arg event "$event_type"
+    )
+    local filter='{ts: $ts, run_id: $run_id, event: $event}'
+
+    local kv key value safe_key json_value
+    for kv in "$@"; do
+        # Support `key:=value` for JSON-typed values (numbers, booleans, null)
+        # in addition to `key=value` for strings. Required because the schema
+        # types fields like attempt/max_attempts/stage_attempt as integer.
+        if [[ "$kv" == *":="* ]]; then
+            key="${kv%%:=*}"
+            value="${kv#*:=}"
+            json_value=true
+        else
+            key="${kv%%=*}"
+            value="${kv#*=}"
+            json_value=false
+        fi
+        # Defensive: only allow alphanumeric/underscore in keys to keep the
+        # generated jq filter safe.
+        safe_key="${key//[^A-Za-z0-9_]/}"
+        if [[ -z "$safe_key" ]]; then
+            continue
+        fi
+        if $json_value; then
+            jq_args+=(--argjson "$safe_key" "$value")
+        else
+            jq_args+=(--arg "$safe_key" "$value")
+        fi
+        filter+=" | .${safe_key} = \$${safe_key}"
+    done
+
+    local event_json
+    event_json=$(jq -nc "${jq_args[@]}" "$filter" 2>/dev/null) || return 0
+
+    LOG_DIR="$LOG_BASE" "$emit_script" "$event_json" >/dev/null 2>>"$LOG_BASE/orchestrator.log" || true
+}
+
+# =============================================================================
 # STATUS FILE MANAGEMENT
 # =============================================================================
 
@@ -381,6 +498,7 @@ update_stage() {
 
 set_stage_started() {
     local stage="$1"
+    local model="${2:-}"
     jq --arg stage "$stage" \
        '.stages[$stage].started_at = (now | todate) |
         .stages[$stage].status = "in_progress" |
@@ -390,6 +508,15 @@ set_stage_started() {
         .last_update = (now | todate)' \
        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
     sync_status_to_log
+
+    # Resolve the model so the stage_start event satisfies the schema's
+    # required `model` field. If effective_model isn't usable yet, fall back
+    # to a stable placeholder so the event still validates.
+    if [[ -z "$model" ]]; then
+        model=$(effective_model "$stage" "" 2>/dev/null) || model=""
+        [[ -n "$model" ]] || model="unresolved"
+    fi
+    emit_event "stage_start" "stage=$stage" "model=$model"
 }
 
 set_stage_completed() {
@@ -400,6 +527,22 @@ set_stage_completed() {
         .last_update = (now | todate)' \
        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
     sync_status_to_log
+    # Schema enum for stage_end.status is ["success","error","rate_limit"];
+    # "completed" is the status.json column name, not the event-stream value.
+    emit_event "stage_end" "stage=$stage" "status=success"
+}
+
+set_stage_failed() {
+    local stage="$1"
+    local error_kind="$2"
+    jq --arg stage "$stage" \
+       '.stages[$stage].completed_at = (now | todate) |
+        .stages[$stage].status = "error" |
+        .state = "failed" |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+    emit_event "stage_end" "stage=$stage" "status=error" "error_kind=$error_kind"
 }
 
 record_escalation() {
@@ -416,6 +559,11 @@ record_escalation() {
         .last_update = (now | todate)' \
        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
     sync_status_to_log
+    emit_event "escalation" \
+        "stage=$stage" \
+        "from_model=$from_model" \
+        "to_model=$to_model" \
+        "reason=$reason"
 }
 
 update_task() {
@@ -454,10 +602,22 @@ set_branch_info() {
 
 set_final_state() {
     local state="$1"
+    local prev_state stage
+    # Capture the previous state and current stage BEFORE we overwrite, so the
+    # status_change event can carry from_state/to_state per schema.
+    prev_state=$(jq -r '.state // "running"' "$STATUS_FILE" 2>/dev/null) \
+        || prev_state="running"
+    stage=$(jq -r '.current_stage // "unknown"' "$STATUS_FILE" 2>/dev/null) \
+        || stage="unknown"
+
     jq --arg state "$state" \
        '.state = $state | .last_update = (now | todate)' \
        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
     sync_status_to_log
+    emit_event "status_change" \
+        "stage=$stage" \
+        "from_state=$prev_state" \
+        "to_state=$state"
 }
 
 increment_quality_iteration() {
@@ -538,6 +698,7 @@ write_task_summary_to_status() {
     jq --argjson summary "$summary" \
        '.task_summary = $summary' \
        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
 }
 
 # =============================================================================
@@ -727,15 +888,15 @@ is_stage_completed() {
 
 # Check if a stage result is a timeout error
 # Arguments:
-#   $1 - JSON string from run_stage output
+#   $1 - stage_result JSON envelope from run_stage (see schemas/stage-result.json)
 # Returns 0 if timeout, 1 if not
 is_stage_timeout() {
     local result="${1:-}"
     [[ -z "$result" ]] && return 1
-    local err_status err_type
+    local err_status err_kind
     err_status=$(printf '%s' "$result" | jq -r '.status // empty' 2>/dev/null)
-    err_type=$(printf '%s' "$result" | jq -r '.error // empty' 2>/dev/null)
-    [[ "$err_status" == "error" && "$err_type" == "timeout" ]]
+    err_kind=$(printf '%s' "$result" | jq -r '.error_kind // empty' 2>/dev/null)
+    [[ "$err_status" == "error" && "$err_kind" == "timeout" ]]
 }
 
 # Get count of completed tasks
@@ -998,6 +1159,10 @@ handle_rate_limit() {
     resume_at=$(date -Iseconds -d "+${wait_time} seconds" 2>/dev/null || date -v+${wait_time}S -Iseconds 2>/dev/null)
 
     log "Rate limit hit. Waiting ${wait_time}s until $resume_at"
+    emit_event "rate_limit_hit" \
+        "stage=${_RUN_STAGE_NAME:-}" \
+        "retry_after_seconds:=$wait_time" \
+        "resume_at=${resume_at:-}"
     sleep "$wait_time"
 }
 
@@ -1023,6 +1188,141 @@ load_skill() {
 }
 
 # =============================================================================
+# STAGE RESULT ENVELOPE
+# =============================================================================
+#
+# run_stage accumulates execution state into local variables and emits a
+# single stage_result JSON envelope (see schemas/stage-result.json) at every
+# exit point. The envelope wraps the parsed structured output under .output
+# and carries the run-level metadata callers need to make escalation
+# decisions: status, raw stdout, permission denials, resolved model,
+# error_kind, and elapsed_ms.
+#
+# Callers reach into .output.<field> for the agent's structured response
+# (e.g., .output.tasks instead of .tasks) — see AC1 of issue #178.
+
+# Get current epoch in milliseconds. EPOCHREALTIME (bash 5+) preferred;
+# python3 fallback covers macOS bash 3.2; date +%s last resort (1s resolution).
+_epoch_ms() {
+    if [[ -n "${EPOCHREALTIME:-}" ]]; then
+        local us="${EPOCHREALTIME//./}"
+        printf '%s\n' "$((us / 1000))"
+    elif command -v python3 &>/dev/null; then
+        python3 -c 'import time; print(int(time.time()*1000))'
+    else
+        printf '%s000\n' "$(date +%s)"
+    fi
+}
+
+# Extract permission_denials tool_name array from raw CLI output as a JSON
+# array. Returns "[]" when absent, malformed, or jq fails.
+_extract_denials() {
+    local raw="$1"
+    local denials
+    denials=$(printf '%s' "$raw" \
+        | jq -c '[.permission_denials[]?.tool_name // empty]' 2>/dev/null)
+    if [[ -z "$denials" || "$denials" == "null" ]]; then
+        printf '[]\n'
+    else
+        printf '%s\n' "$denials"
+    fi
+}
+
+# Emit a stage_result JSON envelope on stdout. All payload args are
+# JSON-encoded so callers can pass nested objects/arrays safely via
+# --argjson without shell-quoting hazards.
+#
+# Arguments:
+#   $1 - status:           "success" | "error" | "rate_limit"
+#   $2 - output_json:      JSON object or "null"
+#   $3 - raw:              raw stdout from CLI (string)
+#   $4 - denials_json:     JSON array of tool names
+#   $5 - model:            resolved model id (e.g. haiku|sonnet|opus)
+#   $6 - error_kind_json:  "null" or JSON-encoded string (e.g. "\"timeout\"")
+#   $7 - elapsed_ms:       integer milliseconds
+_emit_stage_result() {
+    local status="$1"
+    local output_json="$2"
+    local raw="$3"
+    local denials_json="$4"
+    local model="$5"
+    local error_kind_json="$6"
+    local elapsed_ms="$7"
+
+    jq -nc \
+        --arg status "$status" \
+        --argjson output "$output_json" \
+        --arg raw "$raw" \
+        --argjson denials "$denials_json" \
+        --arg model "$model" \
+        --argjson error_kind "$error_kind_json" \
+        --argjson elapsed_ms "$elapsed_ms" \
+        '{status: $status, output: $output, raw: $raw, denials: $denials,
+          model: $model, error_kind: $error_kind, elapsed_ms: $elapsed_ms}'
+}
+
+# Apply a stage outcome action to a stage_result envelope.
+#
+# This is the single bash entry point for stage outcome handling. Callers
+# determine which action to take (via the escalation-policy skill or the
+# inline bash decision tree), then delegate execution to this function.
+# Keeping action execution here keeps the interface uniform so tests can
+# target the action logic independently of the routing backend.
+#
+# Arguments:
+#   $1 - stage_result: JSON envelope (see schemas/stage-result.json)
+#   $2 - action:       "accept" | "bail" | "escalate" | "retry_same"
+#   $3 - reason:       (optional) human-readable reason for logging / diagnostics
+#
+# Stdout:
+#   Emits the stage_result JSON envelope unchanged; re-run and retry
+#   logic lives in run_stage, driven by the escalation-policy skill.
+#
+# Returns:
+#   0 for accept / escalate / retry_same
+#   1 for bail (signals caller that stage result is terminal)
+_apply_stage_action() {
+	local stage_result="$1"
+	local action="$2"
+	local reason="${3:-}"
+
+	case "$action" in
+		accept)
+			printf '%s\n' "$stage_result"
+			return 0
+			;;
+		bail)
+			log_error "Stage bailed: ${reason:-action=bail}"
+			set_stage_failed \
+				"${_RUN_STAGE_NAME:-unknown}" \
+				"$(jq -r '.error_kind // "bail"' <<< "$stage_result")"
+			printf '%s\n' "$stage_result"
+			return 1
+			;;
+		escalate)
+			# Emit stage_result as-is; run_stage reads the action and drives
+			# model escalation via the escalation-policy skill.
+			printf '%s\n' "$stage_result"
+			return 0
+			;;
+		retry_same)
+			# Emit stage_result as-is; run_stage reads the action and drives
+			# the retry loop (same model) via the escalation-policy skill.
+			printf '%s\n' "$stage_result"
+			return 0
+			;;
+		*)
+			log_error "_apply_stage_action: unknown action '$action'"
+			set_stage_failed \
+				"${_RUN_STAGE_NAME:-unknown}" \
+				"unknown_action"
+			printf '%s\n' "$stage_result"
+			return 1
+			;;
+	esac
+}
+
+# =============================================================================
 # STAGE RUNNERS
 # =============================================================================
 
@@ -1035,15 +1335,36 @@ run_stage() {
     local timeout_override="${6:-}"   # optional: override stage timeout (seconds)
     local model_override="${7:-}"    # optional: override model (haiku|sonnet|opus)
 
+    # Track stage in a global so handle_rate_limit() (called from inside this
+    # function) can attribute its rate_limit_hit event to the right stage.
+    _RUN_STAGE_NAME="$stage_name"
+
     local stage_log="$LOG_BASE/stages/$(next_stage_log "$stage_name")"
+
+    # Stage result accumulator — every exit point funnels through
+    # _emit_stage_result so callers receive a uniform stage_result envelope.
+    # See schemas/stage-result.json. result_model tracks the model that
+    # produced the final output (escalation paths reassign it).
+    local result_start_ms result_model=""
+    result_start_ms=$(_epoch_ms)
 
     # Validate schema file exists
     if [[ ! -f "$SCHEMA_DIR/$schema_file" ]]; then
         log_error "Schema file not found: $SCHEMA_DIR/$schema_file"
+        emit_event "schema_validation_fail" \
+            "stage=$stage_name" \
+            "reason=schema_not_found" \
+            "schema=$schema_file" \
+            "errors:=[]"
         _CONSECUTIVE_TIMEOUTS=0
         _TIMED_OUT_STAGE_NAMES=""
-        echo '{"status":"error","error":"schema not found"}'
-        return 1
+        local _sr
+        _sr=$(_emit_stage_result \
+            "error" "null" "" "[]" \
+            "$result_model" '"schema_not_found"' \
+            "$(( $(_epoch_ms) - result_start_ms ))")
+        _apply_stage_action "$_sr" "bail" "schema_not_found"
+        return $?
     fi
 
     local schema
@@ -1059,6 +1380,10 @@ run_stage() {
         model=$(effective_model "$stage_name" "$complexity")
         fallback_model=$(effective_fallback "$model")
     fi
+
+    # Track final model for stage_result envelope. Reassigned by escalation
+    # branches when they produce output via a different model.
+    result_model="$model"
 
     # Record resolved model in status.json stage entry for export_metrics()
     if [[ -f "$STATUS_FILE" ]]; then
@@ -1076,6 +1401,15 @@ run_stage() {
         log "  Complexity: $complexity"
     fi
     log "  Log: $stage_log"
+
+    emit_event "model_call" \
+        "stage=$stage_name" \
+        "model=$model" \
+        "fallback_model=$fallback_model" \
+        "agent=${agent:-default}" \
+        "schema=$schema_file" \
+        "complexity=${complexity:-}" \
+        "stage_attempt:=1"
 
     local -a agent_args=()
     if [[ -n "$agent" ]]; then
@@ -1153,8 +1487,14 @@ run_stage() {
         timeout_structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
         if [[ -n "$timeout_structured" ]]; then
             log "WARN: Stage $stage_name timed out after ${stage_timeout}s but produced structured output — using it"
-            printf '%s\n' "$timeout_structured"
-            return 0
+            local _sr
+            _sr=$(_emit_stage_result \
+                "success" "$timeout_structured" "$output" \
+                "$(_extract_denials "$output")" \
+                "$result_model" "null" \
+                "$(( $(_epoch_ms) - result_start_ms ))")
+            _apply_stage_action "$_sr" "accept"
+            return $?
         fi
 
         # Fallback: if no structured output, try .result text wrapping
@@ -1167,8 +1507,14 @@ run_stage() {
 
         if [[ -n "$timeout_fallback_result" ]]; then
             log "WARN: Stage $stage_name timed out after ${stage_timeout}s but produced .result — using fallback"
-            printf '%s\n' "$timeout_fallback_result"
-            return 0
+            local _sr
+            _sr=$(_emit_stage_result \
+                "success" "$timeout_fallback_result" "$output" \
+                "$(_extract_denials "$output")" \
+                "$result_model" "null" \
+                "$(( $(_epoch_ms) - result_start_ms ))")
+            _apply_stage_action "$_sr" "accept"
+            return $?
         fi
 
         # Retry with a 20% longer timeout before giving up
@@ -1176,6 +1522,23 @@ run_stage() {
         retry_timeout=$(( stage_timeout + stage_timeout / 5 ))
         log "WARN: Stage $stage_name timed out after ${stage_timeout}s — retrying with ${retry_timeout}s timeout"
         printf '%s\n' "=== $stage_name timeout retry (${retry_timeout}s) ===" >> "$stage_log"
+
+        emit_event "retry" \
+            "stage=$stage_name" \
+            "reason=timeout" \
+            "attempt:=2" \
+            "max_attempts:=2" \
+            "model=$model" \
+            "previous_timeout=$stage_timeout" \
+            "retry_timeout=$retry_timeout"
+        emit_event "model_call" \
+            "stage=$stage_name" \
+            "model=$model" \
+            "fallback_model=$fallback_model" \
+            "agent=${agent:-default}" \
+            "schema=$schema_file" \
+            "complexity=${complexity:-}" \
+            "stage_attempt:=2"
 
         exit_code=0
         output=$(timeout "$retry_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
@@ -1192,135 +1555,59 @@ run_stage() {
         printf '%s\n' "=== timeout retry exit code: $exit_code ===" >> "$stage_log"
 
         if (( exit_code == 124 )); then
-            # Double timeout at same model tier — escalate to next model
-            local timeout_escalated_model
-            timeout_escalated_model=$(_next_model_up "$model")
-
-            if [[ "$timeout_escalated_model" != "$model" ]]; then
-                log "WARN: Stage $stage_name timed out twice with $model — escalating to $timeout_escalated_model"
-                printf '%s\n' "=== $stage_name timeout escalation: $model → $timeout_escalated_model ===" >> "$stage_log"
-
-                record_escalation "$stage_name" "$model" "$timeout_escalated_model" "double_timeout"
-
-                local -a timeout_esc_fallback_args=()
-                local timeout_esc_fallback
-                timeout_esc_fallback=$(_next_model_up "$timeout_escalated_model")
-                if [[ "$timeout_esc_fallback" != "$timeout_escalated_model" ]]; then
-                    timeout_esc_fallback_args=(--fallback-model "$timeout_esc_fallback")
-                fi
-
-                exit_code=0
-                output=$(timeout "$retry_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
-                    ${agent_args[@]+"${agent_args[@]}"} \
-                    --model "$timeout_escalated_model" \
-                    ${timeout_esc_fallback_args[@]+"${timeout_esc_fallback_args[@]}"} \
-                    --dangerously-skip-permissions \
-                    --output-format json \
-                    --json-schema "$schema" \
-                    2>&1) || exit_code=$?
-
-                printf '%s\n' "=== $stage_name timeout escalation output ===" >> "$stage_log"
-                printf '%s\n' "$output" >> "$stage_log"
-                printf '%s\n' "=== timeout escalation exit code: $exit_code ===" >> "$stage_log"
-            else
-                log_error "Stage $stage_name timed out twice with $model (ceiling) — cannot escalate"
-                _TIMED_OUT_STAGE_NAMES="${_TIMED_OUT_STAGE_NAMES:+$_TIMED_OUT_STAGE_NAMES, }$stage_name"
-                (( _CONSECUTIVE_TIMEOUTS++ )) || true
-                if (( _CONSECUTIVE_TIMEOUTS >= 2 )); then
-                    log_warn "Cascade timeout detected: $_CONSECUTIVE_TIMEOUTS consecutive stage(s)" \
-                        "timed out: $_TIMED_OUT_STAGE_NAMES. Consider increasing timeout or reducing complexity."
-                fi
-                echo '{"status":"error","error":"timeout"}'
-                return 1
+            # Second timeout at same model tier — fall through to the
+            # consolidated decide-action.sh call below.
+            _TIMED_OUT_STAGE_NAMES="${_TIMED_OUT_STAGE_NAMES:+$_TIMED_OUT_STAGE_NAMES, }$stage_name"
+            (( _CONSECUTIVE_TIMEOUTS++ )) || true
+            if (( _CONSECUTIVE_TIMEOUTS >= 2 )); then
+                log_warn "Cascade timeout detected: $_CONSECUTIVE_TIMEOUTS consecutive stage(s)" \
+                    "timed out: $_TIMED_OUT_STAGE_NAMES. Consider increasing timeout or reducing complexity."
             fi
+            log "WARN: Stage $stage_name timed out twice with $model — deferring to decide-action.sh"
+            printf '%s\n' "=== $stage_name double timeout ===" >> "$stage_log"
         fi
     fi
 
-    # Check for max turns exhaustion — escalate to next model up and retry.
-    # CLI returns subtype:"error_max_turns" with exit code 0 and is_error:false,
-    # but no structured_output, so we detect it before the structured output check.
+    # =========================================================================
+    # CONSOLIDATED ESCALATION DECISION via decide-action.sh
+    # =========================================================================
+    # Determine error_kind from the run outcome; build a stage_result envelope;
+    # call decide-action.sh exactly once (AC1); execute the returned action.
+    # _apply_stage_action is always called with the action decide-action.sh
+    # returned (AC2).  ESCALATION_POLICY_BACKEND=bash is honoured inside
+    # decide-action.sh itself (AC3).
+
+    # Detect max-turns exhaustion
     local output_subtype
     output_subtype=$(printf '%s' "$output" | jq -r '.subtype // empty' 2>/dev/null)
-    if [[ "$output_subtype" == "error_max_turns" ]]; then
-        local escalated_model
-        escalated_model=$(effective_fallback "$model")
 
-        if [[ "$escalated_model" == "$model" ]]; then
-            # Already at ceiling (opus) — can't escalate further
-            log_error "Stage $stage_name hit max turns with $model (ceiling) — cannot escalate"
-            echo '{"status":"error","error":"max_turns_exhausted_at_ceiling"}'
-            return 1
-        fi
+    # Detect permission denials early (needed for structured-error classification)
+    # Produces a comma-joined string for human-readable log_warn messages below.
+    local _permission_denials
+    _permission_denials=$(_extract_denials "$output" \
+        | jq -r 'select(length > 0) | join(", ")' 2>/dev/null || true)
 
-        log "WARN: Stage $stage_name hit max turns with $model — escalating to $escalated_model (no turn cap)"
-        printf '%s\n' "=== $stage_name escalating: $model → $escalated_model ===" >> "$stage_log"
-
-        # Record escalation event
-        record_escalation "$stage_name" "$model" "$escalated_model" "max_turns_exhausted"
-
-        # Retry with escalated model and no --max-turns cap
-        local escalated_fallback
-        escalated_fallback=$(effective_fallback "$escalated_model")
-        local -a escalated_fallback_args=()
-        if [[ "$escalated_fallback" != "$escalated_model" ]]; then
-            escalated_fallback_args=(--fallback-model "$escalated_fallback")
-        fi
-
-        output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
-            ${agent_args[@]+"${agent_args[@]}"} \
-            --model "$escalated_model" \
-            ${escalated_fallback_args[@]+"${escalated_fallback_args[@]}"} \
-            --dangerously-skip-permissions \
-            --output-format json \
-            --json-schema "$schema" \
-            2>&1) || exit_code=$?
-
-        printf '%s\n' "=== $stage_name escalation output ===" >> "$stage_log"
-        printf '%s\n' "$output" >> "$stage_log"
-        printf '%s\n' "=== escalation exit code: $exit_code ===" >> "$stage_log"
-    fi
-
-    # Check rate limit
-    if detect_rate_limit "$output"; then
-        handle_rate_limit "$output"
-        # Retry
-        output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
-            ${agent_args[@]+"${agent_args[@]}"} \
-            --model "$model" \
-            ${fallback_args[@]+"${fallback_args[@]}"} \
-            ${turns_args[@]+"${turns_args[@]}"} \
-            --dangerously-skip-permissions \
-            --output-format json \
-            --json-schema "$schema" \
-            2>&1) || exit_code=$?
-
-        printf '%s\n' "=== $stage_name retry output ===" >> "$stage_log"
-        printf '%s\n' "$output" >> "$stage_log"
-    fi
-
-    # Extract structured output — try .structured_output first, fall back to
-    # wrapping .result text as a success payload (subagents sometimes return
-    # plain .result without matching the JSON schema)
+    # Extract structured output from the run
     local structured
     structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
 
+    # .result fallback — build (with field extraction) when .structured_output
+    # is absent but the CLI returned a text result.
+    local _fallback_result=""
     if [[ -z "$structured" ]]; then
-        # Fallback: if the CLI returned successfully (.is_error == false) and
-        # has a .result string, wrap it as a synthetic structured output
-        local fallback_result
-        fallback_result=$(printf '%s' "$output" | jq -c '
+        local _basic_fallback
+        _basic_fallback=$(printf '%s' "$output" | jq -c '
             select(.is_error == false and .result != null) |
             {status: "success", summary: .result}
         ' 2>/dev/null)
 
-        if [[ -n "$fallback_result" ]]; then
+        if [[ -n "$_basic_fallback" ]]; then
             log "WARNING: No .structured_output from $stage_name — using .result fallback"
-
-            # Field-aware recovery: extract known fields from .result text
             local result_text
             result_text=$(printf '%s' "$output" \
                 | jq -r '.result // empty' 2>/dev/null)
 
+            _fallback_result="$_basic_fallback"
             if [[ -n "$result_text" ]]; then
                 # Extract pr_number from "PR #N", "MR #N", or "!N"
                 # Deliberately omits bare "#N" — too ambiguous (issue refs,
@@ -1330,7 +1617,7 @@ run_stage() {
                 if [[ "$result_text" =~ $pr_re ]] \
                     || [[ "$result_text" =~ $bang_re ]]; then
                     local pr_num="${BASH_REMATCH[1]}"
-                    fallback_result=$(printf '%s' "$fallback_result" \
+                    _fallback_result=$(printf '%s' "$_fallback_result" \
                         | jq -c --argjson n "$pr_num" \
                             '.pr_number = $n')
                 fi
@@ -1339,7 +1626,7 @@ run_stage() {
                 local branch_re='[Bb]ranch[: ]+([a-zA-Z0-9/_.-]+)'
                 if [[ "$result_text" =~ $branch_re ]]; then
                     local br="${BASH_REMATCH[1]}"
-                    fallback_result=$(printf '%s' "$fallback_result" \
+                    _fallback_result=$(printf '%s' "$_fallback_result" \
                         | jq -c --arg b "$br" \
                             '.branch = $b')
                 fi
@@ -1368,165 +1655,285 @@ for m in re.finditer(r'\[\s*\{', t):
                         | jq -c 'if type == "array" then . else empty end' \
                             2>/dev/null)
                     if [[ -n "$valid_tasks" ]]; then
-                        fallback_result=$(printf '%s' "$fallback_result" \
+                        _fallback_result=$(printf '%s' "$_fallback_result" \
                             | jq -c --argjson t "$valid_tasks" \
                                 '.tasks = $t')
                     fi
                 fi
             fi
-
-            printf '%s\n' "$fallback_result"
-            return 0
         fi
+    fi
 
-        # Diagnostic: log raw output first 500 chars and byte count when both
-        # .structured_output and .result extraction fail
-        local output_byte_count
+    # Classify error_kind based on the run outcome
+    local _error_kind="null"
+
+    if (( exit_code == 124 )); then
+        # Timed out even after same-model retry — classify as double_timeout
+        # so downstream (decide-action.sh) can distinguish a single first-pass
+        # timeout (which never reaches here) from a repeated timeout.
+        _error_kind="double_timeout"
+    elif [[ "$output_subtype" == "error_max_turns" ]]; then
+        if [[ "$(effective_fallback "$model")" == "$model" ]]; then
+            log_error "Stage $stage_name hit max turns with $model (ceiling) — cannot escalate"
+            _error_kind="max_turns_exhausted_at_ceiling"
+        else
+            _error_kind="max_turns_exhausted"
+        fi
+    elif detect_rate_limit "$output"; then
+        handle_rate_limit "$output"
+        _error_kind="rate_limit"
+    elif [[ -z "$structured" && -z "$_fallback_result" ]]; then
+        # No parseable output of any kind
+        local output_byte_count output_preview
         output_byte_count=$(printf '%s' "$output" | wc -c)
-        local output_preview="${output:0:500}"
+        output_preview="${output:0:500}"
         log "Diagnostic fallback failure — Output byte count: $output_byte_count"
         log "Diagnostic fallback failure — First 500 characters: $output_preview"
+        emit_event "schema_validation_fail" \
+            "stage=$stage_name" \
+            "reason=no_structured_output" \
+            "model=$model" \
+            "schema=$schema_file" \
+            "errors:=[]"
+        _error_kind="no_structured_output"
+    else
+        # We have some output — check for a structured error status
+        local _structured_status=""
+        _structured_status=$(printf '%s' "${structured:-$_fallback_result}" \
+            | jq -r '.status // empty' 2>/dev/null)
+        if [[ "$_structured_status" == "error" ]]; then
+            if [[ -n "$_permission_denials" ]]; then
+                log "WARN: $stage_name blocked by permission hook" \
+                    "(tools: $_permission_denials) — bailing"
+                _error_kind="permission_denied"
+            else
+                _error_kind="structured_error"
+            fi
+        fi
+    fi
 
-        # Empty/unparseable output — escalate to next model before failing.
-        local empty_escalated_model
-        empty_escalated_model=$(effective_fallback "$model")
+    # Build the interim stage_result that decide-action.sh will inspect
+    local _interim_status _interim_structured _error_kind_json
+    if [[ "$_error_kind" == "null" ]]; then
+        _interim_status="success"
+        _interim_structured="${structured:-$_fallback_result}"
+        _error_kind_json="null"
+    else
+        _interim_status="error"
+        _interim_structured="null"
+        _error_kind_json="\"${_error_kind}\""
+    fi
 
-        if [[ "$empty_escalated_model" != "$model" ]]; then
-            log "WARN: No structured output from $stage_name with $model — escalating to $empty_escalated_model"
-            printf '%s\n' "=== $stage_name empty output escalation: $model → $empty_escalated_model ===" >> "$stage_log"
+    local _sr_interim
+    _sr_interim=$(_emit_stage_result \
+        "$_interim_status" "${_interim_structured}" "$output" \
+        "$(_extract_denials "$output")" \
+        "$result_model" "$_error_kind_json" \
+        "$(( $(_epoch_ms) - result_start_ms ))")
 
-            record_escalation "$stage_name" "$model" "$empty_escalated_model" "empty_output"
+    # Escalation history from status file
+    local _history="[]"
+    if [[ -f "$STATUS_FILE" ]]; then
+        _history=$(jq -c '.escalations // []' "$STATUS_FILE" 2>/dev/null \
+            || printf '[]')
+    fi
 
-            local -a empty_esc_fallback_args=()
-            local empty_esc_fallback
-            empty_esc_fallback=$(effective_fallback "$empty_escalated_model")
-            if [[ "$empty_esc_fallback" != "$empty_escalated_model" ]]; then
-                empty_esc_fallback_args=(--fallback-model "$empty_esc_fallback")
+    # ── Single decide-action.sh call (AC1) ───────────────────────────────────
+    local _da_json _da_action _da_target_model _da_reason
+    _da_json=$(bash "$SCRIPT_DIR/decide-action.sh" \
+        "$_sr_interim" "$_history" 2>/dev/null) \
+        || _da_json='{"action":"bail","reason":"decide-action.sh invocation failed"}'
+    _da_action=$(printf '%s' "$_da_json" \
+        | jq -r '.action // "bail"' 2>/dev/null)
+    _da_target_model=$(printf '%s' "$_da_json" \
+        | jq -r '.model // empty' 2>/dev/null)
+    _da_reason=$(printf '%s' "$_da_json" \
+        | jq -r '.reason // ""' 2>/dev/null)
+
+    log "decide-action.sh → action=$_da_action${_da_target_model:+ model=$_da_target_model}"
+
+    # ── Dispatch: _apply_stage_action called with the action returned by ──────
+    # ── decide-action.sh (AC2)                                           ──────
+    case "$_da_action" in
+        accept)
+            _CONSECUTIVE_TIMEOUTS=0
+            _TIMED_OUT_STAGE_NAMES=""
+            local _sr_accept
+            _sr_accept=$(_emit_stage_result \
+                "success" "$_interim_structured" "$output" \
+                "$(_extract_denials "$output")" \
+                "$result_model" "null" \
+                "$(( $(_epoch_ms) - result_start_ms ))")
+            _apply_stage_action "$_sr_accept" "accept"
+            return $?
+            ;;
+        bail)
+            _CONSECUTIVE_TIMEOUTS=0
+            _TIMED_OUT_STAGE_NAMES=""
+            _apply_stage_action "$_sr_interim" "bail" "$_da_reason"
+            return $?
+            ;;
+        escalate)
+            # Re-run with the model decide-action.sh selected
+            local _esc_model="${_da_target_model:-$(effective_fallback "$model")}"
+            local _esc_fallback
+            _esc_fallback=$(effective_fallback "$_esc_model")
+            local -a _esc_fallback_args=()
+            if [[ "$_esc_fallback" != "$_esc_model" ]]; then
+                _esc_fallback_args=(--fallback-model "$_esc_fallback")
             fi
 
-            local empty_esc_exit_code=0
-            output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
+            log "WARN: Stage $stage_name $_da_reason — escalating $model → $_esc_model"
+            printf '%s\n' \
+                "=== $stage_name escalation: $model → $_esc_model ===" >> "$stage_log"
+            record_escalation "$stage_name" "$model" "$_esc_model" "$_da_reason"
+
+            emit_event "model_call" \
+                "stage=$stage_name" \
+                "model=$_esc_model" \
+                "fallback_model=$_esc_fallback" \
+                "agent=${agent:-default}" \
+                "schema=$schema_file" \
+                "complexity=${complexity:-}" \
+                "stage_attempt:=2"
+
+            # For max_turns escalation, omit --max-turns so the escalated
+            # model can complete without an artificial turn cap.
+            local -a _esc_turns_args=()
+            if [[ "$_error_kind" != "max_turns_exhausted" ]]; then
+                _esc_turns_args=("${turns_args[@]+"${turns_args[@]}"}")
+            fi
+
+            # _esc_exit_code is captured to preserve the raw CLI exit code for
+            # the stage log.  Flow control is handled via structured output
+            # extraction below, not via this value.
+            local _esc_exit_code=0
+            output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
+                -p "$prompt" \
                 ${agent_args[@]+"${agent_args[@]}"} \
-                --model "$empty_escalated_model" \
-                ${empty_esc_fallback_args[@]+"${empty_esc_fallback_args[@]}"} \
+                --model "$_esc_model" \
+                ${_esc_fallback_args[@]+"${_esc_fallback_args[@]}"} \
+                ${_esc_turns_args[@]+"${_esc_turns_args[@]}"} \
                 --dangerously-skip-permissions \
                 --output-format json \
                 --json-schema "$schema" \
-                2>&1) || empty_esc_exit_code=$?
+                2>&1) || _esc_exit_code=$?
 
-            printf '%s\n' "=== $stage_name empty output escalation output ===" >> "$stage_log"
+            result_model="$_esc_model"
+            printf '%s\n' "=== $stage_name escalation output ===" >> "$stage_log"
             printf '%s\n' "$output" >> "$stage_log"
-            printf '%s\n' "=== empty output escalation exit code: $empty_esc_exit_code ===" >> "$stage_log"
+            printf '%s\n' \
+                "=== escalation exit code: $_esc_exit_code ===" >> "$stage_log"
+            (( _esc_exit_code != 0 )) && \
+                log_warn "escalation CLI exited $_esc_exit_code"
 
-            # Re-extract structured output from escalated run
-            structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
-            if [[ -n "$structured" ]]; then
-                _CONSECUTIVE_TIMEOUTS=0
-                _TIMED_OUT_STAGE_NAMES=""
-                printf '%s\n' "$structured"
-                return 0
-            fi
-
-            # Try .result fallback from escalated run
-            local esc_fallback_result
-            esc_fallback_result=$(printf '%s' "$output" | jq -c '
-                select(.is_error == false and .result != null) |
-                {status: "success", summary: .result}
-            ' 2>/dev/null)
-            if [[ -n "$esc_fallback_result" ]]; then
-                log "WARNING: Escalated run for $stage_name produced .result (no .structured_output) — using fallback"
-                _CONSECUTIVE_TIMEOUTS=0
-                _TIMED_OUT_STAGE_NAMES=""
-                printf '%s\n' "$esc_fallback_result"
-                return 0
-            fi
-        fi
-
-        log_error "No structured output from $stage_name"
-        _CONSECUTIVE_TIMEOUTS=0
-        _TIMED_OUT_STAGE_NAMES=""
-        echo '{"status":"error","error":"no structured output"}'
-        return 1
-    fi
-
-    # Structured-error escalation — if the agent explicitly returned
-    # status:"error", try a better model before giving up (unless the failure
-    # was caused by a permission hook, which a better model can't bypass).
-    local structured_status
-    structured_status=$(printf '%s' "$structured" | jq -r '.status // empty' 2>/dev/null)
-
-    if [[ "$structured_status" == "error" ]]; then
-        # Check whether the failure was caused by permission denials embedded
-        # in the raw CLI output.  The CLI surfaces these as an array under
-        # .permission_denials[].tool_name.
-        local permission_denials
-        permission_denials=$(printf '%s' "$output" \
-            | jq -r '[.permission_denials[]?.tool_name // empty] | select(length > 0) | join(", ")' \
-            2>/dev/null || true)
-
-        if [[ -n "$permission_denials" ]]; then
-            log "WARN: $stage_name blocked by permission hook (tools: $permission_denials) — skipping escalation"
-        else
-            # No permission denial — escalate to the next model tier and retry once.
-            local struct_err_escalated_model
-            struct_err_escalated_model=$(effective_fallback "$model")
-
-            if [[ "$struct_err_escalated_model" != "$model" ]]; then
-                log "WARN: $stage_name returned status:error with $model — escalating to $struct_err_escalated_model"
-                printf '%s\n' "=== $stage_name structured-error escalation: $model → $struct_err_escalated_model ===" >> "$stage_log"
-
-                record_escalation "$stage_name" "$model" "$struct_err_escalated_model" "structured_error"
-
-                local -a struct_err_esc_fallback_args=()
-                local struct_err_esc_fallback
-                struct_err_esc_fallback=$(effective_fallback "$struct_err_escalated_model")
-                if [[ "$struct_err_esc_fallback" != "$struct_err_escalated_model" ]]; then
-                    struct_err_esc_fallback_args=(--fallback-model "$struct_err_esc_fallback")
-                fi
-
-                local struct_err_esc_exit_code=0
-                output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
-                    ${agent_args[@]+"${agent_args[@]}"} \
-                    --model "$struct_err_escalated_model" \
-                    ${struct_err_esc_fallback_args[@]+"${struct_err_esc_fallback_args[@]}"} \
-                    --dangerously-skip-permissions \
-                    --output-format json \
-                    --json-schema "$schema" \
-                    2>&1) || struct_err_esc_exit_code=$?
-
-                printf '%s\n' "=== $stage_name structured-error escalation output ===" >> "$stage_log"
-                printf '%s\n' "$output" >> "$stage_log"
-                printf '%s\n' "=== structured-error escalation exit code: $struct_err_esc_exit_code ===" >> "$stage_log"
-
-                # Re-extract structured output from escalated run
-                structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
-                if [[ -n "$structured" ]]; then
-                    _CONSECUTIVE_TIMEOUTS=0
-                    _TIMED_OUT_STAGE_NAMES=""
-                    printf '%s\n' "$structured"
-                    return 0
-                fi
-
-                # Try .result fallback from escalated run
-                local struct_err_esc_fallback_result
-                struct_err_esc_fallback_result=$(printf '%s' "$output" | jq -c '
+            # Extract output from the escalated run
+            local _esc_structured
+            _esc_structured=$(printf '%s' "$output" \
+                | jq -c '.structured_output // empty' 2>/dev/null)
+            if [[ -z "$_esc_structured" ]]; then
+                _esc_structured=$(printf '%s' "$output" | jq -c '
                     select(.is_error == false and .result != null) |
                     {status: "success", summary: .result}
                 ' 2>/dev/null)
-                if [[ -n "$struct_err_esc_fallback_result" ]]; then
-                    log "WARNING: Escalated run for $stage_name produced .result (no .structured_output) — using fallback"
-                    _CONSECUTIVE_TIMEOUTS=0
-                    _TIMED_OUT_STAGE_NAMES=""
-                    printf '%s\n' "$struct_err_esc_fallback_result"
-                    return 0
-                fi
             fi
-        fi
-    fi
 
-    _CONSECUTIVE_TIMEOUTS=0
-    _TIMED_OUT_STAGE_NAMES=""
-    printf '%s\n' "$structured"
+            _CONSECUTIVE_TIMEOUTS=0
+            _TIMED_OUT_STAGE_NAMES=""
+            local _sr_esc
+            if [[ -n "$_esc_structured" ]]; then
+                _sr_esc=$(_emit_stage_result \
+                    "success" "$_esc_structured" "$output" \
+                    "$(_extract_denials "$output")" \
+                    "$result_model" "null" \
+                    "$(( $(_epoch_ms) - result_start_ms ))")
+            else
+                emit_event "schema_validation_fail" \
+                    "stage=$stage_name" \
+                    "reason=no_structured_output_after_escalation" \
+                    "model=$_esc_model" \
+                    "schema=$schema_file" \
+                    "errors:=[]"
+                log_error "No structured output from $stage_name after escalation"
+                _sr_esc=$(_emit_stage_result \
+                    "error" "null" "$output" \
+                    "$(_extract_denials "$output")" \
+                    "$result_model" '"no_structured_output"' \
+                    "$(( $(_epoch_ms) - result_start_ms ))")
+            fi
+            _apply_stage_action "$_sr_esc" "escalate" "$_da_reason"
+            return $?
+            ;;
+        retry_same)
+            # handle_rate_limit() was already called during error_kind
+            # classification above; emit the retry/model_call events now.
+            emit_event "retry" \
+                "stage=$stage_name" \
+                "reason=rate_limit" \
+                "attempt:=2" \
+                "max_attempts:=2" \
+                "model=$model"
+            emit_event "model_call" \
+                "stage=$stage_name" \
+                "model=$model" \
+                "fallback_model=$fallback_model" \
+                "agent=${agent:-default}" \
+                "schema=$schema_file" \
+                "complexity=${complexity:-}" \
+                "stage_attempt:=2"
+
+            local _retry_exit_code=0
+            output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
+                -p "$prompt" \
+                ${agent_args[@]+"${agent_args[@]}"} \
+                --model "$model" \
+                ${fallback_args[@]+"${fallback_args[@]}"} \
+                ${turns_args[@]+"${turns_args[@]}"} \
+                --dangerously-skip-permissions \
+                --output-format json \
+                --json-schema "$schema" \
+                2>&1) || _retry_exit_code=$?
+
+            printf '%s\n' "=== $stage_name retry output ===" >> "$stage_log"
+            printf '%s\n' "$output" >> "$stage_log"
+            printf '%s\n' \
+                "=== retry exit code: $_retry_exit_code ===" >> "$stage_log"
+
+            local _retry_structured
+            _retry_structured=$(printf '%s' "$output" \
+                | jq -c '.structured_output // empty' 2>/dev/null)
+            if [[ -z "$_retry_structured" ]]; then
+                _retry_structured=$(printf '%s' "$output" | jq -c '
+                    select(.is_error == false and .result != null) |
+                    {status: "success", summary: .result}
+                ' 2>/dev/null)
+            fi
+
+            _CONSECUTIVE_TIMEOUTS=0
+            _TIMED_OUT_STAGE_NAMES=""
+            local _sr_retry
+            if [[ -n "$_retry_structured" ]]; then
+                _sr_retry=$(_emit_stage_result \
+                    "success" "$_retry_structured" "$output" \
+                    "$(_extract_denials "$output")" \
+                    "$result_model" "null" \
+                    "$(( $(_epoch_ms) - result_start_ms ))")
+            else
+                _sr_retry=$(_emit_stage_result \
+                    "error" "null" "$output" \
+                    "$(_extract_denials "$output")" \
+                    "$result_model" '"no_structured_output"' \
+                    "$(( $(_epoch_ms) - result_start_ms ))")
+            fi
+            _apply_stage_action "$_sr_retry" "retry_same" "$_da_reason"
+            return $?
+            ;;
+        *)
+            log_error "decide-action.sh returned unknown action '$_da_action'"
+            _apply_stage_action "$_sr_interim" "bail" "unknown_action_from_decide"
+            return $?
+            ;;
+    esac
 }
 
 # =============================================================================
@@ -1549,68 +1956,31 @@ for m in re.finditer(r'\[\s*\{', t):
 # Output (stdout):
 #   - The final route string ("fast-path" or "full")
 
+# build_triage_prompt is a thin wrapper around build_prompt() sourced from
+# prompts/triage-prompt.sh. The sourced build_prompt() is the single source
+# of truth for the triage classifier prompt and is shared with
+# triage-validate.sh's golden tests.
 build_triage_prompt() {
-    local issue_body="$1"
-    cat <<TRIAGE_PROMPT
-You are the triage classifier for an issue-implementation pipeline. Classify
-the GitHub issue below into one of two routes:
+    build_prompt "$@"
+}
 
-  "fast-path" — surgical, test-only, well-specified change. Pipeline runs:
-                branch -> implement -> commit -> PR -> squash-merge. Skips
-                test loop, code review, deploy verify, docs.
-  "full"      — default. Runs the full verification pipeline.
-
-Be CONSERVATIVE. False negatives (missing a fast-path opportunity) cost time.
-False positives (skipping verification when it was needed) cost quality. Bias
-hard toward "full" whenever uncertain.
-
-Check ALL SIX criteria. Every criterion must be true for "fast-path". If ANY
-criterion is false, route is "full".
-
-CRITERIA:
-
-1. test_only_scope — All file paths in the issue's Implementation Tasks
-   section match: tests/**, playwright/**, **/*.spec.ts, **/*.test.ts,
-   **/*.e2e.ts. Any reference to apps/, packages/, src/, or migration files
-   disqualifies.
-
-2. surgical_size — Estimated diff under 30 lines net, across no more than
-   3 files.
-
-3. established_pattern — The change applies a pattern that already exists in
-   the codebase. Identify the pattern as a grep-able regex and place it in
-   "established_pattern_grep". The shell wrapper will run \`git grep -lE\` and
-   verify >= 3 matching files. Set to null if you cannot identify one
-   specific regex (this criterion then fails).
-
-4. precise_specification — Issue body has an "## Implementation Tasks"
-   section AND each task names specific file paths AND (line numbers OR
-   exact code snippets).
-
-5. benign_failure_mode — Worst outcome of a wrong change is "a test still
-   fails" or "a test skips" — NOT "production breaks", "data corrupts", or
-   "users see incorrect behavior". Test files always pass; production code
-   never passes.
-
-6. no_security_concerns — Skip fast-path for: auth flows, RBAC, encryption,
-   secret handling, input validation, CORS, CSP, session management, token
-   handling. Auth tests deserve review even if test-only.
-
-CONFIDENCE: high (all criteria clearly evaluated) | medium (some criteria
-required inference) | low (vague issue). If confidence is medium or low,
-route MUST be "full".
-
-OUTPUT: schema-enforced JSON with route, criteria.{test_only_scope,
-surgical_size, established_pattern, precise_specification,
-benign_failure_mode, no_security_concerns}.{passed, reason},
-established_pattern_grep, confidence, disqualifying_criterion, summary,
-status.
-
-ISSUE BODY:
-<<<
-${issue_body}
->>>
-TRIAGE_PROMPT
+# _run_triage_composition — invoke the triage-classify skill as a standard
+# (non-isolated) subprocess, following the dispatch_composition(isolated=false)
+# pattern from batch-orchestrator.sh.  Triage is a pure classification task;
+# it requires no file-system writes so --dangerously-skip-permissions is
+# omitted.
+#
+# Usage: _run_triage_composition <prompt> [extra claude args...]
+_run_triage_composition() {
+    local prompt="$1"
+    shift
+    local triage_timeout
+    triage_timeout=$(get_stage_timeout "triage" "")
+    log "Composition dispatch → standard (triage-classify)"
+    timeout "$triage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
+        -p "$prompt" \
+        "$@" \
+        2>&1
 }
 
 run_triage_stage() {
@@ -1620,95 +1990,70 @@ run_triage_stage() {
 
     if [[ ! -f "$issue_body_file" ]]; then
         log_error "Triage: issue body file not found: $issue_body_file"
-        # Fail safe: write a minimal triage.json marking full route, return full.
-        printf '{"route":"full","disqualifying_criterion":"issue_body_missing","kill_switch_engaged":false}\n' \
-            > "$LOG_BASE/triage.json"
+        # Fail safe: write minimal triage.json marking full route.
+        jq -n '{
+            route: "full",
+            confidence: "low",
+            disqualifying_criterion: "issue_body_missing",
+            timestamp: (now | todate)
+        }' > "$LOG_BASE/triage.json"
         update_stage triage completed route full
         printf 'full\n'
         return 0
     fi
 
     local issue_body prompt
-    issue_body=$(cat "$issue_body_file")
+    issue_body=$(< "$issue_body_file")
     prompt=$(build_triage_prompt "$issue_body")
 
     # Resolve model. TRIAGE_MODEL env var allows operator override; default
     # falls through to model-config.sh (triage stage maps to "haiku" tier).
     local triage_model="${TRIAGE_MODEL:-}"
-
-    local raw
-    raw=$(run_stage "triage" "$prompt" "implement-issue-triage.json" "" "" "" "$triage_model") || true
-
-    # Extract Claude's classification. If parse fails, default to full.
-    local route confidence dq pattern criteria
-    route=$(printf '%s' "$raw" | jq -r '.route // "full"')
-    confidence=$(printf '%s' "$raw" | jq -r '.confidence // "low"')
-    dq=$(printf '%s' "$raw" | jq -r '.disqualifying_criterion // empty')
-    pattern=$(printf '%s' "$raw" | jq -r '.established_pattern_grep // empty')
-    criteria=$(printf '%s' "$raw" | jq -c '.criteria // {}')
-
-    # Post-processing: defense in depth on top of the prompt.
-    local kill_switch_engaged=false
-    local pattern_grep_count=0
-
-    # 1. Kill switch: forces full regardless of Claude's decision.
-    if [[ "${DISABLE_SURGICAL_FAST_PATH:-0}" == "1" ]]; then
-        if [[ "$route" == "fast-path" ]]; then
-            dq="kill_switch"
-        fi
-        route="full"
-        kill_switch_engaged=true
+    local -a model_args=()
+    if [[ -n "$triage_model" ]]; then
+        model_args=(--model "$triage_model")
     fi
 
-    # 2. Confidence demotion: medium/low forces full.
-    if [[ "$kill_switch_engaged" == "false" && "$route" == "fast-path" ]]; then
-        if [[ "$confidence" != "high" ]]; then
-            route="full"
-            dq="confidence_low"
-        fi
-    fi
+    local schema
+    schema=$(jq -c . "$SCHEMA_DIR/implement-issue-triage.json")
 
-    # 3. Pattern grep verification: requires >= 3 matching files.
-    if [[ "$kill_switch_engaged" == "false" && "$route" == "fast-path" ]]; then
-        if [[ -z "$pattern" || "$pattern" == "null" ]]; then
-            route="full"
-            dq="established_pattern"
-        elif [[ "$pattern" == *$'\n'* ]]; then
-            # Reject multi-line patterns. POSIX/BSD/GNU grep treats embedded
-            # newlines as alternation, so a malformed pattern like
-            # "storageState\n." would falsely match arbitrary files.
-            route="full"
-            dq="established_pattern"
-        else
-            # Run from BASE_BRANCH worktree if available; otherwise current dir.
-            pattern_grep_count=$(git grep -lE -- "$pattern" 2>/dev/null | wc -l | tr -d ' ' || echo "0")
-            if (( pattern_grep_count < 3 )); then
-                route="full"
-                dq="established_pattern"
-            fi
-        fi
-    fi
+    local triage_log="$LOG_BASE/stages/$(next_stage_log "triage")"
 
-    # Write triage.json artifact (always, for both routes — auditable record).
+    # Invoke the triage-classify skill via a standard (non-isolated)
+    # subprocess — the dispatch_composition(isolated=false) pattern from
+    # batch-orchestrator.sh.  No --dangerously-skip-permissions needed.
+    local raw exit_code=0
+    raw=$(_run_triage_composition "$prompt" \
+        ${model_args[@]+"${model_args[@]}"} \
+        --output-format json \
+        --json-schema "$schema") || exit_code=$?
+
+    printf '%s\n' "=== triage output ===" >> "$triage_log"
+    printf '%s\n' "$raw" >> "$triage_log"
+    printf '%s\n' "=== exit code: $exit_code ===" >> "$triage_log"
+
+    # Parse {route, confidence, disqualifying_criterion} from skill output.
+    # Default to full/low on any parse failure.
+    local route confidence dq
+    route=$(printf '%s' "$raw" \
+        | jq -r '.structured_output.route // "full"' 2>/dev/null)
+    confidence=$(printf '%s' "$raw" \
+        | jq -r '.structured_output.confidence // "low"' 2>/dev/null)
+    dq=$(printf '%s' "$raw" \
+        | jq -r \
+            '.structured_output.disqualifying_criterion // empty' \
+            2>/dev/null)
+
+    # Write triage.json artifact (auditable record for both routes).
     local artifact="$LOG_BASE/triage.json"
     jq -n \
         --arg route "$route" \
         --arg confidence "$confidence" \
         --arg dq "${dq:-}" \
-        --arg pattern "${pattern:-}" \
-        --argjson criteria "${criteria:-\{\}}" \
-        --argjson grep_count "$pattern_grep_count" \
-        --argjson kill_switch "$kill_switch_engaged" \
-        --arg summary "$(printf '%s' "$raw" | jq -r '.summary // ""')" \
         '{
             route: $route,
             confidence: $confidence,
             disqualifying_criterion: (if $dq == "" then null else $dq end),
-            established_pattern_grep: (if $pattern == "" or $pattern == "null" then null else $pattern end),
-            pattern_grep_count: $grep_count,
-            kill_switch_engaged: $kill_switch,
-            criteria: $criteria,
-            summary: $summary,
             timestamp: (now | todate)
         }' > "$artifact"
 
@@ -1718,13 +2063,16 @@ run_triage_stage() {
        --arg dq "${dq:-}" \
        '.stages.triage.route = $route |
         .stages.triage.confidence = $confidence |
-        .stages.triage.disqualifying_criterion = (if $dq == "" then null else $dq end) |
+        .stages.triage.disqualifying_criterion =
+            (if $dq == "" then null else $dq end) |
         .route = $route |
         .last_update = (now | todate)' \
-       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" \
+       && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
 
     set_stage_completed "triage"
-    log "Triage complete. Route: $route (confidence: $confidence, dq: ${dq:-none}, kill_switch: $kill_switch_engaged)"
+    log "Triage complete. Route: $route" \
+        "(confidence: $confidence, dq: ${dq:-none})"
 
     printf '%s\n' "$route"
 }
@@ -1752,6 +2100,7 @@ run_quality_loop() {
     local loop_agent="${4:-$AGENT}"
     local max_iterations="${5:-$MAX_QUALITY_ITERATIONS}"
     local loop_complexity="${6:-}"
+    local loop_model_override=""
 
     local loop_approved=false
     local loop_iteration=0  # Per-loop counter (resets each call)
@@ -1805,10 +2154,17 @@ If no TypeScript/React files were modified as part of this issue's implementatio
 Simplify code for clarity and consistency without changing functionality.
 Output a summary of changes made."
 
+            local simplify_stage_name="simplify-${stage_prefix}-iter-$loop_iteration"
+            set_stage_started "$simplify_stage_name"
             local simplify_result
-            simplify_result=$(run_stage "simplify-${stage_prefix}-iter-$loop_iteration" "$simplify_prompt" "implement-issue-simplify.json" "" "$loop_complexity")
+            simplify_result=$(run_stage "$simplify_stage_name" "$simplify_prompt" "implement-issue-simplify.json" "" "$loop_complexity")
+            local simplify_status
+            simplify_status=$(printf '%s' "$simplify_result" | jq -r '.status // "success"')
+            if [[ "$simplify_status" != "error" ]]; then
+                set_stage_completed "$simplify_stage_name"
+            fi
 
-            simplify_summary=$(printf '%s' "$simplify_result" | jq -r '.summary // "No changes"')
+            simplify_summary=$(printf '%s' "$simplify_result" | jq -r '.output.summary // "No changes"')
 
             # If simplify reported no changes, skip it on the next iteration until a
             # fix stage runs (which may introduce new simplification opportunities).
@@ -1871,8 +2227,15 @@ fi)
 DO NOT recommend 'approve and merge' - this is not a PR review.
 Simply output 'approved' if code quality is acceptable, or 'changes_requested' with specific issues to fix."
 
+        local review_stage_name="review-${stage_prefix}-iter-$loop_iteration"
+        set_stage_started "$review_stage_name"
         local review_result
-        review_result=$(run_stage "review-${stage_prefix}-iter-$loop_iteration" "$review_prompt" "implement-issue-review.json" "code-reviewer" "$loop_complexity")
+        review_result=$(run_stage "$review_stage_name" "$review_prompt" "implement-issue-review.json" "code-reviewer" "$loop_complexity")
+        local review_run_status
+        review_run_status=$(printf '%s' "$review_result" | jq -r '.status // "success"')
+        if [[ "$review_run_status" != "error" ]]; then
+            set_stage_completed "$review_stage_name"
+        fi
 
         # Handle timeout: skip result inspection and retry on next iteration
         if is_stage_timeout "$review_result"; then
@@ -1881,13 +2244,13 @@ Simply output 'approved' if code quality is acceptable, or 'changes_requested' w
         fi
 
         local review_verdict review_summary verdict_source
-        review_summary=$(printf '%s' "$review_result" | jq -r '.summary // "Review completed"')
+        review_summary=$(printf '%s' "$review_result" | jq -r '.output.summary // "Review completed"')
         local has_result_field
-        has_result_field=$(printf '%s' "$review_result" | jq 'has("result")' 2>/dev/null)
+        has_result_field=$(printf '%s' "$review_result" | jq '.output | has("result")' 2>/dev/null)
 
         if [[ "$has_result_field" == "true" ]]; then
-            # Structured output available: extract verdict from .result field
-            review_verdict=$(printf '%s' "$review_result" | jq -r '.result')
+            # Structured output available: extract verdict from .output.result field
+            review_verdict=$(printf '%s' "$review_result" | jq -r '.output.result')
             verdict_source="structured output"
             log "Verdict extracted from structured output: $review_verdict"
         else
@@ -1913,7 +2276,7 @@ Simply output 'approved' if code quality is acceptable, or 'changes_requested' w
 
         # Append current iteration findings to review history
         local current_issues
-        current_issues=$(printf '%s' "$review_result" | jq -c "{iteration: $loop_iteration, issues: (.issues // []), result: (.result // .status // \"unknown\")}" 2>/dev/null)
+        current_issues=$(printf '%s' "$review_result" | jq -c "{iteration: $loop_iteration, issues: (.output.issues // []), result: (.output.result // .output.status // \"unknown\")}" 2>/dev/null)
         if [[ -n "$current_issues" ]]; then
             if [[ -f "$review_history_file" ]]; then
                 local existing
@@ -1929,10 +2292,10 @@ Simply output 'approved' if code quality is acceptable, or 'changes_requested' w
             local repeat_ratio repeat_issues
             repeat_ratio=$(printf '%s' "$review_result" | jq -r --slurpfile history "$review_history_file" '
                 . as $root |
-                ($root.issues // []) | length as $current_count |
+                ($root.output.issues // []) | length as $current_count |
                 if $current_count == 0 then 0
                 else
-                    [$root.issues[] | .description] as $current |
+                    [$root.output.issues[] | .description] as $current |
                     [$history[0][] | .issues[]? | .description] as $prior |
                     [$current[] | select(. as $c | $prior | any(. == $c))] as $repeats |
                     ($repeats | length * 100 / $current_count)
@@ -1940,10 +2303,10 @@ Simply output 'approved' if code quality is acceptable, or 'changes_requested' w
             ' 2>/dev/null || echo 0)
             repeat_issues=$(printf '%s' "$review_result" | jq -r --slurpfile history "$review_history_file" '
                 . as $root |
-                ($root.issues // []) | length as $current_count |
+                ($root.output.issues // []) | length as $current_count |
                 if $current_count == 0 then ""
                 else
-                    [$root.issues[] | .description] as $current |
+                    [$root.output.issues[] | .description] as $current |
                     [$history[0][] | .issues[]? | .description] as $prior |
                     [$current[] | select(. as $c | $prior | any(. == $c))] as $repeats |
                     ($repeats | join("\n- "))
@@ -1992,7 +2355,7 @@ Simply output 'approved' if code quality is acceptable, or 'changes_requested' w
         local major_issue_override=false
         if [[ "$review_verdict" == "approved" ]]; then
             local major_issue_count
-            major_issue_count=$(printf '%s' "$review_result" | jq '[.issues // [] | .[] | select(.severity == "major")] | length' 2>/dev/null || echo "0")
+            major_issue_count=$(printf '%s' "$review_result" | jq '[.output.issues // [] | .[] | select(.severity == "major")] | length' 2>/dev/null || echo "0")
             if (( major_issue_count > 0 )); then
                 log_warn "Quality review for $stage_prefix approved but $major_issue_count major issue(s) found — overriding to changes_requested"
                 review_verdict="changes_requested"
@@ -2007,9 +2370,9 @@ Simply output 'approved' if code quality is acceptable, or 'changes_requested' w
             local review_comments
             if $major_issue_override; then
                 # Filter to include only major-severity issues
-                review_comments=$(printf '%s' "$review_result" | jq -r '[.issues // [] | .[] | select(.severity == "major") | .description] | join("\n- ")')
+                review_comments=$(printf '%s' "$review_result" | jq -r '[.output.issues // [] | .[] | select(.severity == "major") | .description] | join("\n- ")')
             else
-                review_comments=$(printf '%s' "$review_result" | jq -r '.comments // "No comments"')
+                review_comments=$(printf '%s' "$review_result" | jq -r '.output.comments // "No comments"')
             fi
             printf '%s\n' "$review_comments" >> "$LOG_BASE/context/review-comments.json"
 
@@ -2041,13 +2404,69 @@ Fix the issues and commit. Output a summary of fixes applied."
 
             verify_on_feature_branch "$loop_branch" || true
 
+            local pre_fix_commits
+            pre_fix_commits=$(git rev-list --count "${BASE_BRANCH}..${loop_branch}" 2>/dev/null || echo "0")
+
             # Pass loop_complexity so run_stage can route model selection by task
-            # size: S→haiku, M→sonnet, L→opus (via resolve_model in run_stage).
+            # size: S→sonnet, M→sonnet, L→opus (via resolve_model in run_stage).
+            # Pass loop_model_override (arg 7) so an escalated model takes effect
+            # on subsequent iterations after stall detection.
+            local fix_stage_name="fix-review-${stage_prefix}-iter-$loop_iteration"
+            set_stage_started "$fix_stage_name"
             local fix_result
-            fix_result=$(run_stage "fix-review-${stage_prefix}-iter-$loop_iteration" "$fix_prompt" "implement-issue-fix.json" "$loop_agent" "$loop_complexity")
+            fix_result=$(run_stage "$fix_stage_name" "$fix_prompt" "implement-issue-fix.json" "$loop_agent" "$loop_complexity" "" "${loop_model_override:-}")
+            local fix_status
+            fix_status=$(printf '%s' "$fix_result" | jq -r '.status // "success"')
+            if [[ "$fix_status" != "error" ]]; then
+                set_stage_completed "$fix_stage_name"
+            fi
 
             local fix_summary
-            fix_summary=$(printf '%s' "$fix_result" | jq -r '.summary // "Fixes applied"')
+            fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
+
+            # Stall detection: if the fix stage did not produce any new commits
+            # and we are at least on iteration 2, escalate via decide-action.sh.
+            local current_fix_model post_fix_commits
+            current_fix_model=$(printf '%s' "$fix_result" | jq -r '.model // "sonnet"')
+            post_fix_commits=$(git rev-list --count "${BASE_BRANCH}..${loop_branch}" 2>/dev/null || echo "0")
+
+            if (( post_fix_commits <= pre_fix_commits )) && (( loop_iteration >= 2 )); then
+                log_warn "Quality loop stall detected on iteration $loop_iteration: fix produced no new commits (pre=$pre_fix_commits post=$post_fix_commits)"
+
+                local _stall_history="[]"
+                if [[ -f "$STATUS_FILE" ]]; then
+                    _stall_history=$(jq -c '.escalations // []' "$STATUS_FILE" 2>/dev/null || printf '[]')
+                fi
+
+                local stall_sr
+                stall_sr=$(jq -nc \
+                    --arg model "$current_fix_model" \
+                    '{status:"error", output:null, raw:"", denials:[], model:$model, error_kind:"quality_stall", elapsed_ms:0}')
+
+                local _stall_da_json _stall_action _stall_target_model _stall_reason
+                local exit_code
+                _stall_da_json=$(bash "$SCRIPT_DIR/decide-action.sh" \
+                    "$stall_sr" "$_stall_history" \
+                    2>>"${LOG_BASE:-/tmp}/orchestrator.log")
+                exit_code=$?
+                if ((exit_code != 0)); then
+                    log_warn "stall decide-action.sh exited non-zero ($exit_code) — falling back to retry_same"
+                    _stall_da_json='{"action":"retry_same","reason":"decide-action.sh invocation failed"}'
+                fi
+                _stall_action=$(printf '%s' "$_stall_da_json" | jq -r '.action // "retry_same"')
+                _stall_target_model=$(printf '%s' "$_stall_da_json" | jq -r '.model // empty' 2>/dev/null)
+                _stall_reason=$(printf '%s' "$_stall_da_json" | jq -r '.reason // ""')
+
+                log "Stall decide-action.sh → action=$_stall_action${_stall_target_model:+ model=$_stall_target_model}"
+
+                if [[ "$_stall_action" == "escalate" ]]; then
+                    local _esc_model="${_stall_target_model:-$(effective_fallback "$current_fix_model")}"
+                    loop_model_override="$_esc_model"
+                    record_escalation "fix-review-${stage_prefix}-stall-iter-$loop_iteration" "$current_fix_model" "$_esc_model" "${_stall_reason:-quality_stall}"
+                    log "Quality loop stall: escalating fix model $current_fix_model → $_esc_model for next iteration"
+                elif [[ "$_stall_action" == "bail" ]]; then break
+                fi
+            fi
 
             # Fix stage introduced new changes — simplify should run next iteration.
             skip_simplify=false
@@ -2548,6 +2967,54 @@ _parse_task_lines() {
 	printf '%s\n' "$tasks_json"
 }
 
+# Builds a well-formed issue body for an adjacent follow-up issue.
+# If the raw body already contains a valid ## Implementation Tasks section
+# with at least one canonical task line, it is returned unchanged.
+# Otherwise a canonical task line is appended in a new ## Implementation Tasks section.
+#
+# Arguments:
+#   $1 - raw body text from the adjacent_issue JSON
+#   $2 - issue title (used to synthesise the task description when body lacks one)
+# Outputs:
+#   validated body on stdout
+_build_adj_body() {
+	local raw_body="$1"
+	local adj_title="$2"
+
+	# Extract any existing Implementation Tasks section
+	local tasks_section
+	tasks_section=$(printf '%s' "$raw_body" \
+		| awk '/^## Implementation Tasks/{found=1; next} found && /^## /{exit} found{print}')
+
+	# Check for at least one canonical task line: - [ ] `[agent]` **(S|M|L)** description
+	local has_valid_task=false
+	if [[ -n "$tasks_section" ]]; then
+		while IFS= read -r line; do
+			[[ -z "$line" ]] && continue
+			if [[ "$line" =~ ^-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ \*\*\([SML]\)\*\*\ .+$ ]]; then
+				has_valid_task=true
+				break
+			fi
+		done <<< "$tasks_section"
+	fi
+
+	if [[ "$has_valid_task" == true ]]; then
+		printf '%s' "$raw_body"
+		return
+	fi
+
+	# Body lacks a valid Implementation Tasks section — synthesise one.
+	# Strip any existing (malformed) Implementation Tasks section, then append a canonical one.
+	local body_prefix
+	body_prefix=$(printf '%s' "$raw_body" \
+		| awk '/^## Implementation Tasks/{exit} {print}' \
+		| sed 's/[[:space:]]*$//')
+
+	printf '%s\n\n## Implementation Tasks\n\n- [ ] `[default]` **(M)** %s\n' \
+		"$body_prefix" "$adj_title"
+}
+
+
 # Known file extensions to avoid false positives when extracting bare filenames
 # (version strings v1.0, domains, etc. are excluded)
 readonly KNOWN_FILE_EXTENSIONS='sh|bats|bash|ts|tsx|js|jsx|mjs|cjs|py|go|rb|rs|java|kt|swift|json|yaml|yml|toml|sql|md|css|html|tf'
@@ -3006,7 +3473,7 @@ Commit your changes with a descriptive message."
 
 		local impl_status
 		impl_status=$(printf '%s' "$impl_result" \
-			| jq -r '.status')
+			| jq -r '.output.status')
 
 		if [[ "$impl_status" == "success" ]]; then
 			task_succeeded=true
@@ -3036,10 +3503,10 @@ Commit your changes with a descriptive message."
 
 		local commit_sha
 		commit_sha=$(printf '%s' "$impl_result" \
-			| jq -r '.commit')
+			| jq -r '.output.commit')
 		local impl_summary
 		impl_summary=$(printf '%s' "$impl_result" \
-			| jq -r '.summary // "Implementation completed"')
+			| jq -r '.output.summary // "Implementation completed"')
 
 		local files_changed_wt_json
 		files_changed_wt_json=$(git -C "$wt_path" diff --name-only HEAD~1 HEAD \
@@ -3267,12 +3734,14 @@ execute_batch_parallel() {
 				"$result_file" "$base_branch" &
 			_task_pid=$!
 			set +m
+			set -m
 			( sleep "${MAX_TASK_WALL_TIME_SECS}" && \
-				kill -- -"$_task_pid" 2>/dev/null ) &
+				kill -- -"$_task_pid" 2>/dev/null ) > /dev/null 2>&1 &
 			_watchdog_pid=$!
+			set +m
 			wait "$_task_pid" 2>/dev/null
 			_task_exit=$?
-			kill "$_watchdog_pid" 2>/dev/null
+			kill -- -"$_watchdog_pid" 2>/dev/null
 			wait "$_watchdog_pid" 2>/dev/null || true
 			# exit 143 = SIGTERM from watchdog; only treat as timeout
 			# when no result file was written (guards against race
@@ -3588,7 +4057,7 @@ Commit your changes with a descriptive message."
 
 					local _pw_status
 					_pw_status=$(printf '%s' "$_pw_result" \
-						| jq -r '.status')
+						| jq -r '.output.status')
 
 					if [[ "$_pw_status" == "success" ]]; then
 						# Find new spec files added by the playwright task
@@ -3744,7 +4213,7 @@ Commit your changes with a descriptive message."
 
 			local impl_status
 			impl_status=$(printf '%s' "$impl_result" \
-				| jq -r '.status')
+				| jq -r '.output.status')
 
 			if [[ "$impl_status" == "success" ]]; then
 				task_succeeded=true
@@ -3773,11 +4242,11 @@ Commit your changes with a descriptive message."
 			# Write result file for main loop
 			local commit_sha
 			commit_sha=$(printf '%s' "$impl_result" \
-				| jq -r '.commit')
+				| jq -r '.output.commit')
 			local impl_summary
 			impl_summary=$(printf '%s' "$impl_result" \
 				| jq -r \
-				'.summary // "Implementation completed"')
+				'.output.summary // "Implementation completed"')
 			local files_changed_json
 			files_changed_json=$(git diff --name-only HEAD~1 HEAD \
 				2>/dev/null | jq -R -s \
@@ -4364,12 +4833,12 @@ Output both test results and validation findings in one structured response.
         fi
 
         local test_status test_summary
-        test_status=$(printf '%s' "$test_result" | jq -r '.result')
-        test_summary=$(printf '%s' "$test_result" | jq -r '.summary // "Tests completed"')
+        test_status=$(printf '%s' "$test_result" | jq -r '.output.result')
+        test_summary=$(printf '%s' "$test_result" | jq -r '.output.summary // "Tests completed"')
 
         local validate_status validate_summary
-        validate_status=$(printf '%s' "$test_result" | jq -r '.validation_result // "skipped"')
-        validate_summary=$(printf '%s' "$test_result" | jq -r '.validation_summary // ""')
+        validate_status=$(printf '%s' "$test_result" | jq -r '.output.validation_result // "skipped"')
+        validate_summary=$(printf '%s' "$test_result" | jq -r '.output.validation_summary // ""')
 
         # -----------------------------------------------------------------
         # HANDLE TEST FAILURES
@@ -4380,7 +4849,7 @@ Output both test results and validation findings in one structured response.
 $test_summary" "default"
             log "Tests failed. Getting failures and fixing..."
             local failures
-            failures=$(printf '%s' "$test_result" | jq -c '.failures')
+            failures=$(printf '%s' "$test_result" | jq -c '.output.failures')
 
             # Filter failures: only include failures from PR-changed test files.
             # Explicit mode (changed_test_files non-empty): all failures are from
@@ -4496,7 +4965,7 @@ Fix the issues and commit. Output a summary of fixes applied."
             fix_result=$(run_stage "fix-tests-iter-$test_iteration" "$fix_prompt" "implement-issue-fix.json" "$loop_agent" "$loop_complexity")
 
             local fix_summary
-            fix_summary=$(printf '%s' "$fix_result" | jq -r '.summary // "Fixes applied"')
+            fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
 
             # Comment: Fix results
             comment_issue "Test Loop: Test Fix ($test_iteration/$max_test_iter)" "$fix_summary" "$loop_agent"
@@ -4536,8 +5005,8 @@ $validate_summary" "default"
             log "Test validation found issues. Fixing... (validation fix iteration $validation_fix_iteration/$MAX_VALIDATION_FIX_ITERATIONS)"
             local validate_issues
             validate_issues=$(printf '%s' "$test_result" | jq -r '
-                if .validation_issues then (.validation_issues | tostring)
-                elif .validation_summary then .validation_summary
+                if .output.validation_issues then (.output.validation_issues | tostring)
+                elif .output.validation_summary then .output.validation_summary
                 else "Fix test quality issues"
                 end
             ')
@@ -4559,7 +5028,7 @@ Output a summary of fixes applied."
             fix_result=$(run_stage "fix-test-quality-iter-$test_iteration" "$fix_prompt" "implement-issue-fix.json" "$loop_agent" "$loop_complexity")
 
             local fix_summary
-            fix_summary=$(printf '%s' "$fix_result" | jq -r '.summary // "Fixes applied"')
+            fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
 
             # Comment: Fix results
             comment_issue "Test Loop: Validation Fix ($test_iteration/$max_test_iter)" "$fix_summary" "$loop_agent"
@@ -4788,9 +5257,9 @@ Report result as 'passed' or 'failed' with a detailed summary."
 
 			local e2e_verify_status e2e_verify_summary
 			e2e_verify_status=$(printf '%s' "$e2e_verify_result" \
-				| jq -r '.result')
+				| jq -r '.output.result')
 			e2e_verify_summary=$(printf '%s' "$e2e_verify_result" \
-				| jq -r '.summary // "E2E verification completed"')
+				| jq -r '.output.summary // "E2E verification completed"')
 
 			local e2e_icon="✅"
 			[[ "$e2e_verify_status" == "failed" ]] \
@@ -4875,10 +5344,10 @@ Output result as 'passed' or 'failed' with a detailed summary."
 
 				local acceptance_status acceptance_summary
 				acceptance_status=$(printf '%s' "$acceptance_result" \
-					| jq -r '.result')
+					| jq -r '.output.result')
 				acceptance_summary=$(printf '%s' "$acceptance_result" \
 					| jq -r \
-					'.summary // "Acceptance test completed"')
+					'.output.summary // "Acceptance test completed"')
 
 				local acceptance_icon="✅"
 				[[ "$acceptance_status" == "failed" ]] \
@@ -4975,7 +5444,7 @@ Commit your changes."
 
 			local e2e_fix_summary
 			e2e_fix_summary=$(printf '%s' "$e2e_fix_result" \
-				| jq -r '.summary // "Fix applied"')
+				| jq -r '.output.summary // "Fix applied"')
 			comment_issue "E2E Fix (iteration $e2e_fix_iter)" \
 				"🔧 $e2e_fix_summary" "$AGENT"
 
@@ -5017,9 +5486,9 @@ Report result as 'passed' or 'failed' with a detailed summary."
 
 			local rerun_status rerun_summary
 			rerun_status=$(printf '%s' "$rerun_result" \
-				| jq -r '.result')
+				| jq -r '.output.result')
 			rerun_summary=$(printf '%s' "$rerun_result" \
-				| jq -r '.summary // "E2E rerun completed"')
+				| jq -r '.output.summary // "E2E rerun completed"')
 
 			local rerun_icon="✅"
 			[[ "$rerun_status" == "failed" ]] && rerun_icon="❌"
@@ -5085,7 +5554,7 @@ Investigate the root cause and fix the issue. Commit your changes."
 		local acceptance_fix_summary
 		acceptance_fix_summary=$(printf '%s' \
 			"$acceptance_fix_result" \
-			| jq -r '.summary // "Fix applied"')
+			| jq -r '.output.summary // "Fix applied"')
 		comment_issue "Acceptance Test Fix" \
 			"$acceptance_fix_summary" "$AGENT"
 	fi
@@ -5974,9 +6443,9 @@ STEPS:
                     deploy_verify_result=$(run_stage "deploy-verify" "$deploy_verify_prompt" "implement-issue-deploy-verify.json" "default")
 
                     local dv_status dv_health dv_summary
-                    dv_status=$(printf '%s' "$deploy_verify_result" | jq -r '.status // "unknown"')
-                    dv_health=$(printf '%s' "$deploy_verify_result" | jq -r '.health_status // "unknown"')
-                    dv_summary=$(printf '%s' "$deploy_verify_result" | jq -r '.summary // "Deploy verification completed"')
+                    dv_status=$(printf '%s' "$deploy_verify_result" | jq -r '.output.status // "unknown"')
+                    dv_health=$(printf '%s' "$deploy_verify_result" | jq -r '.output.health_status // "unknown"')
+                    dv_summary=$(printf '%s' "$deploy_verify_result" | jq -r '.output.summary // "Deploy verification completed"')
 
                     local dv_icon="✅"
                     [[ "$dv_status" == "error" ]] && dv_icon="❌"
@@ -6092,8 +6561,8 @@ $pr_creation_skill}"
         pr_result=$(run_stage "pr" "$pr_prompt" "implement-issue-pr.json" "" "" "" "opus")
 
         local pr_status
-        pr_status=$(printf '%s' "$pr_result" | jq -r '.status')
-        pr_number=$(printf '%s' "$pr_result" | jq -r '.pr_number')
+        pr_status=$(printf '%s' "$pr_result" | jq -r '.output.status')
+        pr_number=$(printf '%s' "$pr_result" | jq -r '.output.pr_number')
 
         if [[ "$pr_status" != "success" ]]; then
             log_error "PR creation failed"
@@ -6263,13 +6732,13 @@ Approve or request changes. Output a summary suitable for an issue comment."
         fi
 
         local review_verdict review_summary verdict_source
-        review_summary=$(printf '%s' "$review_result" | jq -r '.summary // "Review completed"')
+        review_summary=$(printf '%s' "$review_result" | jq -r '.output.summary // "Review completed"')
         local has_result_field
-        has_result_field=$(printf '%s' "$review_result" | jq 'has("result")' 2>/dev/null)
+        has_result_field=$(printf '%s' "$review_result" | jq '.output | has("result")' 2>/dev/null)
 
         if [[ "$has_result_field" == "true" ]]; then
-            # Structured output available: extract verdict from .result field
-            review_verdict=$(printf '%s' "$review_result" | jq -r '.result')
+            # Structured output available: extract verdict from .output.result field
+            review_verdict=$(printf '%s' "$review_result" | jq -r '.output.result')
             verdict_source="structured output"
             log "Verdict extracted from structured output: $review_verdict"
         else
@@ -6300,12 +6769,12 @@ Approve or request changes. Output a summary suitable for an issue comment."
         # -------------------------------------------------------------------------
         if [[ "$review_verdict" == "approved" ]]; then
             local major_issue_count
-            major_issue_count=$(printf '%s' "$review_result" | jq '[.issues // [] | .[] | select(.severity == "major")] | length' 2>/dev/null || echo "0")
+            major_issue_count=$(printf '%s' "$review_result" | jq '[.output.issues // [] | .[] | select(.severity == "major")] | length' 2>/dev/null || echo "0")
             if (( major_issue_count > 0 )); then
                 log_warn "Review verdict was 'approved' but $major_issue_count major issue(s) found — overriding to changes_requested"
                 review_verdict="changes_requested"
                 local major_descriptions
-                major_descriptions=$(printf '%s' "$review_result" | jq -r '[.issues[] | select(.severity == "major") | .description] | join("; ")' 2>/dev/null || echo "")
+                major_descriptions=$(printf '%s' "$review_result" | jq -r '[.output.issues[] | select(.severity == "major") | .description] | join("; ")' 2>/dev/null || echo "")
                 review_summary="${review_summary}
 
 ⚠️ **Override:** Reviewer approved but $major_issue_count major issue(s) must be resolved first:
@@ -6332,9 +6801,24 @@ ${major_descriptions}"
                     adj_title=$(printf '%s' "$adj_item" | jq -r '.title // ""')
                     adj_body=$(printf '%s' "$adj_item" | jq -r '.body // ""')
                     [[ -z "$adj_title" ]] && continue
+
+                    # Deduplication: skip if an open issue with the same title already exists
+                    local dup_count
+                    dup_count=$(gh issue list --state open --json title \
+                        2>/dev/null | jq --arg t "$adj_title" '[.[] | select(.title == $t)] | length' \
+                        2>/dev/null || echo "0")
+                    if (( dup_count > 0 )); then
+                        log "Skipping duplicate follow-up issue (title already open): $adj_title"
+                        continue
+                    fi
+
+                    # Validate/build body to enforce canonical task format
+                    local validated_body
+                    validated_body=$(_build_adj_body "$adj_body" "$adj_title")
+
                     local new_num
                     new_num=$("$PLATFORM_DIR/create-issue.sh" \
-                        --title "$adj_title" --body "$adj_body" \
+                        --title "$adj_title" --body "$validated_body" \
                         --labels "pipeline-followup" 2>/dev/null || true)
                     if [[ -n "$new_num" ]]; then
                         created_nums+=("#$new_num")
@@ -6367,11 +6851,11 @@ $review_summary$followup_comment" "code-reviewer"
 
             # Collect feedback
             local review_comments
-            review_comments=$(printf '%s' "$review_result" | jq -r '[.issues // [] | .[] | "\(.file // ""):\(.line // "") → \(.description // "")"] | join("\n- ")')
+            review_comments=$(printf '%s' "$review_result" | jq -r '[.output.issues // [] | .[] | "\(.file // ""):\(.line // "") → \(.description // "")"] | join("\n- ")')
 
             # Append current iteration issues to history file
             local current_issues
-            current_issues=$(printf '%s' "$review_result" | jq -c '.issues // []')
+            current_issues=$(printf '%s' "$review_result" | jq -c '.output.issues // []')
             if [[ -f "$review_history_file" ]]; then
                 local existing
                 existing=$(< "$review_history_file")
@@ -6415,7 +6899,7 @@ Fix the issues and commit. Output a summary of fixes applied."
             fix_result=$(run_stage "fix-pr-review-iter-$pr_iteration" "$fix_prompt" "implement-issue-fix.json" "$AGENT")
 
             local fix_summary
-            fix_summary=$(printf '%s' "$fix_result" | jq -r '.summary // "Fixes applied"')
+            fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
 
             # Comment #12: PR Fix Result
             comment_pr "$pr_number" "PR Review Fix (Iteration $pr_iteration)" "$fix_summary" "$AGENT"
@@ -6454,7 +6938,7 @@ $complete_skill
         complete_result=$(run_stage "complete" "$complete_prompt" "implement-issue-complete.json")
 
         local complete_summary
-        complete_summary=$(printf '%s' "$complete_result" | jq -r '.summary // "Implementation completed successfully"')
+        complete_summary=$(printf '%s' "$complete_result" | jq -r '.output.summary // "Implementation completed successfully"')
 
         # Add degradation warning to completion comment if any stages soft-failed
         local degraded_warning=""

--- a/.claude/scripts/implement-issue-test/fixtures/escalation-policy/accept-success.json
+++ b/.claude/scripts/implement-issue-test/fixtures/escalation-policy/accept-success.json
@@ -1,0 +1,12 @@
+{
+  "status": "success",
+  "output": {"status": "ok"},
+  "raw": "",
+  "denials": [],
+  "model": "haiku",
+  "error_kind": null,
+  "elapsed_ms": 100,
+  "_fixture_meta": {
+    "description": "Successful stage with valid output — expect accept"
+  }
+}

--- a/.claude/scripts/implement-issue-test/fixtures/escalation-policy/bail-permission-denied.json
+++ b/.claude/scripts/implement-issue-test/fixtures/escalation-policy/bail-permission-denied.json
@@ -1,0 +1,12 @@
+{
+  "status": "error",
+  "output": null,
+  "raw": "",
+  "denials": [],
+  "model": "haiku",
+  "error_kind": "permission_denied",
+  "elapsed_ms": 500,
+  "_fixture_meta": {
+    "description": "Permission denied — expect bail (unrecoverable, no model can bypass)"
+  }
+}

--- a/.claude/scripts/implement-issue-test/fixtures/escalation-policy/golden.manifest.txt
+++ b/.claude/scripts/implement-issue-test/fixtures/escalation-policy/golden.manifest.txt
@@ -1,0 +1,1 @@
+timeout-first-attempt|escalate|*

--- a/.claude/scripts/implement-issue-test/fixtures/escalation-policy/retry-same-rate-limit.json
+++ b/.claude/scripts/implement-issue-test/fixtures/escalation-policy/retry-same-rate-limit.json
@@ -1,0 +1,12 @@
+{
+  "status": "error",
+  "output": null,
+  "raw": "",
+  "denials": [],
+  "model": "haiku",
+  "error_kind": "rate_limit",
+  "elapsed_ms": 200,
+  "_fixture_meta": {
+    "description": "Rate limit on first attempt with empty history — expect retry_same"
+  }
+}

--- a/.claude/scripts/implement-issue-test/fixtures/escalation-policy/timeout-first-attempt.json
+++ b/.claude/scripts/implement-issue-test/fixtures/escalation-policy/timeout-first-attempt.json
@@ -1,0 +1,15 @@
+{
+  "status": "error",
+  "output": null,
+  "raw": "",
+  "denials": [],
+  "model": "haiku",
+  "error_kind": "timeout",
+  "elapsed_ms": 1800000,
+  "_fixture_meta": {
+    "stage": "implement",
+    "attempt": 1,
+    "max_attempts": 3,
+    "description": "First attempt at implement stage hit the wall-clock timeout. Expected escalation to sonnet."
+  }
+}

--- a/.claude/scripts/implement-issue-test/fixtures/model-fallback/at-ceiling.json
+++ b/.claude/scripts/implement-issue-test/fixtures/model-fallback/at-ceiling.json
@@ -1,0 +1,7 @@
+{
+  "current_model": "sonnet",
+  "error_kind": "permission_denied",
+  "_fixture_meta": {
+    "description": "permission_denied — non-escalatable error; no model can bypass permission hooks. Expected next_model=null, at_ceiling=true."
+  }
+}

--- a/.claude/scripts/implement-issue-test/fixtures/model-fallback/haiku-to-sonnet.json
+++ b/.claude/scripts/implement-issue-test/fixtures/model-fallback/haiku-to-sonnet.json
@@ -1,0 +1,7 @@
+{
+  "current_model": "haiku",
+  "error_kind": "timeout",
+  "_fixture_meta": {
+    "description": "Timeout on haiku — expected escalation to sonnet."
+  }
+}

--- a/.claude/scripts/implement-issue-test/fixtures/model-fallback/sonnet-to-opus.json
+++ b/.claude/scripts/implement-issue-test/fixtures/model-fallback/sonnet-to-opus.json
@@ -1,0 +1,7 @@
+{
+  "current_model": "sonnet",
+  "error_kind": "no_structured_output",
+  "_fixture_meta": {
+    "description": "no_structured_output on sonnet — expected escalation to opus."
+  }
+}

--- a/.claude/scripts/implement-issue-test/fixtures/retry-policy/bail-at-max-retries.json
+++ b/.claude/scripts/implement-issue-test/fixtures/retry-policy/bail-at-max-retries.json
@@ -1,0 +1,17 @@
+{
+  "stage_result": {
+    "status": "error",
+    "output": null,
+    "raw": "",
+    "denials": [],
+    "model": "opus",
+    "error_kind": "no_structured_output",
+    "elapsed_ms": 45000
+  },
+  "retry_count": 1,
+  "error_history": [],
+  "_fixture_meta": {
+    "description": "no_structured_output at retry_count=1 on opus (ceiling) — retry threshold met and cannot escalate; expect bail",
+    "expected_action": "bail"
+  }
+}

--- a/.claude/scripts/implement-issue-test/fixtures/retry-policy/golden.manifest.txt
+++ b/.claude/scripts/implement-issue-test/fixtures/retry-policy/golden.manifest.txt
@@ -1,0 +1,3 @@
+retry-on-rate-limit|retry|*
+bail-at-max-retries|bail|*
+immediate-escalate-max-turns|escalate|*

--- a/.claude/scripts/implement-issue-test/fixtures/retry-policy/immediate-escalate-max-turns.json
+++ b/.claude/scripts/implement-issue-test/fixtures/retry-policy/immediate-escalate-max-turns.json
@@ -1,0 +1,17 @@
+{
+  "stage_result": {
+    "status": "error",
+    "output": null,
+    "raw": "Max turns exhausted",
+    "denials": [],
+    "model": "haiku",
+    "error_kind": "max_turns_exhausted",
+    "elapsed_ms": 60000
+  },
+  "retry_count": 0,
+  "error_history": [],
+  "_fixture_meta": {
+    "description": "max_turns_exhausted at non-ceiling model haiku — same model cannot run more turns; expect immediate escalate to sonnet",
+    "expected_action": "escalate"
+  }
+}

--- a/.claude/scripts/implement-issue-test/fixtures/retry-policy/retry-on-rate-limit.json
+++ b/.claude/scripts/implement-issue-test/fixtures/retry-policy/retry-on-rate-limit.json
@@ -1,0 +1,18 @@
+{
+  "stage_result": {
+    "status": "error",
+    "output": null,
+    "raw": "API rate limit exceeded",
+    "denials": [],
+    "model": "haiku",
+    "error_kind": "rate_limit",
+    "elapsed_ms": 2100
+  },
+  "retry_count": 0,
+  "error_history": [],
+  "_fixture_meta": {
+    "description": "Rate limit on first attempt with empty history — expect retry with 30s backoff",
+    "expected_action": "retry",
+    "expected_backoff_ms": 30000
+  }
+}

--- a/.claude/scripts/implement-issue-test/helpers/test-helper.bash
+++ b/.claude/scripts/implement-issue-test/helpers/test-helper.bash
@@ -352,7 +352,7 @@ HEADER
         /^main "\$@"$/ { next }
 
         # Extract function definitions (function_name() { ... })
-        /^[a-z_]+\(\) \{$/,/^\}$/ { print; next }
+        /^[a-z_][a-z_0-9]*\(\) \{$/,/^\}$/ { print; next }
 
         # Skip platform config sourcing (test setup creates platform.sh in the right place)
         /^source "\$SCRIPT_DIR\/\.\.\/config\/platform\.sh"/ { next }

--- a/.claude/scripts/implement-issue-test/test-adj-body-validation.bats
+++ b/.claude/scripts/implement-issue-test/test-adj-body-validation.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+#
+# test-adj-body-validation.bats
+# Unit tests for _build_adj_body() — validates and synthesises the
+# Implementation Tasks section for adjacent follow-up issues.
+#
+# Cases covered:
+#   1. Body with valid canonical task line → returned unchanged
+#   2. Body with Implementation Tasks section containing only prose → section
+#      stripped, canonical line appended
+#   3. Body with no Implementation Tasks section at all → canonical line appended
+#   4. Empty body string → synthesised section only
+#   5. Optional checkbox ([ ]) in task line regex is matched (bracket is optional)
+#
+
+load 'helpers/test-helper.bash'
+
+setup() {
+	setup_test_env
+
+	export ISSUE_NUMBER=99
+	export BASE_BRANCH=main
+	export LOG_BASE="$TEST_TMP/logs/test"
+	export LOG_FILE="$LOG_BASE/orchestrator.log"
+	export STAGE_COUNTER=0
+	mkdir -p "$LOG_BASE"
+
+	source_orchestrator_functions
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# =============================================================================
+# Case 1: body already has a valid canonical task line → pass through unchanged
+# =============================================================================
+
+@test "_build_adj_body: valid canonical task line returns body unchanged" {
+	local body
+	body=$(printf 'Fix the bug.\n\n## Implementation Tasks\n\n- [ ] `[default]` **(M)** Patch the handler\n')
+	run _build_adj_body "$body" "Fix the bug"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'`[default]`'* ]]
+	[[ "$output" == *'Patch the handler'* ]]
+	# Original body prefix must be present
+	[[ "$output" == *'Fix the bug.'* ]]
+}
+
+# =============================================================================
+# Case 2: Implementation Tasks section exists but contains only prose
+# =============================================================================
+
+@test "_build_adj_body: prose-only tasks section is stripped and canonical line appended" {
+	local body
+	body=$(printf 'Context here.\n\n## Implementation Tasks\n\nTask 1: do something\nTask 2: do another thing\n')
+	run _build_adj_body "$body" "Improve the feature"
+	[ "$status" -eq 0 ]
+	# Prose lines must NOT appear in output
+	[[ "$output" != *'Task 1:'* ]]
+	# A synthesised canonical line using [default] must be present
+	[[ "$output" == *'`[default]`'* ]]
+	[[ "$output" == *'Improve the feature'* ]]
+}
+
+# =============================================================================
+# Case 3: no Implementation Tasks section at all
+# =============================================================================
+
+@test "_build_adj_body: missing Implementation Tasks section gets one appended" {
+	local body="Just a description with no tasks section."
+	run _build_adj_body "$body" "Add retry logic"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'## Implementation Tasks'* ]]
+	[[ "$output" == *'`[default]`'* ]]
+	[[ "$output" == *'Add retry logic'* ]]
+	# Original prose must be preserved before the section
+	[[ "$output" == *'Just a description'* ]]
+}
+
+# =============================================================================
+# Case 4: empty body string
+# =============================================================================
+
+@test "_build_adj_body: empty body produces only the synthesised section" {
+	run _build_adj_body "" "Create the widget"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'## Implementation Tasks'* ]]
+	[[ "$output" == *'`[default]`'* ]]
+	[[ "$output" == *'Create the widget'* ]]
+}
+
+# =============================================================================
+# Case 5: optional checkbox — task line without [ ] is still canonical
+# =============================================================================
+
+@test "_build_adj_body: canonical task line without checkbox bracket is accepted" {
+	local body
+	body=$(printf 'Desc.\n\n## Implementation Tasks\n\n- `[my-agent]` **(S)** Do the thing\n')
+	run _build_adj_body "$body" "Do the thing"
+	[ "$status" -eq 0 ]
+	# Should be returned unchanged (valid task detected)
+	[[ "$output" == *'`[my-agent]`'* ]]
+	[[ "$output" == *'Do the thing'* ]]
+	# Must NOT have a second synthesised section
+	local section_count
+	section_count=$(printf '%s' "$output" | grep -c '## Implementation Tasks' || true)
+	[ "$section_count" -eq 1 ]
+}

--- a/.claude/scripts/implement-issue-test/test-canary-measure.bats
+++ b/.claude/scripts/implement-issue-test/test-canary-measure.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+#
+# test-canary-measure.bats
+#
+# Tests for .claude/scripts/canary-measure.sh — the measurement tool that
+# aggregates wall-clock and token usage per issue, used to gate AC5 of
+# issue #179 (tokens-per-issue regression ≤ 10%, wall-clock regression ≤ 25%).
+#
+# Contract under test:
+#   - Reads metrics.json files (one per issue) from --logs-dir
+#   - Reads transcript JSONL files from --transcripts-dir
+#   - Matches transcripts to issues by `cwd` field (worktree path or log dir)
+#   - Outputs per-issue and aggregate stats as JSON or markdown
+#
+# Test cases:
+#   (a) emits one row per metrics.json with wall-clock seconds
+#   (b) sums tokens from matching transcripts (input + output + cache_*)
+#   (c) markdown output includes summary table
+#   (d) --label tags the output for before/after comparison
+#   (e) compute-deltas mode reports % change between two reports
+#
+
+load 'helpers/test-helper.bash'
+
+CANARY_SCRIPT=""
+
+setup() {
+    setup_test_env
+    CANARY_SCRIPT="$SCRIPT_DIR/canary-measure.sh"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+# Build a fake metrics.json under TEST_TMP/logs/implement-issue/issue-N-TS/
+make_metrics() {
+    local issue="$1"
+    local started="$2"
+    local completed="$3"
+    local duration="$4"
+    local ts_dir="20260504-${issue}0000"
+    local log_dir="$TEST_TMP/logs/implement-issue/issue-${issue}-${ts_dir}"
+    mkdir -p "$log_dir"
+    cat >"$log_dir/metrics.json" <<EOF
+{
+  "schema_version": "1",
+  "issue": "${issue}",
+  "base_branch": "main",
+  "branch": "feature/issue-${issue}",
+  "state": "completed",
+  "started_at": "${started}",
+  "completed_at": "${completed}",
+  "total_duration_seconds": ${duration},
+  "stages": {}
+}
+EOF
+    printf '%s\n' "$log_dir"
+}
+
+# Build a fake transcript JSONL under TEST_TMP/transcripts/<mangled>/
+make_transcript() {
+    local mangled="$1"
+    local input="$2"
+    local cache_creation="$3"
+    local cache_read="$4"
+    local output="$5"
+    local cwd="$6"
+    local ts="$7"
+    local dir="$TEST_TMP/transcripts/${mangled}"
+    mkdir -p "$dir"
+    cat >>"$dir/session.jsonl" <<EOF
+{"type":"assistant","timestamp":"${ts}","cwd":"${cwd}","message":{"usage":{"input_tokens":${input},"cache_creation_input_tokens":${cache_creation},"cache_read_input_tokens":${cache_read},"output_tokens":${output}}}}
+EOF
+}
+
+@test "(a) emits one row per metrics.json with wall-clock seconds" {
+    [[ -x "$CANARY_SCRIPT" ]] || skip "canary-measure.sh not present yet"
+
+    make_metrics 100 "2026-05-04T01:00:00Z" "2026-05-04T01:10:00Z" 600
+    make_metrics 101 "2026-05-04T02:00:00Z" "2026-05-04T02:30:00Z" 1800
+
+    run bash "$CANARY_SCRIPT" \
+        --logs-dir "$TEST_TMP/logs/implement-issue" \
+        --transcripts-dir "$TEST_TMP/transcripts" \
+        --format json
+
+    [ "$status" -eq 0 ]
+    issue_count=$(printf '%s' "$output" | jq '.issues | length')
+    [ "$issue_count" -eq 2 ]
+
+    wall_100=$(printf '%s' "$output" | jq '.issues[] | select(.issue=="100") | .wall_clock_seconds')
+    [ "$wall_100" -eq 600 ]
+    wall_101=$(printf '%s' "$output" | jq '.issues[] | select(.issue=="101") | .wall_clock_seconds')
+    [ "$wall_101" -eq 1800 ]
+}
+
+@test "(b) sums tokens from matching transcripts" {
+    [[ -x "$CANARY_SCRIPT" ]] || skip "canary-measure.sh not present yet"
+
+    log_dir=$(make_metrics 200 "2026-05-04T01:00:00Z" "2026-05-04T01:10:00Z" 600)
+
+    # Two transcripts whose cwd field matches the issue log dir or its worktrees
+    make_transcript "session-a" 100 1000 5000 50 \
+        "${log_dir}" "2026-05-04T01:01:00Z"
+    make_transcript "session-b" 200 0 0 75 \
+        "${log_dir}/worktrees/task-1" "2026-05-04T01:02:00Z"
+    # An unrelated transcript that should NOT count (different cwd)
+    make_transcript "session-c" 999 999 999 999 \
+        "/some/other/path" "2026-05-04T01:03:00Z"
+
+    run bash "$CANARY_SCRIPT" \
+        --logs-dir "$TEST_TMP/logs/implement-issue" \
+        --transcripts-dir "$TEST_TMP/transcripts" \
+        --format json
+
+    [ "$status" -eq 0 ]
+    input=$(printf '%s' "$output" | jq '.issues[0].input_tokens')
+    output_t=$(printf '%s' "$output" | jq '.issues[0].output_tokens')
+    cache_c=$(printf '%s' "$output" | jq '.issues[0].cache_creation_input_tokens')
+    cache_r=$(printf '%s' "$output" | jq '.issues[0].cache_read_input_tokens')
+    [ "$input" -eq 300 ]      # 100 + 200
+    [ "$output_t" -eq 125 ]   # 50 + 75
+    [ "$cache_c" -eq 1000 ]
+    [ "$cache_r" -eq 5000 ]
+}
+
+@test "(c) markdown output includes summary table" {
+    [[ -x "$CANARY_SCRIPT" ]] || skip "canary-measure.sh not present yet"
+
+    make_metrics 300 "2026-05-04T01:00:00Z" "2026-05-04T01:10:00Z" 600
+    make_metrics 301 "2026-05-04T02:00:00Z" "2026-05-04T02:30:00Z" 1800
+
+    run bash "$CANARY_SCRIPT" \
+        --logs-dir "$TEST_TMP/logs/implement-issue" \
+        --transcripts-dir "$TEST_TMP/transcripts" \
+        --format markdown
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"| Issue |"* ]]
+    [[ "$output" == *"300"* ]]
+    [[ "$output" == *"301"* ]]
+    [[ "$output" == *"Median wall-clock"* ]]
+}
+
+@test "(d) --label tags the output for before/after comparison" {
+    [[ -x "$CANARY_SCRIPT" ]] || skip "canary-measure.sh not present yet"
+
+    make_metrics 400 "2026-05-04T01:00:00Z" "2026-05-04T01:10:00Z" 600
+
+    run bash "$CANARY_SCRIPT" \
+        --logs-dir "$TEST_TMP/logs/implement-issue" \
+        --transcripts-dir "$TEST_TMP/transcripts" \
+        --label "subprocess-baseline" \
+        --format json
+
+    [ "$status" -eq 0 ]
+    label=$(printf '%s' "$output" | jq -r '.label')
+    [ "$label" = "subprocess-baseline" ]
+}
+
+@test "(e) --compute-deltas reports percentage change between two reports" {
+    [[ -x "$CANARY_SCRIPT" ]] || skip "canary-measure.sh not present yet"
+
+    cat >"$TEST_TMP/before.json" <<'EOF'
+{
+  "label": "before",
+  "summary": {
+    "wall_clock_total": 1000,
+    "wall_clock_median": 500,
+    "tokens_total": 100000,
+    "tokens_median": 50000
+  }
+}
+EOF
+    cat >"$TEST_TMP/after.json" <<'EOF'
+{
+  "label": "after",
+  "summary": {
+    "wall_clock_total": 1100,
+    "wall_clock_median": 550,
+    "tokens_total": 95000,
+    "tokens_median": 47500
+  }
+}
+EOF
+
+    run bash "$CANARY_SCRIPT" \
+        --compute-deltas \
+        --before "$TEST_TMP/before.json" \
+        --after "$TEST_TMP/after.json" \
+        --format json
+
+    [ "$status" -eq 0 ]
+    wall_pct=$(printf '%s' "$output" | jq '.deltas.wall_clock_median_pct')
+    tok_pct=$(printf '%s' "$output" | jq '.deltas.tokens_median_pct')
+    # 550/500 = +10%, 47500/50000 = -5%
+    [ "$wall_pct" = "10" ]
+    [ "$tok_pct" = "-5" ]
+}

--- a/.claude/scripts/implement-issue-test/test-event-emit.bats
+++ b/.claude/scripts/implement-issue-test/test-event-emit.bats
@@ -1,0 +1,447 @@
+#!/usr/bin/env bats
+#
+# test-event-emit.bats
+# Tests for event-emit.sh: JSONL append, schema validation, concurrency,
+# and events-prune.sh integration.
+#
+
+load 'helpers/test-helper.bash'
+
+# Absolute paths resolved once at load time
+EVENT_EMIT_SCRIPT="$SCRIPT_DIR/event-emit.sh"
+PRUNE_SCRIPT="$(cd "$SCRIPT_DIR/../../tools" 2>/dev/null && pwd)/events-prune.sh"
+
+setup() {
+	setup_test_env
+	export LOG_DIR="$TEST_TMP/logs"
+	mkdir -p "$LOG_DIR"
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Minimal valid stage_start event (all required top-level + oneOf fields)
+_valid_event() {
+	printf '%s' \
+		'{"ts":"2026-01-01T00:00:00Z","run_id":"test-run","stage":"test",' \
+		'"event":"stage_start","model":"claude-haiku"}'
+}
+
+# Minimal valid stage_end event
+_valid_stage_end() {
+	printf '%s' \
+		'{"ts":"2026-01-01T00:00:01Z","run_id":"test-run","stage":"test",' \
+		'"event":"stage_end","status":"success"}'
+}
+
+# =============================================================================
+# (a) VALID EVENT APPENDS EXACTLY ONE LINE
+# =============================================================================
+
+@test "(a) valid event appends one JSONL line to events.jsonl" {
+	local event
+	event=$(_valid_event)
+
+	run bash "$EVENT_EMIT_SCRIPT" "$event"
+	[ "$status" -eq 0 ]
+
+	local events_file="$LOG_DIR/events.jsonl"
+	[ -f "$events_file" ] || {
+		echo "events.jsonl was not created" >&2
+		return 1
+	}
+
+	local line_count
+	line_count=$(wc -l < "$events_file")
+	[ "$line_count" -eq 1 ]
+}
+
+@test "(a) appended line is valid JSON matching the emitted event" {
+	local event
+	event=$(_valid_event)
+
+	run bash "$EVENT_EMIT_SCRIPT" "$event"
+	[ "$status" -eq 0 ]
+
+	local events_file="$LOG_DIR/events.jsonl"
+	local stored_event
+	stored_event=$(head -1 "$events_file")
+
+	# Must be parseable JSON
+	printf '%s' "$stored_event" | jq -e '.' > /dev/null
+
+	# Key fields must round-trip
+	local stored_event_type
+	stored_event_type=$(printf '%s' "$stored_event" | jq -r '.event')
+	[ "$stored_event_type" = "stage_start" ]
+
+	local stored_run_id
+	stored_run_id=$(printf '%s' "$stored_event" | jq -r '.run_id')
+	[ "$stored_run_id" = "test-run" ]
+}
+
+@test "(a) second valid event appends a second line (no truncation)" {
+	local e1 e2
+	e1=$(_valid_event)
+	e2=$(_valid_stage_end)
+
+	run bash "$EVENT_EMIT_SCRIPT" "$e1"
+	[ "$status" -eq 0 ]
+
+	run bash "$EVENT_EMIT_SCRIPT" "$e2"
+	[ "$status" -eq 0 ]
+
+	local events_file="$LOG_DIR/events.jsonl"
+	local line_count
+	line_count=$(wc -l < "$events_file")
+	[ "$line_count" -eq 2 ]
+}
+
+@test "(a) events.jsonl is created when LOG_DIR does not yet exist" {
+	local fresh_dir="$TEST_TMP/fresh_logs"
+	local event
+	event=$(_valid_event)
+
+	LOG_DIR="$fresh_dir" run bash "$EVENT_EMIT_SCRIPT" "$event"
+	[ "$status" -eq 0 ]
+	[ -f "$fresh_dir/events.jsonl" ]
+}
+
+# =============================================================================
+# (b) SCHEMA-INVALID EVENTS ARE REJECTED
+# =============================================================================
+
+@test "(b) event missing required field 'ts' is rejected with exit 1" {
+	local event='{"run_id":"r","stage":"s","event":"stage_start","model":"m"}'
+
+	run bash "$EVENT_EMIT_SCRIPT" "$event"
+	[ "$status" -eq 1 ]
+}
+
+@test "(b) rejected event is NOT appended to events.jsonl" {
+	local event='{"run_id":"r","stage":"s","event":"stage_start","model":"m"}'
+
+	run bash "$EVENT_EMIT_SCRIPT" "$event"
+	[ "$status" -eq 1 ]
+
+	local events_file="$LOG_DIR/events.jsonl"
+	# File should not exist, or if it does, it must have 0 lines
+	if [ -f "$events_file" ]; then
+		local line_count
+		line_count=$(wc -l < "$events_file")
+		[ "$line_count" -eq 0 ]
+	fi
+}
+
+@test "(b) event with unknown 'event' enum value is rejected with exit 1" {
+	local event
+	event='{"ts":"2026-01-01T00:00:00Z","run_id":"r","stage":"s",'
+	event+='"event":"not_a_real_event_type"}'
+
+	run bash "$EVENT_EMIT_SCRIPT" "$event"
+	[ "$status" -eq 1 ]
+}
+
+@test "(b) non-JSON argument is rejected with exit 1" {
+	run bash "$EVENT_EMIT_SCRIPT" "this is not json at all"
+	[ "$status" -eq 1 ]
+}
+
+@test "(b) escalation event missing 'reason' field is rejected" {
+	# oneOf for escalation requires: event, reason, from_model, to_model
+	local event
+	event='{"ts":"2026-01-01T00:00:00Z","run_id":"r","stage":"s",'
+	event+='"event":"escalation","from_model":"haiku","to_model":"sonnet"}'
+
+	run bash "$EVENT_EMIT_SCRIPT" "$event"
+	[ "$status" -eq 1 ]
+}
+
+@test "(b) retry event missing 'attempt' field is rejected" {
+	local event
+	event='{"ts":"2026-01-01T00:00:00Z","run_id":"r","stage":"s",'
+	event+='"event":"retry","reason":"timeout","max_attempts":3}'
+
+	run bash "$EVENT_EMIT_SCRIPT" "$event"
+	[ "$status" -eq 1 ]
+}
+
+@test "(b) no argument produces usage error with exit 2" {
+	run bash "$EVENT_EMIT_SCRIPT"
+	[ "$status" -eq 2 ]
+}
+
+@test "(b) LOG_DIR unset produces environment error with exit 3" {
+	local event
+	event=$(_valid_event)
+
+	run env -u LOG_DIR bash "$EVENT_EMIT_SCRIPT" "$event"
+	[ "$status" -eq 3 ]
+}
+
+# =============================================================================
+# (c) CONCURRENT EMITS DO NOT CORRUPT THE FILE
+# =============================================================================
+
+@test "(c) 10 concurrent emits each append exactly one line (no corruption)" {
+	local events_file="$LOG_DIR/events.jsonl"
+	local pids=()
+	local i
+
+	for i in {1..10}; do
+		local pad
+		pad=$(printf '%02d' "$i")
+		local ev
+		ev='{"ts":"2026-01-01T00:00:'"$pad"'Z","run_id":"r'"$i"'",'
+		ev+='"stage":"test","event":"stage_start","model":"m"}'
+		LOG_DIR="$LOG_DIR" bash "$EVENT_EMIT_SCRIPT" "$ev" &
+		pids+=($!)
+	done
+
+	# Wait for all background jobs to complete
+	local failed=0
+	for pid in "${pids[@]}"; do
+		wait "$pid" || (( failed++ )) || true
+	done
+
+	[ "$failed" -eq 0 ] || {
+		echo "$failed concurrent emitter(s) exited non-zero" >&2
+		return 1
+	}
+
+	# Every line must be independently valid JSON
+	local bad_lines=0
+	while IFS= read -r line; do
+		if ! printf '%s' "$line" | jq -e '.' > /dev/null 2>&1; then
+			(( bad_lines++ )) || true
+		fi
+	done < "$events_file"
+
+	[ "$bad_lines" -eq 0 ] || {
+		echo "$bad_lines corrupted line(s) found in events.jsonl" >&2
+		return 1
+	}
+
+	# Exactly 10 lines must be present
+	local line_count
+	line_count=$(wc -l < "$events_file")
+	[ "$line_count" -eq 10 ]
+}
+
+@test "(c) flock path: concurrent writes with flock available produce valid JSONL" {
+	# Explicitly verify the flock code-path is exercised when flock exists
+	if ! command -v flock > /dev/null 2>&1; then
+		skip "flock not available on this platform"
+	fi
+
+	local events_file="$LOG_DIR/events.jsonl"
+	local pids=()
+	local i
+
+	for i in {1..5}; do
+		local pad
+		pad=$(printf '%02d' "$i")
+		local ev
+		ev='{"ts":"2026-01-01T00:01:'"$pad"'Z","run_id":"flock-'"$i"'",'
+		ev+='"stage":"test","event":"stage_end","status":"success"}'
+		LOG_DIR="$LOG_DIR" bash "$EVENT_EMIT_SCRIPT" "$ev" &
+		pids+=($!)
+	done
+
+	for pid in "${pids[@]}"; do
+		wait "$pid"
+	done
+
+	local line_count
+	line_count=$(wc -l < "$events_file")
+	[ "$line_count" -eq 5 ]
+
+	# Validate each line parses cleanly
+	while IFS= read -r line; do
+		printf '%s' "$line" | jq -e '.' > /dev/null
+	done < "$events_file"
+}
+
+@test "(c) sequential emits after concurrent batch preserve all prior lines" {
+	local events_file="$LOG_DIR/events.jsonl"
+	local pids=()
+	local i
+
+	# First: 5 concurrent
+	for i in {1..5}; do
+		local pad
+		pad=$(printf '%02d' "$i")
+		local ev
+		ev='{"ts":"2026-01-01T00:02:'"$pad"'Z","run_id":"seq-'"$i"'",'
+		ev+='"stage":"test","event":"stage_start","model":"m"}'
+		LOG_DIR="$LOG_DIR" bash "$EVENT_EMIT_SCRIPT" "$ev" &
+		pids+=($!)
+	done
+	for pid in "${pids[@]}"; do
+		wait "$pid"
+	done
+
+	# Then: 1 sequential
+	local ev_seq
+	ev_seq='{"ts":"2026-01-01T00:02:06Z","run_id":"seq-6",'
+	ev_seq+='"stage":"test","event":"stage_end","status":"success"}'
+	run bash "$EVENT_EMIT_SCRIPT" "$ev_seq"
+	[ "$status" -eq 0 ]
+
+	local line_count
+	line_count=$(wc -l < "$events_file")
+	[ "$line_count" -eq 6 ]
+}
+
+# =============================================================================
+# (d) events-prune.sh PRUNES >30-DAY-OLD events.jsonl FILES
+# =============================================================================
+
+@test "(d) prune script exists and is executable" {
+	[ -f "$PRUNE_SCRIPT" ] || {
+		echo "tools/events-prune.sh not found at: $PRUNE_SCRIPT" >&2
+		return 1
+	}
+	[ -x "$PRUNE_SCRIPT" ]
+}
+
+@test "(d) prune script deletes events.jsonl files older than 30 days" {
+	local old_dir="$TEST_TMP/old_run/logs"
+	mkdir -p "$old_dir"
+	printf '%s\n' \
+		'{"ts":"2020-01-01T00:00:00Z","run_id":"old","stage":"s","event":"stage_end","status":"success"}' \
+		> "$old_dir/events.jsonl"
+
+	# Back-date the file to 31 days ago (portable: use touch -t)
+	local old_date
+	old_date=$(date -d "31 days ago" +"%Y%m%d%H%M" 2>/dev/null \
+		|| date -v-31d +"%Y%m%d%H%M" 2>/dev/null) \
+		|| { skip "cannot back-date file on this platform"; return; }
+
+	touch -t "${old_date}" "$old_dir/events.jsonl"
+
+	run bash "$PRUNE_SCRIPT" "$TEST_TMP"
+	[ "$status" -eq 0 ]
+
+	[ ! -f "$old_dir/events.jsonl" ] || {
+		echo "Old events.jsonl was not removed" >&2
+		return 1
+	}
+}
+
+@test "(d) prune script keeps events.jsonl files newer than 30 days" {
+	local new_dir="$TEST_TMP/new_run/logs"
+	mkdir -p "$new_dir"
+	printf '%s\n' \
+		'{"ts":"2026-01-01T00:00:00Z","run_id":"new","stage":"s","event":"stage_end","status":"success"}' \
+		> "$new_dir/events.jsonl"
+
+	run bash "$PRUNE_SCRIPT" "$TEST_TMP"
+	[ "$status" -eq 0 ]
+
+	[ -f "$new_dir/events.jsonl" ] || {
+		echo "Recent events.jsonl was incorrectly removed" >&2
+		return 1
+	}
+}
+
+@test "(d) prune script --dry-run does not delete files" {
+	local old_dir="$TEST_TMP/dry_run_test/logs"
+	mkdir -p "$old_dir"
+	printf '%s\n' '{}' > "$old_dir/events.jsonl"
+
+	local old_date
+	old_date=$(date -d "40 days ago" +"%Y%m%d%H%M" 2>/dev/null \
+		|| date -v-40d +"%Y%m%d%H%M" 2>/dev/null) \
+		|| { skip "cannot back-date file on this platform"; return; }
+
+	touch -t "${old_date}" "$old_dir/events.jsonl"
+
+	run bash "$PRUNE_SCRIPT" --dry-run "$TEST_TMP"
+	[ "$status" -eq 0 ]
+
+	[ -f "$old_dir/events.jsonl" ] || {
+		echo "dry-run deleted the file when it should not have" >&2
+		return 1
+	}
+}
+
+@test "(d) prune script --max-age-days custom threshold prunes matching file" {
+	local dir="$TEST_TMP/custom_age/logs"
+	mkdir -p "$dir"
+	printf '%s\n' '{}' > "$dir/events.jsonl"
+
+	# Back-date the file to 2 days ago so --max-age-days 1 matches it
+	local old_date
+	old_date=$(date -d "2 days ago" +"%Y%m%d%H%M" 2>/dev/null \
+		|| date -v-2d +"%Y%m%d%H%M" 2>/dev/null) \
+		|| { skip "cannot back-date file on this platform"; return; }
+
+	touch -t "${old_date}" "$dir/events.jsonl"
+
+	run bash "$PRUNE_SCRIPT" --max-age-days 1 "$TEST_TMP"
+	[ "$status" -eq 0 ]
+
+	[ ! -f "$dir/events.jsonl" ] || {
+		echo "events.jsonl should have been pruned by --max-age-days 1" >&2
+		return 1
+	}
+}
+
+@test "(d) prune script with empty directory exits 0 (nothing to do)" {
+	local empty="$TEST_TMP/empty_search"
+	mkdir -p "$empty"
+
+	run bash "$PRUNE_SCRIPT" "$empty"
+	[ "$status" -eq 0 ]
+}
+
+@test "(d) prune script without argument exits 1 with usage hint" {
+	run bash "$PRUNE_SCRIPT"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"error"* ]]
+}
+
+# =============================================================================
+# (e) SCHEMA_VALIDATION_FAIL EVENT WITH errors=[] IS ACCEPTED
+# =============================================================================
+
+@test "(e) schema_validation_fail event with errors=[] passes schema validation" {
+	local event
+	event='{"ts":"2026-01-01T00:00:00Z","run_id":"test-run","stage":"test",'
+	event+='"event":"schema_validation_fail","schema":"implement-issue-triage.json","errors":[]}'
+
+	run bash "$EVENT_EMIT_SCRIPT" "$event"
+	[ "$status" -eq 0 ]
+}
+
+@test "(d) prune script prunes only events.jsonl — not other old log files" {
+	local dir="$TEST_TMP/mixed/logs"
+	mkdir -p "$dir"
+	printf '%s\n' 'data' > "$dir/events.jsonl"
+	printf '%s\n' 'log' > "$dir/orchestrator.log"
+
+	local old_date
+	old_date=$(date -d "35 days ago" +"%Y%m%d%H%M" 2>/dev/null \
+		|| date -v-35d +"%Y%m%d%H%M" 2>/dev/null) \
+		|| { skip "cannot back-date file on this platform"; return; }
+
+	touch -t "${old_date}" "$dir/events.jsonl" "$dir/orchestrator.log"
+
+	run bash "$PRUNE_SCRIPT" "$TEST_TMP"
+	[ "$status" -eq 0 ]
+
+	[ ! -f "$dir/events.jsonl" ] || {
+		echo "events.jsonl should have been pruned" >&2
+		return 1
+	}
+	[ -f "$dir/orchestrator.log" ] || {
+		echo "orchestrator.log should NOT have been pruned" >&2
+		return 1
+	}
+}

--- a/.claude/scripts/implement-issue-test/test-feedback-record.bats
+++ b/.claude/scripts/implement-issue-test/test-feedback-record.bats
@@ -1,0 +1,400 @@
+#!/usr/bin/env bats
+#
+# test-feedback-record.bats
+#
+# Tests for .claude/scripts/feedback-record.sh — the bash helper that the
+# pipeline-feedback skill invokes to append a structured JSONL record to
+# logs/feedback/<kind>.jsonl.
+#
+# Contract under test (from issue #176):
+#   - Accepts --kind, --issue, --observed, --expected, --evidence, --notes
+#   - Validates against .claude/scripts/schemas/pipeline-feedback.json via jq
+#   - Appends one JSONL line to logs/feedback/<kind>.jsonl (relative to CWD)
+#   - Rejects invalid kinds and missing required fields with non-zero exit
+#   - Idempotent on identical record within a 60s window
+#
+# Test cases (per task 4 of issue #176):
+#   (a) valid record appends one line
+#   (b) invalid kind rejected with non-zero exit
+#   (c) missing required field rejected
+#   (d) idempotent on duplicate within 60s
+#
+
+load 'helpers/test-helper.bash'
+
+# Path to the script under test (resolved against the real repo, not TEST_TMP)
+FEEDBACK_SCRIPT=""
+
+setup() {
+    setup_test_env
+
+    FEEDBACK_SCRIPT="$SCRIPT_DIR/feedback-record.sh"
+
+    # Ensure schemas dir exists in TEST_TMP and contains the pipeline-feedback
+    # schema if the real one is present. The script needs to find this for jq
+    # validation; we mirror the real layout under TEST_TMP/.claude/scripts.
+    mkdir -p "$TEST_TMP/.claude/scripts/schemas"
+    if [[ -f "$SCRIPT_DIR/schemas/pipeline-feedback.json" ]]; then
+        cp "$SCRIPT_DIR/schemas/pipeline-feedback.json" \
+            "$TEST_TMP/.claude/scripts/schemas/pipeline-feedback.json"
+    fi
+
+    # Some scripts in this repo resolve paths via CLAUDE_PROJECT_DIR; export
+    # it so the script can locate the schema regardless of CWD.
+    export CLAUDE_PROJECT_DIR="$TEST_TMP"
+
+    # Tests run from TEST_TMP so logs/feedback/ lands in the temp dir.
+    cd "$TEST_TMP" || return 1
+}
+
+teardown() {
+    teardown_test_env
+}
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+# Run the feedback-record script with the given args. Captures status/output
+# via bats `run`, so callers can assert on `$status` and `$output`.
+run_feedback() {
+    run bash "$FEEDBACK_SCRIPT" "$@"
+}
+
+# =============================================================================
+# (a) VALID RECORD APPENDS ONE LINE
+# =============================================================================
+
+@test "(a) valid record appends one line to logs/feedback/<kind>.jsonl" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind triage_misclassification \
+        --issue 2840 \
+        --observed fast_path \
+        --expected full \
+        --evidence "logs/triage/issue-2840.json" \
+        --notes "Security concern missed"
+
+    [ "$status" -eq 0 ]
+
+    local jsonl="logs/feedback/triage_misclassification.jsonl"
+    [ -f "$jsonl" ] || { echo "expected $jsonl to exist"; return 1; }
+
+    local line_count
+    line_count=$(wc -l < "$jsonl" | tr -d ' ')
+    [ "$line_count" = "1" ]
+}
+
+@test "(a) appended record is valid JSON with all expected fields" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind prompt_regression \
+        --issue 2841 \
+        --observed "verbose output" \
+        --expected "concise output" \
+        --evidence "logs/run/2841.log" \
+        --notes "Regression after model bump"
+
+    [ "$status" -eq 0 ]
+
+    local jsonl="logs/feedback/prompt_regression.jsonl"
+    [ -f "$jsonl" ]
+
+    # Line must be valid JSON
+    jq -e '.' < "$jsonl" >/dev/null
+
+    # Required fields populated
+    local kind issue observed expected
+    kind=$(jq -r '.kind' < "$jsonl")
+    issue=$(jq -r '.issue' < "$jsonl")
+    observed=$(jq -r '.observed' < "$jsonl")
+    expected=$(jq -r '.expected' < "$jsonl")
+
+    [ "$kind" = "prompt_regression" ]
+    [ "$issue" = "2841" ]
+    [ "$observed" = "verbose output" ]
+    [ "$expected" = "concise output" ]
+
+    # Timestamp must be present and non-empty
+    local ts
+    ts=$(jq -r '.timestamp' < "$jsonl")
+    [ -n "$ts" ]
+    [ "$ts" != "null" ]
+}
+
+@test "(a) two distinct records append two lines to the same kind file" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind agent_misroute \
+        --issue 2850 \
+        --observed "code-reviewer" \
+        --expected "test-engineer" \
+        --evidence "logs/dispatch/2850.json" \
+        --notes "First observation"
+    [ "$status" -eq 0 ]
+
+    run_feedback \
+        --kind agent_misroute \
+        --issue 2851 \
+        --observed "fullstack-engineer" \
+        --expected "tdd-expert" \
+        --evidence "logs/dispatch/2851.json" \
+        --notes "Second observation"
+    [ "$status" -eq 0 ]
+
+    local jsonl="logs/feedback/agent_misroute.jsonl"
+    local line_count
+    line_count=$(wc -l < "$jsonl" | tr -d ' ')
+    [ "$line_count" = "2" ]
+}
+
+@test "(a) different kinds write to different files" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind criterion_drift \
+        --issue 2860 \
+        --observed "stale criterion" \
+        --expected "updated criterion" \
+        --evidence "logs/criteria/2860.md" \
+        --notes "Drift after rubric update"
+    [ "$status" -eq 0 ]
+
+    run_feedback \
+        --kind escalation_loop \
+        --issue 2861 \
+        --observed "5 escalations" \
+        --expected "1 escalation" \
+        --evidence "logs/escalation/2861.json" \
+        --notes "Loop in quality stage"
+    [ "$status" -eq 0 ]
+
+    [ -f "logs/feedback/criterion_drift.jsonl" ]
+    [ -f "logs/feedback/escalation_loop.jsonl" ]
+}
+
+# =============================================================================
+# (b) INVALID KIND REJECTED WITH NON-ZERO EXIT
+# =============================================================================
+
+@test "(b) invalid kind rejected with non-zero exit" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind not_a_real_kind \
+        --issue 2870 \
+        --observed "x" \
+        --expected "y" \
+        --evidence "logs/x" \
+        --notes "n"
+
+    [ "$status" -ne 0 ]
+    # Error must be actionable — mention the bad kind or list valid kinds.
+    [[ "$output" == *"kind"* ]] || [[ "$output" == *"not_a_real_kind"* ]]
+}
+
+@test "(b) invalid kind does not create a JSONL file" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind bogus_kind \
+        --issue 2871 \
+        --observed "x" \
+        --expected "y" \
+        --evidence "logs/x" \
+        --notes "n"
+
+    [ "$status" -ne 0 ]
+    [ ! -f "logs/feedback/bogus_kind.jsonl" ]
+}
+
+@test "(b) empty kind rejected with non-zero exit" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind "" \
+        --issue 2872 \
+        --observed "x" \
+        --expected "y" \
+        --evidence "logs/x" \
+        --notes "n"
+
+    [ "$status" -ne 0 ]
+}
+
+# =============================================================================
+# (c) MISSING REQUIRED FIELD REJECTED
+# =============================================================================
+
+@test "(c) missing --kind rejected with non-zero exit" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --issue 2880 \
+        --observed "x" \
+        --expected "y" \
+        --evidence "logs/x" \
+        --notes "n"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"kind"* ]]
+}
+
+@test "(c) missing --issue rejected with non-zero exit" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind triage_misclassification \
+        --observed "x" \
+        --expected "y" \
+        --evidence "logs/x" \
+        --notes "n"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"issue"* ]]
+}
+
+@test "(c) missing --observed rejected with non-zero exit" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind triage_misclassification \
+        --issue 2881 \
+        --expected "y" \
+        --evidence "logs/x" \
+        --notes "n"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"observed"* ]]
+}
+
+@test "(c) missing --expected rejected with non-zero exit" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind triage_misclassification \
+        --issue 2882 \
+        --observed "x" \
+        --evidence "logs/x" \
+        --notes "n"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"expected"* ]]
+}
+
+@test "(c) missing required field does not create a JSONL file" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind triage_misclassification \
+        --observed "x" \
+        --expected "y" \
+        --evidence "logs/x" \
+        --notes "n"
+
+    [ "$status" -ne 0 ]
+    [ ! -f "logs/feedback/triage_misclassification.jsonl" ]
+}
+
+# =============================================================================
+# (d) IDEMPOTENT ON DUPLICATE WITHIN 60s
+# =============================================================================
+
+@test "(d) duplicate record within 60s does not append a second line" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    # First call: writes one line.
+    run_feedback \
+        --kind criterion_drift \
+        --issue 2890 \
+        --observed "obs-A" \
+        --expected "exp-A" \
+        --evidence "logs/x" \
+        --notes "n"
+    [ "$status" -eq 0 ]
+
+    # Second call: identical args, should be a no-op (still exit 0).
+    run_feedback \
+        --kind criterion_drift \
+        --issue 2890 \
+        --observed "obs-A" \
+        --expected "exp-A" \
+        --evidence "logs/x" \
+        --notes "n"
+    [ "$status" -eq 0 ]
+
+    local jsonl="logs/feedback/criterion_drift.jsonl"
+    local line_count
+    line_count=$(wc -l < "$jsonl" | tr -d ' ')
+    [ "$line_count" = "1" ]
+}
+
+@test "(d) duplicate older than 60s appends a new line" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind escalation_loop \
+        --issue 2891 \
+        --observed "obs-B" \
+        --expected "exp-B" \
+        --evidence "logs/x" \
+        --notes "n"
+    [ "$status" -eq 0 ]
+
+    local jsonl="logs/feedback/escalation_loop.jsonl"
+    [ -f "$jsonl" ]
+
+    # Backdate the existing record by rewriting its timestamp to >60s ago.
+    # We compute "two minutes ago" in ISO-8601 UTC. Both BSD (macOS) and GNU
+    # date are supported; we try BSD first and fall back to GNU.
+    local backdated
+    backdated=$(date -u -v-2M +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+        || date -u -d '2 minutes ago' +"%Y-%m-%dT%H:%M:%SZ")
+    jq -c --arg ts "$backdated" '.timestamp = $ts' "$jsonl" > "$jsonl.tmp"
+    mv "$jsonl.tmp" "$jsonl"
+
+    # Re-record the identical record; now outside the 60s window so it appends.
+    run_feedback \
+        --kind escalation_loop \
+        --issue 2891 \
+        --observed "obs-B" \
+        --expected "exp-B" \
+        --evidence "logs/x" \
+        --notes "n"
+    [ "$status" -eq 0 ]
+
+    local line_count
+    line_count=$(wc -l < "$jsonl" | tr -d ' ')
+    [ "$line_count" = "2" ]
+}
+
+@test "(d) different record content within 60s appends a new line" {
+    [[ -x "$FEEDBACK_SCRIPT" ]] || skip "feedback-record.sh not present yet"
+
+    run_feedback \
+        --kind agent_misroute \
+        --issue 2892 \
+        --observed "obs-C" \
+        --expected "exp-C" \
+        --evidence "logs/x" \
+        --notes "n"
+    [ "$status" -eq 0 ]
+
+    # Same kind+issue, different observed value → not a duplicate.
+    run_feedback \
+        --kind agent_misroute \
+        --issue 2892 \
+        --observed "obs-D" \
+        --expected "exp-C" \
+        --evidence "logs/x" \
+        --notes "n"
+    [ "$status" -eq 0 ]
+
+    local jsonl="logs/feedback/agent_misroute.jsonl"
+    local line_count
+    line_count=$(wc -l < "$jsonl" | tr -d ' ')
+    [ "$line_count" = "2" ]
+}

--- a/.claude/scripts/implement-issue-test/test-helper-functions.bats
+++ b/.claude/scripts/implement-issue-test/test-helper-functions.bats
@@ -323,18 +323,21 @@ teardown() {
 # is_stage_timeout() — timeout detection helper
 # =============================================================================
 
+# is_stage_timeout consumes the stage_result envelope (issue #178 PR-A).
+# Envelope shape: {status, output, raw, denials, model, error_kind, elapsed_ms}.
+# Timeout is signalled by status=="error" AND error_kind=="timeout".
 @test "is_stage_timeout returns 0 (true) for timeout error JSON" {
-    run is_stage_timeout '{"status":"error","error":"timeout"}'
+    run is_stage_timeout '{"status":"error","output":null,"error_kind":"timeout"}'
     [ "$status" -eq 0 ]
 }
 
 @test "is_stage_timeout returns 1 (false) for successful result" {
-    run is_stage_timeout '{"status":"success","result":"passed","summary":"All tests passed"}'
+    run is_stage_timeout '{"status":"success","output":{"result":"passed","summary":"All tests passed"},"error_kind":null}'
     [ "$status" -eq 1 ]
 }
 
 @test "is_stage_timeout returns 1 (false) for non-timeout error" {
-    run is_stage_timeout '{"status":"error","error":"no structured output"}'
+    run is_stage_timeout '{"status":"error","output":null,"error_kind":"no_structured_output"}'
     [ "$status" -eq 1 ]
 }
 
@@ -344,7 +347,7 @@ teardown() {
 }
 
 @test "is_stage_timeout returns 1 (false) for schema-not-found error" {
-    run is_stage_timeout '{"status":"error","error":"schema not found"}'
+    run is_stage_timeout '{"status":"error","output":null,"error_kind":"schema_not_found"}'
     [ "$status" -eq 1 ]
 }
 

--- a/.claude/scripts/implement-issue-test/test-orchestrator-composition.bats
+++ b/.claude/scripts/implement-issue-test/test-orchestrator-composition.bats
@@ -1,0 +1,360 @@
+#!/usr/bin/env bats
+#
+# test-orchestrator-composition.bats
+# Tests for composition routing: standard vs isolated subprocess dispatch
+#
+# This file covers the composition backend added by issue #179 and updated
+# in issue #199 to remove the misleading "Skill-tool path" terminology.
+#
+# ARCHITECTURAL CONSTRAINT: bash cannot invoke the Skill tool.
+# Both dispatch paths are `claude -p` subprocess calls.  The distinction is
+# only in whether --dangerously-skip-permissions is forwarded:
+#   - standard (isolated=false): no --dangerously-skip-permissions; for
+#     decision/review tasks like process-pr
+#   - isolated subprocess (isolated=true): with --dangerously-skip-permissions;
+#     for worktree-isolated implementation tasks
+#
+# Cases covered:
+#
+#   (a) Standard subprocess path — non-isolated cases:
+#     1. dispatch_composition with isolated=false routes to standard path by default
+#     2. Standard path does NOT invoke the isolated subprocess
+#     3. dispatch_composition with no second arg defaults to standard path
+#
+#   (b) Isolated subprocess path — worktree/isolated cases:
+#     1. dispatch_composition with isolated=true routes to isolated subprocess by default
+#     2. Isolated subprocess path invokes run_composition_subprocess
+#     3. batch-runner.sh implement-issue call is still an isolated subprocess invocation
+#        (worktree isolation is the point)
+#
+#   (c) Kill-switch — COMPOSITION_BACKEND env var overrides routing:
+#     1. COMPOSITION_BACKEND=subprocess forces isolated subprocess even when isolated=false
+#     2. COMPOSITION_BACKEND=skill forces standard path even when isolated=true
+#        NOTE: "skill" is a legacy value name; it selects run_composition_standard(),
+#        not the Skill tool (bash cannot invoke the Skill tool)
+#     3. Unknown COMPOSITION_BACKEND value exits non-zero with an error message
+#     4. Unset COMPOSITION_BACKEND leaves auto-routing in effect
+#
+
+load 'helpers/test-helper.bash'
+
+# =============================================================================
+# LOCAL STATE
+# =============================================================================
+
+BATCH_ORCHESTRATOR_SCRIPT=""
+BATCH_RUNNER_SCRIPT=""
+
+# Set to "true" once dispatch_composition() is sourced successfully.
+# Unit tests skip when this is "false" (function not yet implemented).
+DISPATCH_AVAILABLE="false"
+
+# =============================================================================
+# HELPER: source dispatch_composition from batch-orchestrator.sh
+# =============================================================================
+
+# Extract and source the dispatch_composition family of functions from
+# batch-orchestrator.sh.  Mirrors the source_batch_emit_event() pattern in
+# test-batch-events.bats, scoped to the composition functions.
+#
+# Returns 0 and sets DISPATCH_AVAILABLE=true on success.
+# Returns 1 (without aborting) when the function is not yet in the script.
+source_batch_dispatch_composition() {
+	local func_file="$TEST_TMP/batch_dispatch_composition.bash"
+
+	# Extract all three related function definitions using awk.
+	# Note: run_composition_skill() was renamed to run_composition_standard()
+	# (architectural constraint: bash cannot invoke the Skill tool).
+	awk '
+		/^dispatch_composition\(\) \{$/,/^\}$/        { print; next }
+		/^run_composition_subprocess\(\) \{$/,/^\}$/  { print; next }
+		/^run_composition_standard\(\) \{$/,/^\}$/    { print; next }
+	' "$BATCH_ORCHESTRATOR_SCRIPT" > "$func_file"
+
+	if ! grep -q "dispatch_composition()" "$func_file" 2>/dev/null; then
+		printf 'NOTE: dispatch_composition() not yet in %s — unit tests will skip\n' \
+			"$BATCH_ORCHESTRATOR_SCRIPT" >&2
+		DISPATCH_AVAILABLE="false"
+		return 1
+	fi
+
+	# shellcheck disable=SC1090
+	source "$func_file"
+	DISPATCH_AVAILABLE="true"
+	return 0
+}
+
+# Install call-tracking mocks for run_composition_subprocess and
+# run_composition_standard.  Each mock writes the supplied prompt to a
+# sentinel file so tests can assert which path was taken.
+#
+# Note: run_composition_skill() was renamed to run_composition_standard()
+# because bash cannot invoke the Skill tool — both composition paths are
+# plain `claude -p` subprocess calls; the distinction is only in whether
+# --dangerously-skip-permissions is forwarded.
+#
+# After calling, check:
+#   "$TEST_TMP/subprocess_called"  — exists iff isolated subprocess path was taken
+#   "$TEST_TMP/standard_called"    — exists iff standard subprocess path was taken
+#   "$TEST_TMP/subprocess_prompt"  — prompt passed to isolated subprocess path
+#   "$TEST_TMP/standard_prompt"    — prompt passed to standard subprocess path
+install_composition_mocks() {
+	run_composition_subprocess() {
+		printf '%s' "$1" > "$TEST_TMP/subprocess_prompt"
+		touch "$TEST_TMP/subprocess_called"
+		return 0
+	}
+	export -f run_composition_subprocess
+
+	run_composition_standard() {
+		printf '%s' "$1" > "$TEST_TMP/standard_prompt"
+		touch "$TEST_TMP/standard_called"
+		return 0
+	}
+	export -f run_composition_standard
+}
+
+# Skip the current test when dispatch_composition() has not yet been merged.
+# Usage: require_dispatch_composition
+require_dispatch_composition() {
+	if [[ "$DISPATCH_AVAILABLE" != "true" ]]; then
+		skip "dispatch_composition() not yet implemented (TDD)"
+	fi
+}
+
+# =============================================================================
+# SETUP / TEARDOWN
+# =============================================================================
+
+setup() {
+	setup_test_env
+
+	# SCRIPT_DIR is set by test-helper.bash to .claude/scripts/
+	BATCH_ORCHESTRATOR_SCRIPT="$SCRIPT_DIR/batch-orchestrator.sh"
+	BATCH_RUNNER_SCRIPT="$SCRIPT_DIR/batch-runner.sh"
+
+	export LOG_BASE="$TEST_TMP/logs/batch-20240101-100000"
+	export LOG_FILE="$LOG_BASE/orchestrator.log"
+	mkdir -p "$LOG_BASE"
+
+	# Clear any inherited kill-switch so tests start with auto-routing.
+	unset COMPOSITION_BACKEND
+
+	# Try to source dispatch_composition — soft failure if not implemented yet.
+	source_batch_dispatch_composition || true
+	install_composition_mocks
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# =============================================================================
+# (a) STANDARD SUBPROCESS PATH — non-isolated cases
+# =============================================================================
+
+@test "(a) dispatch_composition isolated=false routes to standard path by default" {
+	require_dispatch_composition
+
+	dispatch_composition "/process-pr 123 456 main" "false"
+
+	[ -f "$TEST_TMP/standard_called" ]
+}
+
+@test "(a) dispatch_composition isolated=false does NOT invoke isolated subprocess" {
+	require_dispatch_composition
+
+	dispatch_composition "/process-pr 123 456 main" "false"
+
+	[ ! -f "$TEST_TMP/subprocess_called" ]
+}
+
+@test "(a) standard path receives the prompt unchanged" {
+	require_dispatch_composition
+
+	dispatch_composition "/process-pr 99 77 feature" "false"
+
+	[ -f "$TEST_TMP/standard_prompt" ]
+	local actual
+	actual=$(< "$TEST_TMP/standard_prompt")
+	[[ "$actual" == "/process-pr 99 77 feature" ]]
+}
+
+@test "(a) dispatch_composition with no isolated arg defaults to standard path" {
+	require_dispatch_composition
+
+	# Omitting the second arg should behave the same as isolated=false.
+	dispatch_composition "/process-pr 1 2 main"
+
+	[ -f "$TEST_TMP/standard_called" ]
+	[ ! -f "$TEST_TMP/subprocess_called" ]
+}
+
+@test "(a) dispatch_composition exits 0 on standard path" {
+	require_dispatch_composition
+
+	run dispatch_composition "/process-pr 1 2 main" "false"
+
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# (b) SUBPROCESS PATH — worktree/isolated cases
+# =============================================================================
+
+@test "(b) dispatch_composition isolated=true routes to subprocess by default" {
+	require_dispatch_composition
+
+	dispatch_composition "/implement-issue 123 main" "true"
+
+	[ -f "$TEST_TMP/subprocess_called" ]
+}
+
+@test "(b) dispatch_composition isolated=true does NOT invoke standard path" {
+	require_dispatch_composition
+
+	dispatch_composition "/implement-issue 123 main" "true"
+
+	[ ! -f "$TEST_TMP/standard_called" ]
+}
+
+@test "(b) subprocess path receives the prompt unchanged" {
+	require_dispatch_composition
+
+	dispatch_composition "/implement-issue 456 feature" "true"
+
+	[ -f "$TEST_TMP/subprocess_prompt" ]
+	local actual
+	actual=$(< "$TEST_TMP/subprocess_prompt")
+	[[ "$actual" == "/implement-issue 456 feature" ]]
+}
+
+@test "(b) dispatch_composition exits 0 on subprocess path" {
+	require_dispatch_composition
+
+	run dispatch_composition "/implement-issue 123 main" "true"
+
+	[ "$status" -eq 0 ]
+}
+
+@test "(b) batch-runner.sh implement-issue call is still a subprocess invocation" {
+	# Structural test: the implement-issue invocation in batch-runner.sh must
+	# remain a subprocess call — worktree isolation is the point.
+	# This test does NOT require dispatch_composition() to be implemented.
+	[ -f "$BATCH_RUNNER_SCRIPT" ] \
+		|| { printf 'SKIP: batch-runner.sh not found at %s\n' \
+			"$BATCH_RUNNER_SCRIPT" >&2; skip; }
+
+	# Accept any line where claude -p and implement-issue appear together
+	# (may be inline or wrapped in an if/timeout/env chain).
+	local pattern
+	pattern='claude[[:space:]].*-p.*implement-issue'
+	grep -qE "$pattern" "$BATCH_RUNNER_SCRIPT"
+}
+
+# =============================================================================
+# (c) KILL-SWITCH — COMPOSITION_BACKEND env var overrides
+# =============================================================================
+
+@test "(c) COMPOSITION_BACKEND=subprocess forces subprocess even when isolated=false" {
+	require_dispatch_composition
+	export COMPOSITION_BACKEND="subprocess"
+
+	dispatch_composition "/process-pr 123 456 main" "false"
+
+	[ -f "$TEST_TMP/subprocess_called" ]
+	[ ! -f "$TEST_TMP/standard_called" ]
+}
+
+@test "(c) COMPOSITION_BACKEND=subprocess prompt is passed to subprocess path" {
+	require_dispatch_composition
+	export COMPOSITION_BACKEND="subprocess"
+
+	dispatch_composition "/process-pr 7 8 main" "false"
+
+	local actual
+	actual=$(< "$TEST_TMP/subprocess_prompt")
+	[[ "$actual" == "/process-pr 7 8 main" ]]
+}
+
+@test "(c) COMPOSITION_BACKEND=skill forces standard path even when isolated=true" {
+	# NOTE: COMPOSITION_BACKEND=skill is a legacy value name; it routes to
+	# run_composition_standard() (the non-sandboxed subprocess path).
+	# It does NOT invoke the Skill tool — bash cannot do that.
+	require_dispatch_composition
+	export COMPOSITION_BACKEND="skill"
+
+	dispatch_composition "/implement-issue 123 main" "true"
+
+	[ -f "$TEST_TMP/standard_called" ]
+	[ ! -f "$TEST_TMP/subprocess_called" ]
+}
+
+@test "(c) COMPOSITION_BACKEND=skill prompt is passed to standard path" {
+	require_dispatch_composition
+	export COMPOSITION_BACKEND="skill"
+
+	dispatch_composition "/implement-issue 9 feature" "true"
+
+	local actual
+	actual=$(< "$TEST_TMP/standard_prompt")
+	[[ "$actual" == "/implement-issue 9 feature" ]]
+}
+
+@test "(c) unknown COMPOSITION_BACKEND value exits non-zero" {
+	require_dispatch_composition
+	export COMPOSITION_BACKEND="invalid-backend"
+
+	run dispatch_composition "/process-pr 1 2 main" "false"
+
+	[ "$status" -ne 0 ]
+}
+
+@test "(c) unknown COMPOSITION_BACKEND error message names the bad value" {
+	require_dispatch_composition
+	export COMPOSITION_BACKEND="bogus"
+
+	run dispatch_composition "/process-pr 1 2 main" "false" 2>&1
+
+	[[ "$output" == *"bogus"* ]]
+}
+
+@test "(c) unset COMPOSITION_BACKEND leaves auto-routing in effect for standard path" {
+	require_dispatch_composition
+	unset COMPOSITION_BACKEND
+
+	dispatch_composition "/process-pr 1 2 main" "false"
+
+	# Auto-routing: non-isolated → standard subprocess
+	[ -f "$TEST_TMP/standard_called" ]
+	[ ! -f "$TEST_TMP/subprocess_called" ]
+}
+
+@test "(c) unset COMPOSITION_BACKEND leaves auto-routing in effect for subprocess path" {
+	require_dispatch_composition
+	unset COMPOSITION_BACKEND
+
+	dispatch_composition "/implement-issue 123 main" "true"
+
+	# Auto-routing: isolated → subprocess
+	[ -f "$TEST_TMP/subprocess_called" ]
+	[ ! -f "$TEST_TMP/standard_called" ]
+}
+
+@test "(c) COMPOSITION_BACKEND=subprocess exits 0" {
+	require_dispatch_composition
+	export COMPOSITION_BACKEND="subprocess"
+
+	run dispatch_composition "/process-pr 1 2 main" "false"
+
+	[ "$status" -eq 0 ]
+}
+
+@test "(c) COMPOSITION_BACKEND=skill exits 0" {
+	require_dispatch_composition
+	export COMPOSITION_BACKEND="skill"
+
+	run dispatch_composition "/implement-issue 123 main" "true"
+
+	[ "$status" -eq 0 ]
+}

--- a/.claude/scripts/implement-issue-test/test-quality-loop.bats
+++ b/.claude/scripts/implement-issue-test/test-quality-loop.bats
@@ -1695,3 +1695,77 @@ HIST_EOF
     was_fix_called=$(cat "$fix_called")
     [ "$was_fix_called" = "false" ] || fail "Fix should not be called when only minor issues exist in an approved review"
 }
+
+# =============================================================================
+# STALL BAIL EARLY EXIT
+# =============================================================================
+
+@test "run_quality_loop stall handling has bail branch that breaks the loop" {
+    local func_def
+    func_def=$(declare -f run_quality_loop)
+
+    # Must have a bail branch in the stall action handling
+    [[ "$func_def" == *'"bail"'* ]] || fail "run_quality_loop must handle bail action from stall detection"
+
+    # The bail branch must break the loop (not just log and continue)
+    # Verify bail and break appear together in the stall section
+    local stall_section
+    stall_section=$(printf '%s' "$func_def" | awk '/quality_stall/,/skip_simplify=false/')
+    [[ "$stall_section" == *"bail"* ]] || fail "bail action must be handled in the stall detection section"
+    [[ "$stall_section" == *"break"* ]] || fail "bail action must break the loop in the stall detection section"
+}
+
+@test "bail stall action exits quality loop before max iterations" {
+    # Create a fake decide-action.sh that returns bail (simulating opus ceiling)
+    local fake_script_dir="$TEST_TMP/fake-scripts"
+    mkdir -p "$fake_script_dir"
+    cat > "$fake_script_dir/decide-action.sh" << 'FAKE_EOF'
+#!/usr/bin/env bash
+printf '{"action":"bail","reason":"quality_stall: at opus ceiling, cannot escalate"}\n'
+FAKE_EOF
+    chmod +x "$fake_script_dir/decide-action.sh"
+
+    # Override SCRIPT_DIR so the orchestrator uses our fake decide-action.sh
+    SCRIPT_DIR="$fake_script_dir"
+
+    local review_count_file="$TEST_TMP/bail_review_count"
+    echo "0" > "$review_count_file"
+    export review_count_file
+
+    run_stage() {
+        local stage_name="$1"
+        case "$stage_name" in
+            simplify-*)
+                printf '{"status":"success","summary":"No changes"}\n'
+                ;;
+            review-*)
+                local count
+                count=$(cat "$review_count_file")
+                count=$((count + 1))
+                echo "$count" > "$review_count_file"
+                # Always request changes so fix runs and stall can be detected
+                printf '{"status":"success","result":"changes_requested","comments":"Fix this","summary":"1 issue"}\n'
+                ;;
+            fix-review-*)
+                # Return without committing — keeps pre/post commit counts equal,
+                # satisfying the stall condition on iteration >= 2
+                printf '{"status":"success","output":{"summary":"Applied fixes"},"summary":"Applied fixes","model":"opus"}\n'
+                ;;
+        esac
+    }
+    export -f run_stage
+
+    comment_issue() { :; }
+    export -f comment_issue
+
+    # Run with max 5 iterations; bail should cause early exit after iter 2
+    ( run_quality_loop "$TEST_TMP" "test-branch" "test" "" 5 ) || true
+
+    local review_count
+    review_count=$(cat "$review_count_file")
+
+    # Without the bail branch the loop runs all 5 iterations (5 review calls).
+    # With the bail branch the loop exits after iteration 2 (2 review calls).
+    [ "$review_count" -le 2 ] || fail "Expected loop to exit after bail on iter 2, but review ran $review_count times"
+}
+

--- a/.claude/scripts/implement-issue-test/test-skill-golden-lib.bats
+++ b/.claude/scripts/implement-issue-test/test-skill-golden-lib.bats
@@ -1,0 +1,708 @@
+#!/usr/bin/env bats
+#
+# test-skill-golden-lib.bats
+#
+# Tests for skill-golden-lib.sh — manifest parsing, JSON diff (payload
+# extraction), red/green reporting, and retry-on-rate-limit.
+#
+# Mocking strategy: a mock-claude script at $TEST_TMP/bin/mock-claude is
+# pointed to by SG_CLAUDE_CLI.  Behaviour is controlled via env vars:
+#   MOCK_CLAUDE_OUTPUT     — stdout on success
+#   MOCK_CLAUDE_EXIT_CODE  — exit code when succeeding (default 0)
+#   MOCK_CLAUDE_CALL_FILE  — path to a file that counts invocations
+#   MOCK_CLAUDE_FAIL_TIMES — fail with retryable output this many times first
+#   MOCK_CLAUDE_FAIL_OUTPUT— output text when failing (default: "rate limit exceeded")
+#   MOCK_CLAUDE_FAIL_EXIT  — exit code when failing (default: 1)
+#
+
+load 'helpers/test-helper.bash'
+
+setup() {
+	setup_test_env
+
+	local mock_bin="$TEST_TMP/bin"
+	mkdir -p "$mock_bin"
+
+	# ---------------------------------------------------------------
+	# Mock Claude CLI
+	# ---------------------------------------------------------------
+	cat > "$mock_bin/mock-claude" <<'MOCK_CLAUDE'
+#!/usr/bin/env bash
+# Mock Claude CLI — controlled via env vars (see test file header).
+call_file="${MOCK_CLAUDE_CALL_FILE:-}"
+fail_times="${MOCK_CLAUDE_FAIL_TIMES:-0}"
+call_n=0
+
+if [[ -n "$call_file" ]]; then
+	[[ -f "$call_file" ]] && call_n=$(cat "$call_file")
+	call_n=$((call_n + 1))
+	printf '%d' "$call_n" > "$call_file"
+fi
+
+if ((fail_times > 0 && call_n <= fail_times)); then
+	printf '%s' "${MOCK_CLAUDE_FAIL_OUTPUT:-rate limit exceeded}"
+	exit "${MOCK_CLAUDE_FAIL_EXIT:-1}"
+fi
+
+default_output='{"result":"mock","structured_output":{"route":"fast-path","confidence":"high"}}'
+printf '%s' "${MOCK_CLAUDE_OUTPUT:-$default_output}"
+exit "${MOCK_CLAUDE_EXIT_CODE:-0}"
+MOCK_CLAUDE
+	chmod +x "$mock_bin/mock-claude"
+
+	# ---------------------------------------------------------------
+	# Default mock state — reset for each test
+	# ---------------------------------------------------------------
+	export MOCK_CLAUDE_OUTPUT='{"result":"mock","structured_output":{"route":"fast-path","confidence":"high"}}'
+	export MOCK_CLAUDE_EXIT_CODE=0
+	export MOCK_CLAUDE_FAIL_TIMES=0
+	export MOCK_CLAUDE_CALL_FILE="$TEST_TMP/mock-claude-calls"
+	rm -f "$MOCK_CLAUDE_CALL_FILE"
+
+	# ---------------------------------------------------------------
+	# Library configuration
+	# ---------------------------------------------------------------
+	export SG_CLAUDE_CLI="$mock_bin/mock-claude"
+	export SG_RETRY_BASE_SLEEP=0   # no real sleeps in tests
+	export SG_MAX_ATTEMPTS=3
+
+	# ---------------------------------------------------------------
+	# Test artefacts: schema and fixture directory
+	# ---------------------------------------------------------------
+	mkdir -p "$TEST_TMP/fixtures" "$TEST_TMP/schemas"
+
+	cat > "$TEST_TMP/schemas/test-skill.json" <<'SCHEMA'
+{"type":"object","properties":{"route":{"type":"string"},"confidence":{"type":"string"}}}
+SCHEMA
+
+	# ---------------------------------------------------------------
+	# Source the library under test (guard ensures single load per process)
+	# ---------------------------------------------------------------
+	# shellcheck source=/dev/null
+	source "$SCRIPT_DIR/skill-golden-lib.sh"
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# =============================================================================
+# MANIFEST PARSING — sg_parse_manifest_entry
+# =============================================================================
+
+@test "sg_parse_manifest_entry splits fixture|route|criterion into three lines" {
+	run sg_parse_manifest_entry "issue-2836|fast-path|no_security_concerns"
+	[ "$status" -eq 0 ]
+	local fixture route criterion
+	fixture=$(printf '%s' "$output" | sed -n '1p')
+	route=$(printf '%s'   "$output" | sed -n '2p')
+	criterion=$(printf '%s' "$output" | sed -n '3p')
+	[ "$fixture"   = "issue-2836"          ]
+	[ "$route"     = "fast-path"           ]
+	[ "$criterion" = "no_security_concerns" ]
+}
+
+@test "sg_parse_manifest_entry handles wildcard criterion" {
+	run sg_parse_manifest_entry "issue-2837|fast-path|*"
+	[ "$status" -eq 0 ]
+	local criterion
+	criterion=$(printf '%s' "$output" | sed -n '3p')
+	[ "$criterion" = "*" ]
+}
+
+@test "sg_parse_manifest_entry handles empty criterion field" {
+	run sg_parse_manifest_entry "issue-vague|full|"
+	[ "$status" -eq 0 ]
+	local fixture route criterion
+	fixture=$(printf '%s'   "$output" | sed -n '1p')
+	route=$(printf '%s'     "$output" | sed -n '2p')
+	criterion=$(printf '%s' "$output" | sed -n '3p')
+	[ "$fixture"   = "issue-vague" ]
+	[ "$route"     = "full"        ]
+	[ "$criterion" = ""            ]
+}
+
+@test "sg_parse_manifest_entry outputs exactly three newline-separated fields" {
+	local result
+	result=$(sg_parse_manifest_entry "f|r|c")
+	# $() strips trailing newlines, so "f\nr\nc\n" becomes "f\nr\nc" (2 \n).
+	# Re-add one newline via printf '%s\n' to get 3 lines for wc -l.
+	local line_count
+	line_count=$(printf '%s\n' "$result" | wc -l | tr -d ' ')
+	[ "$line_count" -eq 3 ]
+}
+
+# =============================================================================
+# JSON DIFF / PAYLOAD EXTRACTION — sg_extract_payload
+# =============================================================================
+
+@test "sg_extract_payload extracts .structured_output when present" {
+	local claude_output='{"result":"ok","structured_output":{"route":"fast-path","confidence":"high"}}'
+	run sg_extract_payload "$claude_output"
+	[ "$status" -eq 0 ]
+	local route
+	route=$(printf '%s' "$output" | jq -r '.route')
+	[ "$route" = "fast-path" ]
+}
+
+@test "sg_extract_payload falls back to .result when no .structured_output" {
+	local claude_output='{"result":{"route":"full","confidence":"medium"}}'
+	run sg_extract_payload "$claude_output"
+	[ "$status" -eq 0 ]
+	local route
+	route=$(printf '%s' "$output" | jq -r '.route')
+	[ "$route" = "full" ]
+}
+
+@test "sg_extract_payload parses stringified JSON in .result" {
+	local inner='{"route":"fast-path","confidence":"high"}'
+	local claude_output
+	claude_output=$(jq -n --arg r "$inner" '{"result":$r}')
+	run sg_extract_payload "$claude_output"
+	[ "$status" -eq 0 ]
+	local route
+	route=$(printf '%s' "$output" | jq -r '.route')
+	[ "$route" = "fast-path" ]
+}
+
+@test "sg_extract_payload falls back to top-level object when no nested keys" {
+	local claude_output='{"route":"escalate","confidence":"high"}'
+	run sg_extract_payload "$claude_output"
+	[ "$status" -eq 0 ]
+	local route
+	route=$(printf '%s' "$output" | jq -r '.route')
+	[ "$route" = "escalate" ]
+}
+
+@test "sg_extract_payload returns {} for completely non-JSON input" {
+	run sg_extract_payload "not json at all"
+	[ "$status" -eq 0 ]
+	# Output should be {} (the safe fallback)
+	[[ "$output" == "{}" ]]
+}
+
+@test "sg_extract_payload does not crash on empty string input" {
+	# The function is designed for non-empty Claude CLI output; empty input
+	# is an edge case.  We only verify the function returns without error.
+	run sg_extract_payload ""
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# JSON DIFF / FIELD ACCESS — sg_get_field
+# =============================================================================
+
+@test "sg_get_field returns field value when present" {
+	local payload='{"route":"fast-path","confidence":"high"}'
+	run sg_get_field "$payload" "route"
+	[ "$status" -eq 0 ]
+	[ "$output" = "fast-path" ]
+}
+
+@test "sg_get_field returns MISSING when field absent and no default given" {
+	local payload='{"confidence":"high"}'
+	run sg_get_field "$payload" "route"
+	[ "$status" -eq 0 ]
+	[ "$output" = "MISSING" ]
+}
+
+@test "sg_get_field returns custom default for absent field" {
+	local payload='{"confidence":"high"}'
+	run sg_get_field "$payload" "route" "unknown"
+	[ "$status" -eq 0 ]
+	[ "$output" = "unknown" ]
+}
+
+@test "sg_get_field returns explicit empty default for absent field" {
+	local payload='{"confidence":"high"}'
+	run sg_get_field "$payload" "disqualifying_criterion" ""
+	[ "$status" -eq 0 ]
+	[ "$output" = "" ]
+}
+
+@test "sg_get_field returns nested-value as string via tostring" {
+	# Numeric JSON values are returned as strings (jq tostring coercion).
+	local payload='{"count":42}'
+	run sg_get_field "$payload" "count"
+	[ "$status" -eq 0 ]
+	[ "$output" = "42" ]
+}
+
+@test "sg_get_field is safe against field names with special chars via --arg" {
+	# The function uses --arg f "$field" to prevent jq filter injection.
+	local payload='{"normal":"value"}'
+	run sg_get_field "$payload" 'normal'
+	[ "$status" -eq 0 ]
+	[ "$output" = "value" ]
+}
+
+# =============================================================================
+# RETRYABLE DETECTION — sg_is_retryable
+# =============================================================================
+
+@test "sg_is_retryable returns 0 for 'rate limit' in output" {
+	run sg_is_retryable "Error: rate limit exceeded, please slow down"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_is_retryable returns 0 for '429' in output" {
+	run sg_is_retryable "HTTP 429: Too Many Requests"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_is_retryable returns 0 for 'overloaded' in output" {
+	run sg_is_retryable "API overloaded, try again later"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_is_retryable returns 0 for 'overload_error' in output" {
+	run sg_is_retryable "overload_error: service is at capacity"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_is_retryable returns 0 for 'timeout' in output" {
+	run sg_is_retryable "Connection timeout after 30 seconds"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_is_retryable returns 0 for 'timed out' in output" {
+	run sg_is_retryable "Request timed out"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_is_retryable returns 0 for '503 service unavailable'" {
+	run sg_is_retryable "503 Service Unavailable from upstream"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_is_retryable returns 0 for 'econnreset' in output" {
+	run sg_is_retryable "read ECONNRESET"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_is_retryable is case-insensitive for 'RATE LIMIT'" {
+	run sg_is_retryable "RATE LIMIT REACHED"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_is_retryable returns 1 for a normal error message" {
+	run sg_is_retryable "Error: schema validation failed"
+	[ "$status" -eq 1 ]
+}
+
+@test "sg_is_retryable returns 1 for empty string" {
+	run sg_is_retryable ""
+	[ "$status" -eq 1 ]
+}
+
+@test "sg_is_retryable returns 1 for successful output" {
+	run sg_is_retryable '{"result":"ok","structured_output":{"status":"success"}}'
+	[ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# CLAUDE INVOCATION WITH RETRY — sg_invoke_claude
+# =============================================================================
+
+@test "sg_invoke_claude returns 0 and prints output on success" {
+	export MOCK_CLAUDE_OUTPUT='{"structured_output":{"route":"fast-path"}}'
+	run sg_invoke_claude "test prompt" "haiku" "$TEST_TMP/schemas/test-skill.json"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"fast-path"* ]]
+}
+
+@test "sg_invoke_claude returns 2 when schema file is missing" {
+	run sg_invoke_claude "test prompt" "haiku" "$TEST_TMP/schemas/nonexistent.json"
+	[ "$status" -eq 2 ]
+}
+
+@test "sg_invoke_claude retries on rate-limit and succeeds on second attempt" {
+	export MOCK_CLAUDE_FAIL_TIMES=1
+	export MOCK_CLAUDE_FAIL_OUTPUT="rate limit exceeded"
+	export MOCK_CLAUDE_OUTPUT='{"structured_output":{"route":"escalate"}}'
+
+	run sg_invoke_claude "test prompt" "haiku" "$TEST_TMP/schemas/test-skill.json"
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"escalate"* ]]
+
+	# Verify the mock was called twice (1 failure + 1 success)
+	local call_count
+	call_count=$(cat "$MOCK_CLAUDE_CALL_FILE")
+	[ "$call_count" -eq 2 ]
+}
+
+@test "sg_invoke_claude returns 1 after exhausting all SG_MAX_ATTEMPTS retries" {
+	export SG_MAX_ATTEMPTS=3
+	export MOCK_CLAUDE_FAIL_TIMES=10   # more than max attempts
+	export MOCK_CLAUDE_FAIL_OUTPUT="rate limit exceeded"
+
+	run sg_invoke_claude "test prompt" "haiku" "$TEST_TMP/schemas/test-skill.json"
+
+	[ "$status" -eq 1 ]
+
+	# Verify the last error output is surfaced to the caller (not swallowed).
+	[[ "$output" == *"rate limit exceeded"* ]]
+
+	# Verify the mock was called exactly SG_MAX_ATTEMPTS times
+	local call_count
+	call_count=$(cat "$MOCK_CLAUDE_CALL_FILE")
+	[ "$call_count" -eq 3 ]
+}
+
+@test "sg_invoke_claude does not retry on non-transient errors" {
+	# Non-retryable error (e.g. authentication / schema failure): the function
+	# must surface the error output, return non-zero, and invoke claude exactly
+	# once — no retry loop.
+	export MOCK_CLAUDE_EXIT_CODE=1
+	export MOCK_CLAUDE_OUTPUT="Error: authentication failed, check API key"
+
+	run sg_invoke_claude "test prompt" "haiku" "$TEST_TMP/schemas/test-skill.json"
+
+	# Non-transient failures must return 1.
+	[ "$status" -eq 1 ]
+
+	# Output must contain the error message (surfaced from claude).
+	[[ "$output" == *"authentication failed"* ]]
+
+	# Should only have been called once (no retries).
+	local call_count
+	call_count=$(cat "$MOCK_CLAUDE_CALL_FILE")
+	[ "$call_count" -eq 1 ]
+}
+
+@test "sg_invoke_claude succeeds without retry when first call succeeds" {
+	run sg_invoke_claude "test prompt" "haiku" "$TEST_TMP/schemas/test-skill.json"
+	[ "$status" -eq 0 ]
+
+	local call_count
+	call_count=$(cat "$MOCK_CLAUDE_CALL_FILE")
+	[ "$call_count" -eq 1 ]
+}
+
+# =============================================================================
+# SETUP CHECKS — sg_require_cmd / sg_check_setup
+# =============================================================================
+
+@test "sg_require_cmd returns 0 for a command that exists" {
+	run sg_require_cmd "jq"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_require_cmd returns 2 for a command that does not exist" {
+	run sg_require_cmd "no-such-command-xyzzy-999"
+	[ "$status" -eq 2 ]
+}
+
+@test "sg_require_cmd writes error to stderr for missing command" {
+	run sg_require_cmd "no-such-command-xyzzy-999"
+	[ "$status" -eq 2 ]
+	[[ "$output" == *"no-such-command-xyzzy-999"* ]]
+}
+
+@test "sg_check_setup returns 0 when all prerequisites are present" {
+	run sg_check_setup "$TEST_TMP/fixtures" "$TEST_TMP/schemas/test-skill.json"
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_check_setup returns 2 when schema file is missing" {
+	run sg_check_setup "$TEST_TMP/fixtures" "$TEST_TMP/schemas/does-not-exist.json"
+	[ "$status" -eq 2 ]
+}
+
+@test "sg_check_setup returns 2 when fixture directory is missing" {
+	run sg_check_setup "$TEST_TMP/no-fixtures-dir" "$TEST_TMP/schemas/test-skill.json"
+	[ "$status" -eq 2 ]
+}
+
+@test "sg_check_setup returns 2 when SG_CLAUDE_CLI is not found" {
+	# VAR=val before a bash function (run) does not propagate the variable
+	# into subshells spawned by that function — only external commands honour
+	# the temporary env-var prefix.  Export explicitly instead, then restore.
+	local _saved_cli="${SG_CLAUDE_CLI:-}"
+	export SG_CLAUDE_CLI="no-such-claude-binary-xyzzy"
+	run sg_check_setup \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json"
+	export SG_CLAUDE_CLI="$_saved_cli"
+	[ "$status" -eq 2 ]
+	[[ "$output" == *"no-such-claude-binary-xyzzy"* ]]
+}
+
+# =============================================================================
+# RED/GREEN REPORTING — sg_print_summary
+# =============================================================================
+
+@test "sg_print_summary returns 0 when all fixtures pass" {
+	run sg_print_summary 3 3 0 1
+	[ "$status" -eq 0 ]
+}
+
+@test "sg_print_summary returns 1 when at least one fixture fails" {
+	run sg_print_summary 3 2 1 2
+	[ "$status" -eq 1 ]
+}
+
+@test "sg_print_summary returns 2 when total is zero (no fixtures matched)" {
+	run sg_print_summary 0 0 0 0 "myfilter"
+	[ "$status" -eq 2 ]
+}
+
+@test "sg_print_summary outputs passed/total count line" {
+	run sg_print_summary 5 4 1 3
+	[[ "$output" == *"4/5"* ]]
+}
+
+@test "sg_print_summary includes elapsed time in output" {
+	run sg_print_summary 2 2 0 7
+	[[ "$output" == *"7s"* ]]
+}
+
+@test "sg_print_summary includes PASS indicator on full success" {
+	run sg_print_summary 2 2 0 1
+	[ "$status" -eq 0 ]
+	# ANSI-wrapped PASS — check for the word inside escape codes
+	[[ "$output" == *"PASS"* ]]
+}
+
+@test "sg_print_summary includes FAIL indicator when failures present" {
+	run sg_print_summary 3 1 2 4
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"FAIL"* ]]
+}
+
+@test "sg_print_summary emits no-match message to stderr for zero total with filter" {
+	run sg_print_summary 0 0 0 0 "specific-fixture"
+	[ "$status" -eq 2 ]
+	# The no-match message goes to stderr; BATS captures combined output via run
+	[[ "$output" == *"specific-fixture"* ]]
+}
+
+# =============================================================================
+# INTEGRATION — sg_run_fixture (PASS / FAIL / WARN / missing fixture)
+# =============================================================================
+
+# Helper: define a minimal build_prompt for integration tests.
+# Called inside each test that needs it (export -f so subshells see it).
+_define_build_prompt() {
+	build_prompt() {
+		printf 'classify this: %s\n' "$1"
+	}
+	export -f build_prompt
+}
+
+@test "sg_run_fixture returns 0 and prints PASS when route matches" {
+	_define_build_prompt
+	printf 'test fixture body\n' > "$TEST_TMP/fixtures/issue-pass.md"
+	export MOCK_CLAUDE_OUTPUT='{"structured_output":{"route":"fast-path","confidence":"high"}}'
+
+	run sg_run_fixture \
+		"issue-pass|fast-path|*" \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json" \
+		"haiku" \
+		"build_prompt"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"PASS"* ]]
+}
+
+@test "sg_run_fixture returns 1 and prints FAIL when route does not match" {
+	_define_build_prompt
+	printf 'test fixture body\n' > "$TEST_TMP/fixtures/issue-fail.md"
+	export MOCK_CLAUDE_OUTPUT='{"structured_output":{"route":"full","confidence":"high"}}'
+
+	run sg_run_fixture \
+		"issue-fail|fast-path|*" \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json" \
+		"haiku" \
+		"build_prompt"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"FAIL"* ]]
+	[[ "$output" == *"fast-path"* ]]   # expected route visible in output
+	[[ "$output" == *"full"* ]]        # actual route visible in output
+}
+
+@test "sg_run_fixture returns 0 and prints WARN when criterion mismatches" {
+	_define_build_prompt
+	printf 'test fixture body\n' > "$TEST_TMP/fixtures/issue-warn.md"
+	# Route matches but criterion is different from expected
+	export MOCK_CLAUDE_OUTPUT='{"structured_output":{"route":"full","confidence":"high","disqualifying_criterion":"surgical_size"}}'
+
+	run sg_run_fixture \
+		"issue-warn|full|test_only_scope" \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json" \
+		"haiku" \
+		"build_prompt"
+	# WARN is non-fatal: exit 0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"WARN"* ]]
+}
+
+@test "sg_run_fixture returns 1 when fixture file does not exist" {
+	_define_build_prompt
+	# Do NOT create the fixture file
+
+	run sg_run_fixture \
+		"issue-missing|fast-path|*" \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json" \
+		"haiku" \
+		"build_prompt"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"FAIL"* ]]
+}
+
+@test "sg_run_fixture accepts .json fixture when .md is absent" {
+	_define_build_prompt
+	printf '{"stage":"implement","status":"timeout"}\n' \
+		> "$TEST_TMP/fixtures/issue-json.json"
+	export MOCK_CLAUDE_OUTPUT='{"structured_output":{"route":"escalate","confidence":"high"}}'
+
+	run sg_run_fixture \
+		"issue-json|escalate|*" \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json" \
+		"haiku" \
+		"build_prompt"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"PASS"* ]]
+}
+
+@test "sg_run_fixture returns 1 when prompt builder function is not defined" {
+	printf 'test fixture body\n' > "$TEST_TMP/fixtures/issue-noprompt.md"
+	# unset_build_prompt is not a defined function
+
+	run sg_run_fixture \
+		"issue-noprompt|fast-path|*" \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json" \
+		"haiku" \
+		"unset_build_prompt_fn_xyz"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"FAIL"* ]]
+}
+
+# =============================================================================
+# INTEGRATION — sg_run_manifest
+# =============================================================================
+
+@test "sg_run_manifest returns 0 when all entries pass" {
+	_define_build_prompt
+	printf 'body a\n' > "$TEST_TMP/fixtures/fix-a.md"
+	printf 'body b\n' > "$TEST_TMP/fixtures/fix-b.md"
+	export MOCK_CLAUDE_OUTPUT='{"structured_output":{"route":"fast-path","confidence":"high"}}'
+
+	run sg_run_manifest \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json" \
+		"haiku" \
+		"build_prompt" \
+		"" \
+		"fix-a|fast-path|*" \
+		"fix-b|fast-path|*"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"PASS"* ]]
+}
+
+@test "sg_run_manifest returns 1 when at least one entry fails" {
+	_define_build_prompt
+	printf 'body a\n' > "$TEST_TMP/fixtures/fix-c.md"
+	printf 'body b\n' > "$TEST_TMP/fixtures/fix-d.md"
+	# Claude always returns full; manifest expects fast-path for fix-c → FAIL
+	export MOCK_CLAUDE_OUTPUT='{"structured_output":{"route":"full","confidence":"high"}}'
+
+	run sg_run_manifest \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json" \
+		"haiku" \
+		"build_prompt" \
+		"" \
+		"fix-c|fast-path|*" \
+		"fix-d|full|*"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"FAIL"* ]]
+}
+
+@test "sg_run_manifest returns 2 when filter matches no fixtures" {
+	_define_build_prompt
+	printf 'body a\n' > "$TEST_TMP/fixtures/fix-e.md"
+	export MOCK_CLAUDE_OUTPUT='{"structured_output":{"route":"fast-path","confidence":"high"}}'
+
+	run sg_run_manifest \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json" \
+		"haiku" \
+		"build_prompt" \
+		"nonexistent-fixture" \
+		"fix-e|fast-path|*"
+	[ "$status" -eq 2 ]
+}
+
+@test "sg_run_manifest filter runs only the matching fixture" {
+	_define_build_prompt
+	printf 'body x\n' > "$TEST_TMP/fixtures/fix-x.md"
+	printf 'body y\n' > "$TEST_TMP/fixtures/fix-y.md"
+	# Only fix-x should run; fix-y is filtered out.
+	# Claude returns full; fix-y expects fast-path (would fail) but it won't run.
+	export MOCK_CLAUDE_OUTPUT='{"structured_output":{"route":"fast-path","confidence":"high"}}'
+
+	run sg_run_manifest \
+		"$TEST_TMP/fixtures" \
+		"$TEST_TMP/schemas/test-skill.json" \
+		"haiku" \
+		"build_prompt" \
+		"fix-x" \
+		"fix-x|fast-path|*" \
+		"fix-y|fast-path|*"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"PASS"* ]]
+}
+
+# =============================================================================
+# COLOR HELPERS — sg_red / sg_green / sg_yellow / sg_dim
+# =============================================================================
+
+@test "sg_red wraps text with red ANSI codes" {
+	local result
+	result=$(sg_red "FAIL")
+	# Must contain the text itself
+	[[ "$result" == *"FAIL"* ]]
+	# Must start with an ESC (ANSI) sequence
+	[[ "$result" == $'\033'* ]]
+}
+
+@test "sg_green wraps text with green ANSI codes" {
+	local result
+	result=$(sg_green "PASS")
+	[[ "$result" == *"PASS"* ]]
+	[[ "$result" == $'\033'* ]]
+}
+
+@test "sg_yellow wraps text with yellow ANSI codes" {
+	local result
+	result=$(sg_yellow "WARN")
+	[[ "$result" == *"WARN"* ]]
+	[[ "$result" == $'\033'* ]]
+}
+
+@test "sg_dim wraps text with dim ANSI codes" {
+	local result
+	result=$(sg_dim "note")
+	[[ "$result" == *"note"* ]]
+	[[ "$result" == $'\033'* ]]
+}
+
+# =============================================================================
+# DOUBLE-SOURCE GUARD — _SKILL_GOLDEN_LIB_SOURCED
+# =============================================================================
+
+@test "sourcing the lib a second time in same process is a no-op" {
+	# The guard variable is already set from setup().
+	# Sourcing again must not redefine or error.
+	# shellcheck source=/dev/null
+	source "$SCRIPT_DIR/skill-golden-lib.sh"
+	# If we get here without error, the guard worked.
+	[ "$_SKILL_GOLDEN_LIB_SOURCED" -eq 1 ]
+}

--- a/.claude/scripts/implement-issue-test/test-skill-validate.bats
+++ b/.claude/scripts/implement-issue-test/test-skill-validate.bats
@@ -1,0 +1,385 @@
+#!/usr/bin/env bats
+#
+# test-skill-validate.bats
+# Tests for .claude/scripts/skill-validate.sh
+#
+# Covers:
+#   (a) valid frontmatter passes
+#   (b) missing required fields rejected
+#   (c) malformed YAML rejected
+#   (d) unknown top-level keys rejected
+#
+# Environment overrides used by skill-validate.sh:
+#   SKILLS_DIR    — directory containing skill subdirectories
+#                   (default: .claude/skills)
+#   SKILL_SCHEMA  — path to the JSON schema file
+#
+
+load 'helpers/test-helper.bash'
+
+# Resolved in setup() once SCRIPT_DIR and TEST_TMP are available.
+SKILL_VALIDATE_SCRIPT=""
+TEST_SKILLS_DIR=""
+TEST_SCHEMA_FILE=""
+
+setup() {
+	setup_test_env
+
+	SKILL_VALIDATE_SCRIPT="$SCRIPT_DIR/skill-validate.sh"
+	TEST_SKILLS_DIR="$TEST_TMP/skills"
+	TEST_SCHEMA_FILE="$TEST_TMP/schemas/skill-frontmatter.json"
+
+	mkdir -p "$TEST_SKILLS_DIR"
+	mkdir -p "$TEST_TMP/schemas"
+
+	# Prefer the real schema when it exists; otherwise inline a minimal one so
+	# the tests are self-contained even before task-1 is merged.
+	if [[ -f "$SCRIPT_DIR/schemas/skill-frontmatter.json" ]]; then
+		cp "$SCRIPT_DIR/schemas/skill-frontmatter.json" "$TEST_SCHEMA_FILE"
+	else
+		cat > "$TEST_SCHEMA_FILE" << 'SCHEMA_EOF'
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["name", "description"],
+  "additionalProperties": false,
+  "properties": {
+    "name":          { "type": "string", "minLength": 1 },
+    "description":   { "type": "string", "minLength": 1 },
+    "argument-hint": { "type": "string" },
+    "inputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "name":        { "type": "string" },
+          "type":        { "type": "string" },
+          "required":    { "type": "boolean" },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "outputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "name":        { "type": "string" },
+          "type":        { "type": "string" },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "side_effects": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "composes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "failure_modes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "mitigation"],
+        "additionalProperties": false,
+        "properties": {
+          "id":         { "type": "string" },
+          "mitigation": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+SCHEMA_EOF
+	fi
+
+	export SKILLS_DIR="$TEST_SKILLS_DIR"
+	export SKILL_SCHEMA="$TEST_SCHEMA_FILE"
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# Helper: write a skill directory + SKILL.md from a frontmatter string.
+# Usage: make_skill <skill-name> <frontmatter-body>
+# The frontmatter-body is written between the --- delimiters.
+# ---------------------------------------------------------------------------
+make_skill() {
+	local name="$1"
+	local body="$2"
+
+	mkdir -p "$TEST_SKILLS_DIR/$name"
+	printf -- '---\n%s\n---\n\n# %s\n' "$body" "$name" \
+		> "$TEST_SKILLS_DIR/$name/SKILL.md"
+}
+
+# =============================================================================
+# (a) VALID FRONTMATTER PASSES
+# =============================================================================
+
+@test "(a) minimal valid frontmatter — name and description — exits 0" {
+	make_skill "my-skill" \
+		"name: my-skill
+description: A minimal test skill"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill my-skill
+	[ "$status" -eq 0 ]
+}
+
+@test "(a) valid frontmatter with all known optional fields exits 0" {
+	make_skill "full-skill" \
+		"name: full-skill
+description: A skill with every optional field populated
+argument-hint: \"<target>\"
+inputs:
+  - name: target
+    type: string
+    required: true
+    description: The target to act on
+outputs:
+  - name: result_url
+    type: url
+    description: URL of the created resource
+side_effects:
+  - creates_github_issue
+composes:
+  - mcp-tools
+failure_modes:
+  - id: auth_failure
+    mitigation: surface the gh auth error and do not retry"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill full-skill
+	[ "$status" -eq 0 ]
+}
+
+@test "(a) --all exits 0 when every skill in SKILLS_DIR has valid frontmatter" {
+	make_skill "skill-alpha" "name: skill-alpha
+description: First valid skill"
+	make_skill "skill-beta" "name: skill-beta
+description: Second valid skill"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --all
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# (b) MISSING REQUIRED FIELDS REJECTED
+# =============================================================================
+
+@test "(b) frontmatter missing 'name' is rejected with non-zero exit" {
+	make_skill "no-name" "description: A skill that forgot to declare its name"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill no-name 2>&1
+	[ "$status" -ne 0 ]
+}
+
+@test "(b) error for missing 'name' mentions the field in output" {
+	make_skill "no-name-msg" "description: A skill without a name field"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill no-name-msg 2>&1
+	[[ "$output" == *"name"* ]]
+}
+
+@test "(b) frontmatter missing 'description' is rejected with non-zero exit" {
+	make_skill "no-desc" "name: no-desc"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill no-desc 2>&1
+	[ "$status" -ne 0 ]
+}
+
+@test "(b) error for missing 'description' mentions the field in output" {
+	make_skill "no-desc-msg" "name: no-desc-msg"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill no-desc-msg 2>&1
+	[[ "$output" == *"description"* ]]
+}
+
+@test "(b) frontmatter missing 'side_effects' is rejected with non-zero exit" {
+	make_skill "no-side-effects" \
+		"name: no-side-effects
+description: A skill missing the required side_effects field
+inputs: []
+outputs: []
+composes: []
+failure_modes: []"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill no-side-effects 2>&1
+	[ "$status" -ne 0 ]
+}
+
+@test "(b) empty frontmatter block is rejected" {
+	mkdir -p "$TEST_SKILLS_DIR/empty-fm"
+	printf -- '---\n---\n\n# Empty\n' > "$TEST_SKILLS_DIR/empty-fm/SKILL.md"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill empty-fm 2>&1
+	[ "$status" -ne 0 ]
+}
+
+@test "(b) --all exits non-zero when any skill is missing a required field" {
+	make_skill "good-skill" "name: good-skill
+description: This one is fine"
+	make_skill "bad-skill" "description: No name field here"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --all 2>&1
+	[ "$status" -ne 0 ]
+}
+
+# =============================================================================
+# (c) MALFORMED YAML REJECTED
+# =============================================================================
+
+@test "(c) unclosed quoted string in frontmatter is rejected" {
+	local target="$TEST_SKILLS_DIR/bad-quote/SKILL.md"
+	mkdir -p "$TEST_SKILLS_DIR/bad-quote"
+	# Write the malformed frontmatter using printf so the literal
+	# unclosed-quote string reaches the file unchanged.
+	printf -- '%s\n' \
+		'---' \
+		'name: bad-quote' \
+		'description: "unclosed string' \
+		'---' \
+		'' \
+		'# Skill' > "$target"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill bad-quote 2>&1
+	[ "$status" -ne 0 ]
+}
+
+@test "(c) tab-indented block sequence in frontmatter is rejected" {
+	local target="$TEST_SKILLS_DIR/tab-indent/SKILL.md"
+	mkdir -p "$TEST_SKILLS_DIR/tab-indent"
+	# YAML 1.1/1.2 forbids tabs as indentation (spec §6.1). Ruby's Psych parser
+	# (the engine used by skill-validate.sh) enforces this and raises a
+	# Psych::SyntaxError for tab-indented block sequences. If skill-validate.sh
+	# is ever ported to a Python-based parser, note that PyYAML tolerates tabs
+	# in some positions by default — the test would need to be re-evaluated.
+	# The \t below must be a hard tab character, not spaces.
+	printf -- '%s\n' \
+		'---' \
+		'name: tab-indent' \
+		'description: test' \
+		'composes:' \
+		$'\t- mcp-tools' \
+		'---' > "$target"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill tab-indent 2>&1
+	[ "$status" -ne 0 ]
+}
+
+@test "(c) SKILL.md with no frontmatter delimiters at all is rejected" {
+	mkdir -p "$TEST_SKILLS_DIR/no-delimiters"
+	printf -- '# My Skill\n\nJust prose, no frontmatter block present.\n' \
+		> "$TEST_SKILLS_DIR/no-delimiters/SKILL.md"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill no-delimiters 2>&1
+	[ "$status" -ne 0 ]
+}
+
+@test "(c) SKILL.md referencing an undefined YAML anchor is rejected" {
+	mkdir -p "$TEST_SKILLS_DIR/bad-anchor"
+	printf -- '---\nname: bad-anchor\ndescription: *undefined_anchor\n---\n' \
+		> "$TEST_SKILLS_DIR/bad-anchor/SKILL.md"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill bad-anchor 2>&1
+	[ "$status" -ne 0 ]
+}
+
+# =============================================================================
+# (d) UNKNOWN TOP-LEVEL KEYS REJECTED
+# =============================================================================
+
+@test "(d) frontmatter with one unknown top-level key is rejected" {
+	make_skill "unknown-key" "name: unknown-key
+description: A skill with a rogue top-level field
+mystery_field: should not be here"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill unknown-key 2>&1
+	[ "$status" -ne 0 ]
+}
+
+@test "(d) error for unknown key names the offending key in output" {
+	make_skill "named-bad-key" "name: named-bad-key
+description: Test skill
+extra_metadata: this key is not in the schema"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill named-bad-key 2>&1
+	[[ "$output" == *"extra_metadata"* ]]
+}
+
+@test "(d) frontmatter with multiple unknown top-level keys is rejected" {
+	make_skill "multi-unknown" "name: multi-unknown
+description: Multiple unrecognised fields
+foo: bar
+baz: qux"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --skill multi-unknown 2>&1
+	[ "$status" -ne 0 ]
+}
+
+@test "(d) --all exits non-zero when any skill has an unknown top-level key" {
+	make_skill "valid-in-batch" "name: valid-in-batch
+description: This skill is fine"
+	make_skill "invalid-in-batch" "name: invalid-in-batch
+description: This skill has an unknown key
+typo_field: oops"
+
+	run bash "$SKILL_VALIDATE_SCRIPT" --all 2>&1
+	[ "$status" -ne 0 ]
+}
+
+# =============================================================================
+# (e) ISSUE #204 BATCH-1 INTEGRATION — validate 6 real Batch-1 skill files
+#
+# These tests use the actual SKILL.md files and the real schema.  They act as
+# regression guards: if a later edit breaks a skill's frontmatter the suite
+# will catch it without needing a separate manual run.
+# =============================================================================
+
+_real_skill_run() {
+	local skill_name="$1"
+	local real_skills="$SCRIPT_DIR/../skills"
+	local real_schema="$SCRIPT_DIR/schemas/skill-frontmatter.json"
+
+	run env \
+		SKILLS_DIR="$real_skills" \
+		SKILL_SCHEMA="$real_schema" \
+		bash "$SKILL_VALIDATE_SCRIPT" --skill "$skill_name" 2>&1
+}
+
+@test "(e) issue-204 using-skills SKILL.md exits 0" {
+	_real_skill_run using-skills
+	[ "$status" -eq 0 ]
+}
+
+@test "(e) issue-204 writing-skills SKILL.md exits 0" {
+	_real_skill_run writing-skills
+	[ "$status" -eq 0 ]
+}
+
+@test "(e) issue-204 writing-plans SKILL.md exits 0" {
+	_real_skill_run writing-plans
+	[ "$status" -eq 0 ]
+}
+
+@test "(e) issue-204 writing-agents SKILL.md exits 0" {
+	_real_skill_run writing-agents
+	[ "$status" -eq 0 ]
+}
+
+@test "(e) issue-204 brainstorming SKILL.md exits 0" {
+	_real_skill_run brainstorming
+	[ "$status" -eq 0 ]
+}
+
+@test "(e) issue-204 adapting-claude-pipeline SKILL.md exits 0" {
+	_real_skill_run adapting-claude-pipeline
+	[ "$status" -eq 0 ]
+}

--- a/.claude/scripts/implement-issue-test/test-stage-runner.bats
+++ b/.claude/scripts/implement-issue-test/test-stage-runner.bats
@@ -49,7 +49,9 @@ teardown() {
 @test "run_stage fails with missing schema file" {
     run run_stage "test-stage" "test prompt" "nonexistent.json"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"schema not found"* ]]
+    # New stage_result envelope reports error_kind="schema_not_found"
+    # (snake_case; see schemas/stage-result.json enum).
+    [[ "$output" == *"schema_not_found"* ]]
 }
 
 @test "run_stage uses correct schema file" {
@@ -149,8 +151,10 @@ teardown() {
     result=$(run_stage "test" "prompt" "test-schema.json" | grep '^{')
     [ -n "$result" ] || fail "run_stage returned no JSON output"
 
+    # Envelope: .status reflects run-level outcome; .output carries the
+    # parsed structured output from the agent (issue #178 PR-A).
     local extracted_status
-    extracted_status=$(echo "$result" | jq -r '.status')
+    extracted_status=$(echo "$result" | jq -r '.output.status')
     [ "$extracted_status" = "success" ]
 }
 
@@ -160,7 +164,8 @@ teardown() {
 
     run run_stage "test" "prompt" "test-schema.json"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"no structured output"* ]]
+    # Envelope reports error_kind="no_structured_output" (snake_case enum).
+    [[ "$output" == *"no_structured_output"* ]]
 }
 
 # =============================================================================
@@ -180,7 +185,7 @@ teardown() {
 	[ -n "$result" ] || fail "run_stage returned no JSON output"
 
 	local pr_number
-	pr_number=$(printf '%s' "$result" | jq -r '.pr_number // empty')
+	pr_number=$(printf '%s' "$result" | jq -r '.output.pr_number // empty')
 	[ "$pr_number" = "42" ] || \
 		fail "Expected pr_number=42, got: $pr_number (full output: $result)"
 }
@@ -199,7 +204,7 @@ teardown() {
 	[ -n "$result" ] || fail "run_stage returned no JSON output"
 
 	local pr_number
-	pr_number=$(printf '%s' "$result" | jq -r '.pr_number // empty')
+	pr_number=$(printf '%s' "$result" | jq -r '.output.pr_number // empty')
 	[ -z "$pr_number" ] || \
 		fail "pr_number should be empty for bare issue ref, got: $pr_number"
 }
@@ -217,7 +222,7 @@ teardown() {
 	[ -n "$result" ] || fail "run_stage returned no JSON output"
 
 	local branch
-	branch=$(printf '%s' "$result" | jq -r '.branch // empty')
+	branch=$(printf '%s' "$result" | jq -r '.output.branch // empty')
 	[ "$branch" = "feature/issue-52" ] || \
 		fail "Expected branch=feature/issue-52, got: $branch (full output: $result)"
 }
@@ -239,7 +244,7 @@ teardown() {
 	[ -n "$result" ] || fail "run_stage returned no JSON output"
 
 	local tasks_count
-	tasks_count=$(printf '%s' "$result" | jq -r 'if .tasks then (.tasks | length) else 0 end')
+	tasks_count=$(printf '%s' "$result" | jq -r 'if .output.tasks then (.output.tasks | length) else 0 end')
 	[ "$tasks_count" = "2" ] || \
 		fail "Expected 2 tasks, got: $tasks_count (full output: $result)"
 }
@@ -256,10 +261,12 @@ teardown() {
 	result=$(run_stage "implement" "prompt" "test-schema.json" | grep '^{')
 	[ -n "$result" ] || fail "run_stage returned no JSON output"
 
+	# Envelope-level status reflects run-level success even when no fields
+	# extracted from .result text — agent's status sits under .output.status.
 	local status_val
-	status_val=$(printf '%s' "$result" | jq -r '.status')
+	status_val=$(printf '%s' "$result" | jq -r '.output.status')
 	[ "$status_val" = "success" ] || \
-		fail "Expected status=success, got: $status_val (full output: $result)"
+		fail "Expected output.status=success, got: $status_val (full output: $result)"
 }
 
 # =============================================================================
@@ -612,6 +619,7 @@ teardown() {
     result=$(run_stage "test" "prompt" "test-schema.json" | grep '^{')
     [ -n "$result" ] || fail "run_stage returned no JSON output"
 
+    # Envelope-level status: run completed (recovered structured output).
     local status_val
     status_val=$(printf '%s' "$result" | jq -r '.status')
     [ "$status_val" = "success" ] || \
@@ -645,13 +653,15 @@ teardown() {
 	result=$(run_stage "test" "prompt" "test-schema.json" | grep '^{')
 	[ -n "$result" ] || fail "run_stage returned no JSON output"
 
+	# Envelope-level status: run completed via .result-text fallback.
 	local status_val
 	status_val=$(printf '%s' "$result" | jq -r '.status')
 	[ "$status_val" = "success" ] || \
 		fail "Expected status=success, got: $status_val (result: $result)"
 
+	# Agent-reported summary lives under .output.summary in the envelope.
 	local summary_val
-	summary_val=$(printf '%s' "$result" | jq -r '.summary')
+	summary_val=$(printf '%s' "$result" | jq -r '.output.summary')
 	[ "$summary_val" = "Summary of work done" ] || \
 		fail "Expected summary='Summary of work done', got: $summary_val"
 
@@ -891,11 +901,18 @@ EOF
     [[ "$second_call_args" == *"--model opus"* ]] || \
         fail "Expected --model opus in escalated retry. Args: $second_call_args"
 
-    # Final returned status must reflect the successful escalated run
+    # Final envelope status must reflect the successful escalated run.
+    # Both envelope .status and agent .output.status are "success" here
+    # because the escalated agent returned status:"success".
     local status_val
     status_val=$(printf '%s' "$result" | jq -r '.status')
     [ "$status_val" = "success" ] || \
         fail "Expected 'success' after escalation, got: $status_val"
+
+    local agent_status
+    agent_status=$(printf '%s' "$result" | jq -r '.output.status')
+    [ "$agent_status" = "success" ] || \
+        fail "Expected output.status='success' after escalation, got: $agent_status"
 }
 
 @test "run_stage skips escalation and logs warning when permission_denials is non-empty" {
@@ -1125,4 +1142,183 @@ EOF
 
     grep -q "Max turns: 25 (sonnet with S/empty complexity)" "$LOG_FILE" || \
         fail "Max turns logging not found in log. Log: $(cat "$LOG_FILE")"
+}
+
+# =============================================================================
+# _APPLY_STAGE_ACTION — STAGE_RESULT ENVELOPE SHAPE
+#
+# The same 4 escalation behaviors (max_turns, timeout, empty, structured-error)
+# expressed via the stage_result + _apply_stage_action interface
+# (issue #178 PR-A, task 4). No behavior change — these tests verify the new
+# dispatch surface is consistent with the run_stage test assertions above.
+#
+# Convention: bail exits 1 and emits the envelope; accept/escalate/retry_same
+# exit 0 and emit the envelope.  The error_kind field in the envelope
+# identifies which escalation path triggered the bail/escalate decision.
+# =============================================================================
+
+@test "_apply_stage_action: bail exits 1 and preserves error_kind for max_turns_exhausted_at_ceiling" {
+	# max_turns behavior: run_stage calls _apply_stage_action with bail when
+	# opus (ceiling) hits error_max_turns. The envelope must survive intact so
+	# callers can inspect error_kind without re-running the stage.
+	local stage_result
+	stage_result=$(jq -nc '{
+		status: "error",
+		output: null,
+		raw: "{\"subtype\":\"error_max_turns\"}",
+		denials: [],
+		model: "opus",
+		error_kind: "max_turns_exhausted_at_ceiling",
+		elapsed_ms: 5000
+	}')
+
+	run _apply_stage_action "$stage_result" "bail" "max_turns_exhausted_at_ceiling"
+	[ "$status" -eq 1 ]
+
+	# Envelope must be emitted on stdout so callers can inspect error_kind.
+	local emitted_envelope
+	emitted_envelope=$(printf '%s' "$output" | grep '^{' | tail -1)
+	[ -n "$emitted_envelope" ] || \
+		fail "_apply_stage_action bail must emit stage_result on stdout"
+
+	local error_kind
+	error_kind=$(printf '%s' "$emitted_envelope" | jq -r '.error_kind // empty')
+	[ "$error_kind" = "max_turns_exhausted_at_ceiling" ] || \
+		fail "Expected error_kind=max_turns_exhausted_at_ceiling, got: $error_kind"
+
+	local envelope_status
+	envelope_status=$(printf '%s' "$emitted_envelope" | jq -r '.status')
+	[ "$envelope_status" = "error" ] || \
+		fail "Expected envelope status=error, got: $envelope_status"
+}
+
+@test "_apply_stage_action: bail exits 1 and preserves error_kind for timeout" {
+	# timeout behavior: run_stage calls _apply_stage_action with bail when
+	# both initial attempt and retry time out at the ceiling model.
+	local stage_result
+	stage_result=$(jq -nc '{
+		status: "error",
+		output: null,
+		raw: "",
+		denials: [],
+		model: "opus",
+		error_kind: "timeout",
+		elapsed_ms: 60000
+	}')
+
+	run _apply_stage_action "$stage_result" "bail" "timeout"
+	[ "$status" -eq 1 ]
+
+	local emitted_envelope
+	emitted_envelope=$(printf '%s' "$output" | grep '^{' | tail -1)
+	[ -n "$emitted_envelope" ] || \
+		fail "_apply_stage_action bail must emit stage_result on stdout"
+
+	local error_kind
+	error_kind=$(printf '%s' "$emitted_envelope" | jq -r '.error_kind // empty')
+	[ "$error_kind" = "timeout" ] || \
+		fail "Expected error_kind=timeout, got: $error_kind"
+
+	local envelope_status
+	envelope_status=$(printf '%s' "$emitted_envelope" | jq -r '.status')
+	[ "$envelope_status" = "error" ] || \
+		fail "Expected envelope status=error, got: $envelope_status"
+}
+
+@test "_apply_stage_action: bail exits 1 and preserves error_kind for no_structured_output" {
+	# empty behavior: run_stage calls _apply_stage_action with bail when no
+	# structured output can be extracted even after escalation attempts.
+	local stage_result
+	stage_result=$(jq -nc '{
+		status: "error",
+		output: null,
+		raw: "{\"result\":\"some text\",\"is_error\":true}",
+		denials: [],
+		model: "sonnet",
+		error_kind: "no_structured_output",
+		elapsed_ms: 10000
+	}')
+
+	run _apply_stage_action "$stage_result" "bail" "no_structured_output"
+	[ "$status" -eq 1 ]
+
+	local emitted_envelope
+	emitted_envelope=$(printf '%s' "$output" | grep '^{' | tail -1)
+	[ -n "$emitted_envelope" ] || \
+		fail "_apply_stage_action bail must emit stage_result on stdout"
+
+	local error_kind
+	error_kind=$(printf '%s' "$emitted_envelope" | jq -r '.error_kind // empty')
+	[ "$error_kind" = "no_structured_output" ] || \
+		fail "Expected error_kind=no_structured_output, got: $error_kind"
+
+	local envelope_status
+	envelope_status=$(printf '%s' "$emitted_envelope" | jq -r '.status')
+	[ "$envelope_status" = "error" ] || \
+		fail "Expected envelope status=error, got: $envelope_status"
+}
+
+@test "_apply_stage_action: escalate exits 0 and emits envelope for structured_error" {
+	# structured-error behavior: run_stage calls _apply_stage_action with
+	# escalate when the agent returned status:error without permission_denials.
+	# The shim emits the envelope and exits 0; the re-run lives in run_stage
+	# (PR-A pass-through; PR-B will invoke escalation-policy skill here).
+	local stage_result
+	stage_result=$(jq -nc '{
+		status: "error",
+		output: {status: "error", error: "first attempt failed"},
+		raw: "{\"structured_output\":{\"status\":\"error\"}}",
+		denials: [],
+		model: "haiku",
+		error_kind: null,
+		elapsed_ms: 3000
+	}')
+
+	run _apply_stage_action "$stage_result" "escalate" "structured_error"
+	[ "$status" -eq 0 ]
+
+	# Envelope must be emitted so callers can inspect output.status.
+	local emitted_envelope
+	emitted_envelope=$(printf '%s' "$output" | grep '^{' | tail -1)
+	[ -n "$emitted_envelope" ] || \
+		fail "_apply_stage_action escalate must emit stage_result on stdout"
+
+	# The structured error's .output.status must survive in the emitted envelope
+	# so the caller (run_stage / future PR-B skill) can act on the original result.
+	local agent_status
+	agent_status=$(printf '%s' "$emitted_envelope" | jq -r '.output.status // empty')
+	[ "$agent_status" = "error" ] || \
+		fail "Expected output.status=error in emitted envelope, got: $agent_status"
+}
+
+@test "_apply_stage_action: retry_same exits 0 and emits stage_result envelope unchanged" {
+	# retry_same behavior: run_stage calls _apply_stage_action with retry_same
+	# for rate-limit scenarios. The shim must emit the envelope and return 0 so
+	# the caller can re-issue the stage; the envelope must survive intact.
+	local stage_result
+	stage_result=$(jq -nc '{
+		status: "error",
+		output: null,
+		raw: "{\"result\":\"rate limited\",\"is_error\":true}",
+		denials: [],
+		model: "sonnet",
+		error_kind: "rate_limit",
+		elapsed_ms: 2000
+	}')
+
+	run _apply_stage_action "$stage_result" "retry_same" "rate_limit"
+	[ "$status" -eq 0 ]
+
+	# Envelope must be emitted on stdout so callers can inspect stage_result.
+	local emitted_envelope
+	emitted_envelope=$(printf '%s' "$output" | grep '^{' | tail -1)
+	[ -n "$emitted_envelope" ] || \
+		fail "_apply_stage_action retry_same must emit stage_result on stdout"
+
+	# The error_kind must survive unchanged so the caller knows why retry was
+	# requested (PR-B will use this to drive the retry decision).
+	local error_kind
+	error_kind=$(printf '%s' "$emitted_envelope" | jq -r '.error_kind // empty')
+	[ "$error_kind" = "rate_limit" ] || \
+		fail "Expected error_kind=rate_limit in emitted envelope, got: $error_kind"
 }

--- a/.claude/scripts/implement-issue-test/test-task-batching.bats
+++ b/.claude/scripts/implement-issue-test/test-task-batching.bats
@@ -232,16 +232,16 @@ teardown() {
 	git checkout -q -b feature/test-wt2 main
 
 	local wt_base="$TEST_TMP/worktrees"
-	create_task_worktree "$wt_base" "feature/test-wt2" "7" \
+	create_task_worktree "$wt_base" "feature/test-wt2" "7" "42" \
 		>/dev/null
 
-	# Branch should exist
-	git rev-parse --verify "wt-task-7" >/dev/null 2>&1
+	# Branch should exist with new naming format wt-i<issue>-t<task>
+	git rev-parse --verify "wt-i42-t7" >/dev/null 2>&1
 	[ $? -eq 0 ]
 
 	# Clean up
 	git worktree remove --force "${wt_base}/task-7" 2>/dev/null || true
-	git branch -D "wt-task-7" 2>/dev/null || true
+	git branch -D "wt-i42-t7" 2>/dev/null || true
 	git checkout -q main
 }
 
@@ -540,6 +540,10 @@ _setup_parallel_stage_mocks() {
 	log_warn()  { true; }
 	comment_issue() { true; }
 	verify_on_feature_branch() { return 0; }
+	rebuild_and_health_check() {
+		printf '{"rebuild":"skipped","health":"skipped","elapsed_secs":0}'
+	}
+	_build_targeted_e2e_cmd() { printf '%s' "${TEST_E2E_CMD:-true}"; }
 
 	export TEST_E2E_CMD="echo run-e2e"
 	export RESUME_MODE=""
@@ -727,6 +731,7 @@ _setup_parallel_stage_mocks() {
 	resolve_model() { printf '%s' "sonnet"; }
 	build_files_block() { printf '\n'; }
 	extract_task_size() { printf '%s' "S"; }
+	classify_e2e_strategy() { printf '%s' "none"; }
 
 	local tasks
 	tasks='[{"id":3,"description":"Do thing","agent":"default"}]'
@@ -1342,9 +1347,14 @@ _setup_parallel_stage_mocks() {
 	}
 	log()                { :; }
 	log_warn()           { :; }
+	rebuild_and_health_check() {
+		printf '{"rebuild":"skipped","health":"skipped","elapsed_secs":0}'
+	}
+	_build_targeted_e2e_cmd() { printf '%s' "${TEST_E2E_CMD:-true}"; }
 
 	export -f is_stage_completed set_stage_started set_stage_completed
-	export -f comment_issue run_stage log log_warn
+	export -f comment_issue run_stage log log_warn rebuild_and_health_check
+	export -f _build_targeted_e2e_cmd
 	export status_calls_file
 
 	# Call the real function with conditions that allow both stages to run
@@ -1404,9 +1414,14 @@ _setup_parallel_stage_mocks() {
 		fi
 	}
 	log_warn() { :; }
+	rebuild_and_health_check() {
+		printf '{"rebuild":"skipped","health":"skipped","elapsed_secs":0}'
+	}
+	_build_targeted_e2e_cmd() { printf '%s' "${TEST_E2E_CMD:-true}"; }
 
 	export -f is_stage_completed set_stage_started set_stage_completed
-	export -f comment_issue run_stage log log_warn
+	export -f comment_issue run_stage log log_warn rebuild_and_health_check
+	export -f _build_targeted_e2e_cmd
 
 	run_parallel_post_task_stages \
 		"main" "frontend" "" "S" 2>/dev/null
@@ -1456,9 +1471,14 @@ _setup_parallel_stage_mocks() {
 	log_warn() {
 		printf 'warned: %s\n' "$1" >> "$status_log"
 	}
+	rebuild_and_health_check() {
+		printf '{"rebuild":"skipped","health":"skipped","elapsed_secs":0}'
+	}
+	_build_targeted_e2e_cmd() { printf '%s' "${TEST_E2E_CMD:-true}"; }
 
 	export -f is_stage_completed set_stage_started set_stage_completed
-	export -f comment_issue run_stage log log_warn
+	export -f comment_issue run_stage log log_warn rebuild_and_health_check
+	export -f _build_targeted_e2e_cmd
 
 	run_parallel_post_task_stages \
 		"main" "frontend" "" "S" 2>/dev/null
@@ -1508,9 +1528,14 @@ _setup_parallel_stage_mocks() {
 		true
 	}
 	log_warn() { :; }
+	rebuild_and_health_check() {
+		printf '{"rebuild":"skipped","health":"skipped","elapsed_secs":0}'
+	}
+	_build_targeted_e2e_cmd() { printf '%s' "${TEST_E2E_CMD:-true}"; }
 
 	export -f is_stage_completed set_stage_started set_stage_completed
-	export -f comment_issue run_stage log log_warn
+	export -f comment_issue run_stage log log_warn rebuild_and_health_check
+	export -f _build_targeted_e2e_cmd
 	export e2e_pid_file acc_pid_file
 
 	run_parallel_post_task_stages \
@@ -1582,6 +1607,15 @@ _setup_parallel_stage_mocks() {
 @test "run_parallel_post_task_stages: e2e and acceptance truly run in parallel (timing)" {
 	cd "$TEST_TMP/repo" || exit 1
 
+	# Add a route file on a new branch so acceptance stage calls run_stage too.
+	# Without this, acceptance short-circuits (no route files) and only e2e sleeps,
+	# making serial vs parallel indistinguishable.
+	git checkout -q -b feature/parallel-timing-test main
+	mkdir -p routes
+	printf 'export const handler = () => {}\n' > routes/api.ts
+	git add routes/api.ts
+	git commit -q -m "add route"
+
 	export TEST_E2E_CMD="true"
 	export BASE_BRANCH=main
 	unset RESUME_MODE
@@ -1598,31 +1632,33 @@ _setup_parallel_stage_mocks() {
 		local stage="$1"
 		local start_ns=$(date +%s%N)
 		printf "stage=%s,start=%s\n" "$stage" "$start_ns" >> "$timing_file"
-		# Simulate 0.1 second work
-		sleep 0.1
+		# Simulate 0.15 second work per stage
+		sleep 0.15
 		printf '{"status":"success","result":"passed","summary":"ok"}'
 	}
 	log()     { :; }
 	log_warn() { :; }
+	rebuild_and_health_check() {
+		printf '{"rebuild":"skipped","health":"skipped","elapsed_secs":0}'
+	}
+	_build_targeted_e2e_cmd() { printf '%s' "${TEST_E2E_CMD:-true}"; }
 
 	export -f is_stage_completed set_stage_started set_stage_completed
-	export -f comment_issue run_stage log log_warn
+	export -f comment_issue run_stage log log_warn rebuild_and_health_check
+	export -f _build_targeted_e2e_cmd
 	export timing_file
 
 	local global_start_ns=$(date +%s%N)
 	run_parallel_post_task_stages \
-		"main" "frontend" "" "S" 2>/dev/null
+		"feature/parallel-timing-test" "frontend" "" "S" 2>/dev/null
 	local global_end_ns=$(date +%s%N)
 	local global_elapsed_ns=$(( global_end_ns - global_start_ns ))
 	local global_elapsed_ms=$(( global_elapsed_ns / 1000000 ))
 
-	[ $? -eq 0 ]
-
-	# If stages ran serially (one after another), total time would be ~200ms
-	# If stages ran in parallel, total time would be ~100ms
-	# Add some buffer for system overhead
-	# Parallel should be much less than serial
-	[[ "$global_elapsed_ms" -lt 180 ]] || {
+	# With both stages sleeping 0.15s in parallel, total time ≈ 150ms + overhead.
+	# If they ran serially, total would be ≈ 300ms + overhead.
+	# Threshold of 400ms: passes parallel (~270ms), fails serial (~500ms).
+	[[ "$global_elapsed_ms" -lt 400 ]] || {
 		echo "Stages appear to have run serially (took ${global_elapsed_ms}ms)"
 		cat "$timing_file"
 		exit 1

--- a/.claude/scripts/implement-issue-test/test-task-summary.bats
+++ b/.claude/scripts/implement-issue-test/test-task-summary.bats
@@ -292,3 +292,27 @@ _set_tasks_json() {
     [ "$status" -eq 0 ]
     [ ! -f "$missing" ]
 }
+
+@test "write_task_summary_to_status syncs task_summary to LOG_BASE/status.json" {
+    _set_tasks_json '[
+        {"id":1,"description":"**(S)** Task one","status":"completed"},
+        {"id":2,"description":"**(M)** Task two","status":"pending"}
+    ]'
+    write_task_summary_to_status
+    local expected actual
+    expected=$(jq -r '.task_summary.sp_completed' "$STATUS_FILE")
+    actual=$(jq -r '.task_summary.sp_completed' "$LOG_BASE/status.json")
+    [ "$actual" = "$expected" ]
+}
+
+@test "write_task_summary_to_status LOG_BASE copy has same sp_total as STATUS_FILE" {
+    _set_tasks_json '[
+        {"id":1,"description":"**(S)** Task one","status":"completed"},
+        {"id":2,"description":"**(L)** Task two","status":"pending"}
+    ]'
+    write_task_summary_to_status
+    local status_sp_total log_sp_total
+    status_sp_total=$(jq -r '.task_summary.sp_total' "$STATUS_FILE")
+    log_sp_total=$(jq -r '.task_summary.sp_total' "$LOG_BASE/status.json")
+    [ "$log_sp_total" = "$status_sp_total" ]
+}

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -2,122 +2,183 @@
 #
 # model-config.sh - Tier-to-model mapping for orchestrator pipeline
 #
-# Provides semantic tier abstraction (light/standard/advanced) decoupled
-# from specific model names. Update this single file when models change.
+# Data-only: tier-to-model table, stage-to-tier tables,
+# complexity-to-tier table, model-escalation table, and the ordered
+# stage-prefix list.  Decision logic for retry and model-fallback
+# lives in the companion skills:
+#   .claude/skills/retry-policy/SKILL.md
+#   .claude/skills/model-fallback/SKILL.md
 #
 # Usage: source this file, then call resolve_model <stage> [complexity]
 #
 
+# Idempotent sourcing guard — skip re-definition on repeated source.
+[[ -z "${_MODEL_CONFIG_LOADED+set}" ]] || return 0
+readonly _MODEL_CONFIG_LOADED=1
+
 # =============================================================================
-# TIER-TO-MODEL MAPPING (TIER_MODEL)
+# TIER-TO-MODEL TABLE
 # =============================================================================
 #
 # Semantic tiers mapped to concrete model names.
 # Change models here — propagates to all stages automatically.
 #
-# Uses case-based lookup for bash 3.2 compatibility (macOS default).
+# light    → haiku   (mechanical: parse, template, simplify)
+# standard → sonnet  (judgment: review, fix, match)
+# advanced → opus    (deep reasoning: complex implementation)
 #
+# Lookup: _tier_to_model <tier>
+# Decision logic: .claude/skills/model-fallback/SKILL.md
 
-_tier_to_model() {
-	case "$1" in
-		light)    printf '%s' "haiku" ;;
-		standard) printf '%s' "sonnet" ;;
-		advanced) printf '%s' "opus" ;;
-		*)        printf '%s' "opus" ;;
-	esac
-}
+readonly _MODEL_light="haiku"
+readonly _MODEL_standard="sonnet"
+readonly _MODEL_advanced="opus"
+readonly _MODEL_default="opus"    # fallback for unknown tiers
 
 # =============================================================================
-# STAGE-TO-TIER DEFAULTS (STAGE_TIER)
+# COMPLEXITY-TO-TIER TABLE
+# =============================================================================
+#
+# Task complexity hints (S/M/L) from issue parsing override stage defaults.
+#
+# S, M → standard → sonnet  (judgment tier)
+# L    → advanced → opus    (deep-reasoning tier)
+#
+# Lookup: _complexity_to_tier <hint>
+# Decision logic: .claude/skills/model-fallback/SKILL.md
+
+readonly _COMPLEXITY_S="standard"
+readonly _COMPLEXITY_M="standard"
+readonly _COMPLEXITY_L="advanced"
+
+# =============================================================================
+# MODEL ESCALATION TABLE
+# =============================================================================
+#
+# Next model up in the haiku → sonnet → opus escalation chain.
+# opus → opus signals the ceiling (no further escalation).
+#
+# Lookup: _next_model_up <model>
+# Retry decisions:    .claude/skills/retry-policy/SKILL.md
+# Fallback decisions: .claude/skills/model-fallback/SKILL.md
+
+readonly _NEXT_MODEL_haiku="sonnet"
+readonly _NEXT_MODEL_sonnet="opus"
+readonly _NEXT_MODEL_opus="opus"
+readonly _NEXT_MODEL_default="opus"   # fallback for unknown models
+
+# =============================================================================
+# STAGE-TO-TIER TABLES
 # =============================================================================
 #
 # Each orchestrator stage maps to a tier based on its cognitive demands.
 #
-# light    — mechanical: parse markdown, run commands, fill templates, simplify
+# light    — mechanical: parse markdown, run commands, fill templates
 # standard — judgment: reviews, fixes, pattern matching
-# advanced — deep reasoning: complex implementation, root cause analysis
 #
+# (No stage defaults to advanced; complexity hint upgrades to advanced.)
+#
+# Lookup: _stage_to_tier <stage>
+# Decision logic: .claude/skills/model-fallback/SKILL.md
 
-_stage_to_tier() {
-	case "$1" in
-		parse-issue)    printf '%s' "light" ;;
-		validate-plan)  printf '%s' "light" ;;
-		triage)         printf '%s' "light" ;;
-		implement)      printf '%s' "standard" ;;
-		task-review)    printf '%s' "standard" ;;
-		fix)            printf '%s' "standard" ;;
-		test-iter)      printf '%s' "standard" ;;
-		test)           printf '%s' "light" ;;
-		review)         printf '%s' "standard" ;;
-		research)       printf '%s' "light" ;;
-		simplify)       printf '%s' "light" ;;
-		pr)             printf '%s' "standard" ;;
-		pr-review)      printf '%s' "standard" ;;
-		pr-fix)         printf '%s' "standard" ;;
-		spec-review)    printf '%s' "standard" ;;
-		code-review)    printf '%s' "standard" ;;
-		e2e-verify)     printf '%s' "light" ;;
-		fix-e2e)        printf '%s' "standard" ;;
-		fix-acceptance-test) printf '%s' "standard" ;;
-		fix-deploy-verify) printf '%s' "standard" ;;
-		deploy-verify)  printf '%s' "light" ;;
-		complete)       printf '%s' "light" ;;
-		docs)           printf '%s' "light" ;;
-		acceptance-test) printf '%s' "light" ;;
-		*)              printf '%s' "" ;;
-	esac
-}
+readonly -a _LIGHT_STAGES=(
+	parse-issue validate-plan triage
+	test research simplify
+	e2e-verify deploy-verify
+	complete docs acceptance-test
+)
+
+readonly -a _STANDARD_STAGES=(
+	implement task-review fix test-iter review
+	pr pr-review pr-fix
+	spec-review code-review
+	fix-e2e fix-acceptance-test fix-deploy-verify
+)
 
 # =============================================================================
-# COMPLEXITY-TO-TIER MAPPING (COMPLEXITY_TIER)
-# =============================================================================
-#
-# Task complexity hints (S/M/L) from issue parsing override stage defaults.
-# The quality loop forwards these to implement, review, and fix stages.
-#
-
-_complexity_to_tier() {
-	case "$1" in
-		S) printf '%s' "standard" ;;
-		M) printf '%s' "standard" ;;
-		L) printf '%s' "advanced" ;;
-		*) printf '%s' "" ;;
-	esac
-}
-
-# =============================================================================
-# STAGE PREFIX MATCHING
+# STAGE PREFIX MATCHING TABLE
 # =============================================================================
 #
 # Orchestrator stage names follow the pattern: <base>-<suffix>
 # e.g. "implement-task-1", "review-task-1-iter-2", "fix-tests-iter-1"
 #
-# We match the longest known prefix for specificity:
-# "spec-review-iter-1" matches "spec-review" (11 chars) over "review" (6)
+# Listed longest-first so _match_stage_prefix finds the most specific
+# match: "spec-review-iter-1" matches "spec-review" (11 chars) over
+# "review" (6 chars).
 #
+# Lookup: _match_stage_prefix <stage_name>
 
-# All known stage prefixes, ordered longest-first for greedy matching
-if [[ -z "${_STAGE_PREFIXES+set}" ]]; then
-	readonly -a _STAGE_PREFIXES=(
-		fix-acceptance-test acceptance-test validate-plan
-		fix-deploy-verify deploy-verify spec-review code-review task-review parse-issue e2e-verify
-		pr-review implement simplify research complete pr-fix fix-e2e review test-iter test docs fix pr
-		triage
-	)
-fi
+readonly -a _STAGE_PREFIXES=(
+	fix-acceptance-test acceptance-test validate-plan
+	fix-deploy-verify deploy-verify spec-review code-review
+	task-review parse-issue e2e-verify
+	pr-review implement simplify research complete
+	pr-fix fix-e2e review test-iter test docs fix pr
+	triage
+)
 
-_match_stage_prefix() {
-	local stage_name="$1"
+# =============================================================================
+# LOOKUP FUNCTIONS
+# =============================================================================
+#
+# Thin wrappers over the data tables above.  All retry / escalation
+# decision logic lives in the skills; these functions only look up data.
 
-	for prefix in "${_STAGE_PREFIXES[@]}"; do
-		if [[ "$stage_name" == "$prefix" || \
-			"$stage_name" == "$prefix-"* ]]; then
-			printf '%s' "$prefix"
-			return 0
-		fi
+# _tier_to_model <tier>
+# Prints the model name for the given semantic tier.
+# Unknown tiers fall back to _MODEL_default (opus).
+_tier_to_model() {
+	local _var="_MODEL_${1//[^a-zA-Z]/}"
+	printf '%s' "${!_var:-$_MODEL_default}"
+}
+
+# _stage_to_tier <stage>
+# Prints the tier for an exact stage name.
+# Returns empty string for unknown stages.
+_stage_to_tier() {
+	local _s
+	for _s in "${_LIGHT_STAGES[@]}"; do
+		[[ "$_s" == "${1:-}" ]] || continue
+		printf '%s' "light"
+		return 0
 	done
+	for _s in "${_STANDARD_STAGES[@]}"; do
+		[[ "$_s" == "${1:-}" ]] || continue
+		printf '%s' "standard"
+		return 0
+	done
+	printf '%s' ""
+}
 
+# _complexity_to_tier <hint>
+# Prints the tier for S/M/L complexity hint.
+# Returns empty string for unknown hints.
+_complexity_to_tier() {
+	local _var="_COMPLEXITY_${1//[^a-zA-Z]/}"
+	printf '%s' "${!_var:-}"
+}
+
+# _match_stage_prefix <stage_name>
+# Prints the longest known prefix that matches the stage name.
+# Returns 1 and prints nothing for unknown stage names.
+_match_stage_prefix() {
+	local _stage_name="$1" _prefix
+	for _prefix in "${_STAGE_PREFIXES[@]}"; do
+		[[ "$_stage_name" == "$_prefix" || \
+			"$_stage_name" == "$_prefix-"* ]] || continue
+		printf '%s' "$_prefix"
+		return 0
+	done
 	return 1
+}
+
+# _next_model_up <model>
+# Prints the next model up in the escalation chain.
+# opus stays at opus (ceiling); unknown models fall back to opus.
+# Full decision logic: .claude/skills/model-fallback/SKILL.md
+_next_model_up() {
+	local _var="_NEXT_MODEL_${1//[^a-zA-Z]/}"
+	printf '%s' "${!_var:-$_NEXT_MODEL_default}"
 }
 
 # =============================================================================
@@ -134,68 +195,33 @@ _match_stage_prefix() {
 # Logic:
 #   1. Match stage name against known prefixes (longest match wins)
 #   2. Look up default tier for that stage
-#   3. If complexity hint provided and valid, override with its tier
+#   3. If complexity hint provided and tier is not light, override
 #   4. Fall back to advanced (opus) for unknown stages
 #
 
 resolve_model() {
 	local stage_name="${1:-}"
 	local complexity="${2:-}"
-	local tier=""
-	local matched_prefix=""
+	local tier="" matched_prefix="" complexity_tier=""
 
 	# Match stage name against known prefixes
-	if [[ -n "$stage_name" ]]; then
+	[[ -n "$stage_name" ]] && \
 		matched_prefix=$(_match_stage_prefix "$stage_name") || true
-
-		if [[ -n "$matched_prefix" ]]; then
-			tier=$(_stage_to_tier "$matched_prefix")
-		fi
-	fi
+	[[ -n "$matched_prefix" ]] && \
+		tier=$(_stage_to_tier "$matched_prefix") || true
 
 	# Fall back to advanced for unknown stages
-	if [[ -z "$tier" ]]; then
-		tier="advanced"
-	fi
+	tier="${tier:-advanced}"
 
-	# Apply complexity hint — overrides stage default when provided.
-	# Light-tier stages (test, parse-issue, validate-plan, complete, docs,
-	# simplify, acceptance-test) are mechanical and always use haiku;
-	# complexity hints are ignored for them.
-	# The quality loop forwards task-level complexity to implement, review,
-	# and fix stages so model selection scales with task size.
-	if [[ -n "$complexity" && "$tier" != "light" ]]; then
-		local complexity_tier
-		complexity_tier=$(_complexity_to_tier "$complexity")
-
-		if [[ -n "$complexity_tier" ]]; then
-			tier="$complexity_tier"
-		fi
-	fi
+	# Apply complexity hint — light-tier stages are always haiku;
+	# complexity hints are ignored for them.  The quality loop forwards
+	# task-level complexity to implement, review, and fix stages so
+	# model selection scales with task size.
+	[[ -n "$complexity" && "$tier" != "light" ]] && \
+		complexity_tier=$(_complexity_to_tier "$complexity") || true
+	[[ -n "$complexity_tier" ]] && tier="$complexity_tier" || true
 
 	printf '%s\n' "$(_tier_to_model "$tier")"
-}
-
-# =============================================================================
-# MODEL ESCALATION (_next_model_up)
-# =============================================================================
-#
-# Given a model name, returns the next model up in the tier hierarchy.
-# Used for --fallback-model to provide resilience when the primary model
-# is unavailable or rate-limited.
-#
-# haiku  -> sonnet
-# sonnet -> opus
-# opus   -> opus (ceiling)
-#
-
-_next_model_up() {
-	case "$1" in
-		haiku)  printf '%s' "sonnet" ;;
-		sonnet) printf '%s' "opus" ;;
-		opus)   printf '%s' "opus" ;;
-		*)      printf '%s' "opus" ;;
-	esac
 }
 
 # =============================================================================
@@ -203,9 +229,9 @@ _next_model_up() {
 # =============================================================================
 #
 # Wraps resolve_model with a check against claude-usage.sh's
-# is_model_exhausted. When the picked model is exhausted (per-model bucket
-# full and overage isn't absorbing), escalate via _next_model_up until we
-# find one that isn't exhausted or hit the opus ceiling.
+# is_model_exhausted.  When the picked model is exhausted (per-model
+# bucket full and overage isn't absorbing), escalates via _next_model_up
+# until a non-exhausted model is found or the opus ceiling is reached.
 #
 # When claude-usage.sh isn't loaded OR no sessionKey is configured,
 # is_model_exhausted returns false for everything and these wrappers
@@ -214,33 +240,31 @@ _next_model_up() {
 #
 
 _usage_aware_escalate() {
-	local model="$1" original="$1" next
-	# is_model_exhausted comes from claude-usage.sh. When it isn't sourced
-	# (or polling is unconfigured), treat all models as not exhausted.
-	if ! declare -F is_model_exhausted >/dev/null 2>&1; then
+	local model="$1" original="$1" next _reset _msg
+	declare -F is_model_exhausted >/dev/null 2>&1 || {
 		printf '%s\n' "$model"
 		return 0
-	fi
+	}
 
 	# _next_model_up returns the same model at the opus ceiling, which
 	# terminates the loop unconditionally — no infinite spin if every
 	# tier is exhausted.
 	while is_model_exhausted "$model"; do
 		next=$(_next_model_up "$model")
-		if [[ "$next" == "$model" ]]; then
-			break
-		fi
+		[[ "$next" == "$model" ]] && break
 		model="$next"
 	done
 
 	# Surface the escalation so operators can correlate cost spikes with
-	# bucket exhaustion. Logged via the orchestrator's `log` if available,
+	# bucket exhaustion.  Logged via the orchestrator's log if available,
 	# else stderr — see _usage_log in claude-usage.sh.
-	if [[ "$model" != "$original" ]] && declare -F model_reset_at >/dev/null 2>&1; then
-		local _reset
-		_reset=$(model_reset_at "$original")
-		_usage_log "Usage gate: $original exhausted (resets ${_reset}) — escalating to $model"
-	fi
+	[[ "$model" != "$original" ]] && \
+		declare -F model_reset_at >/dev/null 2>&1 && {
+			_reset=$(model_reset_at "$original")
+			_msg="Usage gate: $original exhausted"
+			_msg+=" (resets ${_reset}) — escalating to $model"
+			_usage_log "$_msg"
+		} || true
 
 	printf '%s\n' "$model"
 }

--- a/.claude/scripts/platform/merge-mr.sh
+++ b/.claude/scripts/platform/merge-mr.sh
@@ -6,8 +6,39 @@ source "$SCRIPT_DIR/../../config/platform.sh"
 
 MR="$1"
 
+wait_for_mergeable() {
+  local pr="$1"
+  local interval=10
+  local max=90
+  local elapsed=0
+
+  while [ "$elapsed" -lt "$max" ]; do
+    local state
+    state=$(gh pr view "$pr" --json mergeable --jq '.mergeable' 2>/dev/null || echo "UNKNOWN")
+
+    case "$state" in
+      MERGEABLE)
+        return 0
+        ;;
+      CONFLICTING)
+        echo "PR has unresolvable merge conflicts" >&2
+        return 1
+        ;;
+      *)
+        echo "Waiting for PR #$pr to become mergeable (state: $state, ${elapsed}s elapsed)..." >&2
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+        ;;
+    esac
+  done
+
+  echo "Timed out waiting for GitHub to compute mergeability" >&2
+  return 1
+}
+
 case "$GIT_HOST" in
   github)
+    wait_for_mergeable "$MR" || exit 1
     case "$MERGE_STYLE" in
       squash) gh pr merge "$MR" --squash --delete-branch ;;
       merge) gh pr merge "$MR" --merge --delete-branch ;;

--- a/.claude/scripts/prompts/triage-prompt.sh
+++ b/.claude/scripts/prompts/triage-prompt.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# triage-prompt.sh — build_prompt() for the triage classifier
+#
+# Defines a single function with no external dependencies. Source this file
+# wherever a triage prompt is needed.
+#
+# ─── Prompt File Convention ───────────────────────────────────────────────────
+# Each file in this directory follows the pattern:
+#
+#   prompts/<stage>-prompt.sh
+#
+# Rules for skill/pipeline authors adding a new stage prompt:
+#   1. Name the file  prompts/<stage>-prompt.sh  (e.g. implement-prompt.sh)
+#   2. Define exactly one function — build_prompt() — with no global side-effects
+#   3. Accept stage-specific arguments as positional parameters ($1, $2, …)
+#   4. Declare no globals; output the prompt text to stdout via cat <<HEREDOC
+#   5. Source the file once from the orchestrator, before first use:
+#        # shellcheck source=prompts/<stage>-prompt.sh
+#        source "$SCRIPT_DIR/prompts/<stage>-prompt.sh"
+#
+# This keeps all stage prompt logic isolated from the orchestrator and easy to
+# unit-test independently.
+# ──────────────────────────────────────────────────────────────────────────────
+
+build_prompt() {
+	local issue_body="$1"
+	cat <<TRIAGE_PROMPT
+You are the triage classifier for an issue-implementation pipeline. Classify
+the GitHub issue below into one of two routes:
+
+  "fast-path" — surgical, test-only, well-specified change. Pipeline runs:
+                branch -> implement -> commit -> PR -> squash-merge. Skips
+                test loop, code review, deploy verify, docs.
+  "full"      — default. Runs the full verification pipeline.
+
+Be CONSERVATIVE. False negatives (missing a fast-path opportunity) cost time.
+False positives (skipping verification when it was needed) cost quality. Bias
+hard toward "full" whenever uncertain.
+
+Check ALL SIX criteria. Every criterion must be true for "fast-path". If ANY
+criterion is false, route is "full".
+
+CRITERIA:
+
+1. test_only_scope — All file paths in the issue's Implementation Tasks
+   section match: tests/**, playwright/**, **/*.spec.ts, **/*.test.ts,
+   **/*.e2e.ts. Any reference to apps/, packages/, src/, or migration files
+   disqualifies.
+
+2. surgical_size — Estimated diff under 30 lines net, across no more than
+   3 files.
+
+3. established_pattern — The change applies a pattern that already exists in
+   the codebase. Identify the pattern as a grep-able regex and place it in
+   "established_pattern_grep". The shell wrapper will run \`git grep -lE\` and
+   verify >= 3 matching files. Set to null if you cannot identify one
+   specific regex (this criterion then fails).
+
+4. precise_specification — Issue body has an "## Implementation Tasks"
+   section AND each task names specific file paths AND (line numbers OR
+   exact code snippets).
+
+5. benign_failure_mode — Worst outcome of a wrong change is "a test still
+   fails" or "a test skips" — NOT "production breaks", "data corrupts", or
+   "users see incorrect behavior". Test files always pass; production code
+   never passes.
+
+6. no_security_concerns — Skip fast-path for: auth flows, RBAC, encryption,
+   secret handling, input validation, CORS, CSP, session management, token
+   handling. Auth tests deserve review even if test-only.
+
+CONFIDENCE: high (all criteria clearly evaluated) | medium (some criteria
+required inference) | low (vague issue). If confidence is medium or low,
+route MUST be "full".
+
+OUTPUT: schema-enforced JSON with route, criteria.{test_only_scope,
+surgical_size, established_pattern, precise_specification,
+benign_failure_mode, no_security_concerns}.{passed, reason},
+established_pattern_grep, confidence, disqualifying_criterion, summary,
+status.
+
+ISSUE BODY:
+<<<
+${issue_body}
+>>>
+TRIAGE_PROMPT
+}

--- a/.claude/scripts/schemas/escalation-policy.json
+++ b/.claude/scripts/schemas/escalation-policy.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "escalation-policy skill output: route a completed stage_result to accept, escalate, bail, or retry_same",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["accept", "escalate", "bail", "retry_same"],
+      "description": "Routing decision for the pipeline"
+    },
+    "model": {
+      "type": "string",
+      "enum": ["haiku", "sonnet", "opus"],
+      "description": "Target model when action==escalate; omitted otherwise"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable routing rationale for logging and diagnostics"
+    }
+  },
+  "required": ["action", "reason"]
+}

--- a/.claude/scripts/schemas/implement-issue-review.json
+++ b/.claude/scripts/schemas/implement-issue-review.json
@@ -17,5 +17,6 @@
     },
     "summary": {"type": "string"}
   },
-  "required": ["result", "summary"]
+  "required": ["result", "summary"],
+  "additionalProperties": false
 }

--- a/.claude/scripts/schemas/model-fallback-output.json
+++ b/.claude/scripts/schemas/model-fallback-output.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "model-fallback skill output: next model tier to try, or null when at the opus ceiling",
+  "properties": {
+    "next_model": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["haiku", "sonnet", "opus"],
+          "description": "The next model tier to use; only present when at_ceiling is false"
+        },
+        {
+          "type": "null",
+          "description": "null when at_ceiling is true — no further fallback is possible"
+        }
+      ]
+    },
+    "at_ceiling": {
+      "type": "boolean",
+      "description": "true when current_model is opus or error_kind is non-escalatable (permission_denied, schema_not_found, max_turns_exhausted_at_ceiling)"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable rationale for the decision"
+    }
+  },
+  "required": ["next_model", "at_ceiling", "reason"]
+}

--- a/.claude/scripts/schemas/model-fallback.json
+++ b/.claude/scripts/schemas/model-fallback.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "model-fallback skill output: next model to escalate to, or at-ceiling indication",
+  "properties": {
+    "next_model": {
+      "type": ["string", "null"],
+      "enum": ["haiku", "sonnet", "opus", null],
+      "description": "Model to escalate to, or null when no further escalation is possible"
+    },
+    "at_ceiling": {
+      "type": "boolean",
+      "description": "True when current_model is opus or the error_kind makes escalation impossible"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable escalation rationale"
+    }
+  },
+  "required": ["next_model", "at_ceiling", "reason"]
+}

--- a/.claude/scripts/schemas/pipeline-feedback.json
+++ b/.claude/scripts/schemas/pipeline-feedback.json
@@ -1,0 +1,43 @@
+{
+  "description": "Schema for pipeline feedback records — structured observations about classification or routing errors for offline analysis and prompt improvement.",
+  "type": "object",
+  "required": ["timestamp", "kind", "issue", "observed", "expected"],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp when the feedback was recorded"
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "triage_misclassification",
+        "prompt_regression",
+        "criterion_drift",
+        "agent_misroute",
+        "escalation_loop"
+      ],
+      "description": "Category of pipeline failure being reported"
+    },
+    "issue": {
+      "type": "string",
+      "description": "Issue number or identifier associated with this feedback, e.g. 176"
+    },
+    "observed": {
+      "type": "string",
+      "description": "What the pipeline actually did (the incorrect or unexpected behaviour)"
+    },
+    "expected": {
+      "type": "string",
+      "description": "What the pipeline should have done (the correct or desired behaviour)"
+    },
+    "evidence_path": {
+      "type": "string",
+      "description": "Relative path to a log file, JSONL event stream, or artifact that supports this feedback (optional)"
+    },
+    "notes": {
+      "type": "string",
+      "description": "Free-form context, hypotheses, or reproduction steps (optional)"
+    }
+  }
+}

--- a/.claude/scripts/schemas/retry-policy.json
+++ b/.claude/scripts/schemas/retry-policy.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "retry-policy skill output: retry same tier, escalate, or bail permanently",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["retry", "escalate", "bail"],
+      "description": "Decision: retry at same tier, escalate to higher tier, or bail permanently"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable rationale for the decision"
+    },
+    "backoff_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Milliseconds to wait before retrying; only present when action==retry and error_kind==rate_limit"
+    }
+  },
+  "required": ["action", "reason"]
+}

--- a/.claude/scripts/schemas/skill-frontmatter.json
+++ b/.claude/scripts/schemas/skill-frontmatter.json
@@ -1,0 +1,142 @@
+{
+  "description": "JSON schema for SKILL.md YAML frontmatter — validates the existing required fields and the five optional metadata fields added in issue #177.",
+  "type": "object",
+  "required": ["name", "description", "inputs", "outputs", "side_effects", "composes", "failure_modes"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Canonical skill identifier (matches the directory name under .claude/skills/)"
+    },
+    "description": {
+      "type": "string",
+      "description": "One-line summary used by the skill router to decide whether this skill applies"
+    },
+    "argument-hint": {
+      "type": "string",
+      "description": "Human-readable hint for the argument(s) the skill accepts, shown in skill listings"
+    },
+    "inputs": {
+      "type": "array",
+      "description": "Explicit contract for what the skill consumes; enables a meta-skill to validate args before invocation",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Input parameter name"
+          },
+          "type": {
+            "type": "string",
+            "description": "Data type of the input (e.g. string, integer, url, boolean, file_path)"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Whether this input is required; defaults to false if omitted"
+          },
+          "description": {
+            "type": "string",
+            "description": "What the input represents and how it is used"
+          }
+        }
+      }
+    },
+    "outputs": {
+      "type": "array",
+      "description": "Explicit contract for what consumers can rely on; enables piping skill outputs into other skills",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Output value name"
+          },
+          "type": {
+            "type": "string",
+            "description": "Data type of the output (e.g. string, integer, url, boolean, file_path, json)"
+          },
+          "description": {
+            "type": "string",
+            "description": "What the output represents and where it can be found"
+          }
+        }
+      }
+    },
+    "side_effects": {
+      "type": "array",
+      "description": "Declares what changes outside the conversation (files written, issues created, processes spawned) so a dry-run skill can predict impact",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Named side effect with no extra detail (e.g. 'creates_github_issue')"
+          },
+          {
+            "type": "object",
+            "description": "Named side effect with an associated path or value (e.g. {writes_log: 'logs/foo/status.json'})",
+            "minProperties": 1,
+            "maxProperties": 1,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "composes": {
+      "type": "array",
+      "description": "Names sub-skills invoked via the Skill tool; enables a graph of skill dependencies",
+      "items": {
+        "type": "string",
+        "description": "Skill name as it appears in the skills directory (e.g. 'mcp-tools', 'explore')"
+      }
+    },
+    "failure_modes": {
+      "type": "array",
+      "description": "Known ways this skill can fail and what callers should do; enables a pipeline-recovery skill to take action",
+      "items": {
+        "type": "object",
+        "required": ["id", "mitigation"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Short snake_case identifier for the failure mode (e.g. 'gh_api_unauthorized')"
+          },
+          "mitigation": {
+            "type": "string",
+            "description": "What the skill or its caller should do when this failure occurs"
+          }
+        }
+      }
+    },
+    "golden": {
+      "type": "object",
+      "description": "Golden test configuration for decision skills — declares the model, manifest path, fixture directory, and output schema used by skill-golden.sh",
+      "required": ["model", "manifest", "fixture_dir"],
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "Model tier to use for golden test runs (e.g. haiku, sonnet)"
+        },
+        "manifest": {
+          "type": "string",
+          "description": "Path to the golden manifest file (relative to repo root) listing fixture|expected_route|expected_criterion entries"
+        },
+        "fixture_dir": {
+          "type": "string",
+          "description": "Path to the directory containing fixture files (relative to repo root)"
+        },
+        "schema": {
+          "type": "string",
+          "description": "Path to the JSON schema file used to validate Claude's structured output (relative to repo root). Falls back to .claude/scripts/schemas/<skill-name>.json when omitted."
+        }
+      }
+    }
+  }
+}

--- a/.claude/scripts/schemas/skill-golden-manifest.json
+++ b/.claude/scripts/schemas/skill-golden-manifest.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Golden test manifest for a decision skill. Each entry pins one fixture to its expected output so prompt regressions surface before merge. Mirrors the 'fixture|expected_route|expected_criterion' pipe-delimited convention from triage-validate.sh but expressed as structured JSON.",
+  "type": "array",
+  "minItems": 0,
+  "items": {
+    "type": "object",
+    "description": "One golden test case: a fixture file mapped to the output the model must produce.",
+    "required": ["fixture", "expected_route"],
+    "additionalProperties": false,
+    "properties": {
+      "fixture": {
+        "type": "string",
+        "description": "Fixture file basename without extension, relative to the skill's fixture directory (e.g. 'issue-2836')"
+      },
+      "expected_route": {
+        "type": "string",
+        "description": "The categorical routing decision the model must return for this fixture (e.g. 'fast-path', 'full', 'escalate', 'retry')"
+      },
+      "expected_criterion": {
+        "type": "string",
+        "description": "Expected disqualifying criterion name. Use '*' when the route alone is the contract and any criterion reason is acceptable. Mutually exclusive with any_of."
+      },
+      "any_of": {
+        "type": "array",
+        "description": "Two or more acceptable criterion values for multi-correct cases — the test passes if the model returns any one of them. Mutually exclusive with expected_criterion.",
+        "minItems": 2,
+        "items": {
+          "type": "string",
+          "description": "An acceptable criterion name"
+        }
+      }
+    }
+  }
+}

--- a/.claude/scripts/schemas/stage-result.json
+++ b/.claude/scripts/schemas/stage-result.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Envelope returned by run_stage for every stage invocation",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["success", "error", "rate_limit"],
+      "description": "High-level outcome of the stage run"
+    },
+    "output": {
+      "description": "Parsed structured output from the Claude CLI response; null on error",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "raw": {
+      "type": "string",
+      "description": "Raw stdout from the Claude CLI call before structured output extraction"
+    },
+    "denials": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Tool names blocked by permission hooks during this stage run"
+    },
+    "model": {
+      "type": "string",
+      "description": "Model ID that produced the final output, e.g. haiku, sonnet, opus"
+    },
+    "error_kind": {
+      "type": ["string", "null"],
+      "enum": [
+        "timeout",
+        "double_timeout",
+        "schema_not_found",
+        "no_structured_output",
+        "max_turns_exhausted_at_ceiling",
+        "rate_limit",
+        "permission_denied",
+        "quality_stall",
+        "max_turns_exhausted",
+        "structured_error",
+        null
+      ],
+      "description": "Machine-readable error classification; null when status is success"
+    },
+    "elapsed_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Wall-clock milliseconds from stage invocation to return"
+    }
+  },
+  "required": ["status"]
+}

--- a/.claude/scripts/skill-golden-lib.sh
+++ b/.claude/scripts/skill-golden-lib.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+#
+# skill-golden-lib.sh
+#
+# Reusable functions for skill-golden tests — real-Claude prompt regression
+# harness for decision skills. Extracted from triage-validate.sh so the same
+# pattern can pin down every decision skill (triage-classify, escalation-
+# policy, retry-policy, model-fallback, pipeline-recovery), not just triage.
+#
+# This file is a LIBRARY — source it from a thin driver script:
+#
+#     #!/usr/bin/env bash
+#     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#     source "$SCRIPT_DIR/skill-golden-lib.sh"
+#
+#     build_prompt() {
+#         local issue_body="$1"
+#         cat <<EOF
+#     ... your skill's prompt referencing $issue_body ...
+#     EOF
+#     }
+#
+#     MANIFEST=(
+#         "fixture-a|fast-path|*"
+#         "fixture-b|full|some_criterion"
+#     )
+#
+#     sg_check_setup "$FIXTURE_DIR" "$SCHEMA_FILE" || exit 2
+#     sg_run_manifest "$FIXTURE_DIR" "$SCHEMA_FILE" "$MODEL" \
+#         build_prompt "${1:-}" "${MANIFEST[@]}"
+#     exit $?
+#
+# CONTRACT (manifest format):
+#   "fixture_basename|expected_route|expected_criterion_or_*"
+#     - fixture_basename — file under FIXTURE_DIR named "<basename>.md"
+#     - expected_route   — primary decision the skill returns under .route
+#     - expected_criterion_or_* — pinpoint criterion under
+#       .disqualifying_criterion (or "*" to accept any). Only checked when
+#       the route mismatch would otherwise be the only flip surface; a wrong
+#       criterion is a WARN, not a FAIL — the route is the contract.
+#
+# OUTPUT EXTRACTION:
+#   Mirrors run_stage() in implement-issue-orchestrator.sh: prefer
+#   .structured_output, fall back to .result (parsed if stringified JSON),
+#   then to the top-level object. If these diverge from the orchestrator,
+#   the validator stops reflecting prod — keep them in sync.
+#
+# CUSTOMIZATION (env vars, all optional):
+#   SG_CLAUDE_CLI         path to claude CLI (default "claude")
+#   SG_MAX_ATTEMPTS       Claude invocation retries on transient errors (3)
+#   SG_RETRY_BASE_SLEEP   seconds between retries, multiplied by attempt (5)
+#   SG_ROUTE_FIELD        JSON field for primary decision (default "route")
+#   SG_CRITERION_FIELD    JSON field for criterion (default
+#                         "disqualifying_criterion")
+#   SG_CONFIDENCE_FIELD   JSON field for confidence (default "confidence")
+#   SG_SUMMARY_FIELD      JSON field for summary (default "summary")
+#
+
+# Guard against double-sourcing — multiple drivers may pull this in via the
+# same parent process (skill-golden.sh --all dispatches per-skill).
+if [[ -n "${_SKILL_GOLDEN_LIB_SOURCED:-}" ]]; then
+	return 0 2>/dev/null || true
+fi
+_SKILL_GOLDEN_LIB_SOURCED=1
+
+# Defaults — set only if unset so drivers can pre-configure.
+: "${SG_CLAUDE_CLI:=claude}"
+: "${SG_MAX_ATTEMPTS:=3}"
+: "${SG_RETRY_BASE_SLEEP:=5}"
+: "${SG_ROUTE_FIELD:=route}"
+: "${SG_CRITERION_FIELD:=disqualifying_criterion}"
+: "${SG_CONFIDENCE_FIELD:=confidence}"
+: "${SG_SUMMARY_FIELD:=summary}"
+
+# =============================================================================
+# Color helpers — write ANSI escapes to stdout. Callers wrap with printf.
+# =============================================================================
+
+sg_red()    { printf '\033[31m%s\033[0m' "$1"; }
+sg_green()  { printf '\033[32m%s\033[0m' "$1"; }
+sg_yellow() { printf '\033[33m%s\033[0m' "$1"; }
+sg_dim()    { printf '\033[2m%s\033[0m' "$1"; }
+
+# =============================================================================
+# Setup checks — verify external commands and required paths exist.
+# All errors go to stderr; functions return non-zero on failure.
+# =============================================================================
+
+sg_require_cmd() {
+	local cmd="$1"
+	if ! command -v "$cmd" >/dev/null 2>&1; then
+		printf 'skill-golden: required command not found: %s\n' \
+			"$cmd" >&2
+		return 2
+	fi
+	return 0
+}
+
+# sg_check_setup FIXTURE_DIR SCHEMA_FILE
+# Verifies jq, the configured claude CLI, the schema file, and the fixture
+# directory all exist. Returns 0 on success, 2 on any failure.
+sg_check_setup() {
+	local fixture_dir="$1"
+	local schema_file="$2"
+	local rc=0
+
+	sg_require_cmd jq || rc=2
+	sg_require_cmd "$SG_CLAUDE_CLI" || rc=2
+
+	if [[ ! -f "$schema_file" ]]; then
+		printf 'skill-golden: schema not found: %s\n' \
+			"$schema_file" >&2
+		rc=2
+	fi
+
+	if [[ ! -d "$fixture_dir" ]]; then
+		printf 'skill-golden: fixture dir not found: %s\n' \
+			"$fixture_dir" >&2
+		rc=2
+	fi
+
+	return "$rc"
+}
+
+# =============================================================================
+# Manifest parser — splits "fixture|expected_route|expected_criterion" into
+# three newline-separated fields on stdout. Drivers usually parse inline with
+# `IFS='|' read -r f r c <<<"$entry"`; this function exists for tests and
+# for any caller that wants a single source of truth for the format.
+# =============================================================================
+
+sg_parse_manifest_entry() {
+	local entry="$1"
+	local fixture expected_route expected_criterion
+	IFS='|' read -r fixture expected_route expected_criterion <<<"$entry"
+	printf '%s\n%s\n%s\n' \
+		"$fixture" "$expected_route" "$expected_criterion"
+}
+
+# =============================================================================
+# Claude invocation with retry — calls the claude CLI with the prompt and
+# schema, retrying on transient errors (rate limit, overload, timeout) with
+# linear backoff. Output (stdout from claude on success, stderr from claude
+# on failure) is written to this function's stdout. Logs go to stderr.
+#
+# sg_invoke_claude PROMPT MODEL SCHEMA_FILE
+#   PROMPT      — full prompt string passed via -p
+#   MODEL       — model alias (haiku, sonnet, etc)
+#   SCHEMA_FILE — path to the JSON schema for --json-schema
+#
+# Returns:
+#   0 — claude succeeded; payload on stdout
+#   1 — claude failed after all retries; last output on stdout for diagnostics
+#   2 — schema file unreadable
+# =============================================================================
+
+sg_invoke_claude() {
+	local prompt="$1"
+	local model="$2"
+	local schema_file="$3"
+	local schema_compact output rc=0
+	local attempt=1 backoff
+
+	if ! schema_compact=$(jq -c . "$schema_file" 2>&1); then
+		printf 'skill-golden: failed to compact schema %s: %s\n' \
+			"$schema_file" "$schema_compact" >&2
+		return 2
+	fi
+
+	while ((attempt <= SG_MAX_ATTEMPTS)); do
+		# NB: capture rc separately, not via `rc=$?` after `if...fi`.
+		# Bash sets $? to 0 after a failed `if` with no `else` branch,
+		# so the post-fi capture would always read 0 and silently
+		# convert non-retryable failures into "success" returns.
+		output=$(env -u CLAUDECODE "$SG_CLAUDE_CLI" -p "$prompt" \
+			--model "$model" \
+			--dangerously-skip-permissions \
+			--output-format json \
+			--json-schema "$schema_compact" 2>&1)
+		rc=$?
+		if ((rc == 0)); then
+			printf '%s' "$output"
+			return 0
+		fi
+
+		# Retry on transient signals only. Anything else is a real
+		# error (auth, schema mismatch, missing flag) — surface it.
+		if sg_is_retryable "$output"; then
+			backoff=$((attempt * SG_RETRY_BASE_SLEEP))
+			printf 'skill-golden: transient error (attempt %d/%d), sleeping %ds\n' \
+				"$attempt" "$SG_MAX_ATTEMPTS" \
+				"$backoff" >&2
+			sleep "$backoff"
+			attempt=$((attempt + 1))
+			continue
+		fi
+
+		printf '%s' "$output"
+		return "$rc"
+	done
+
+	printf '%s' "$output"
+	return 1
+}
+
+# Pure check — does this output look like a transient/retryable error?
+# Kept small and case-insensitive; expand only when a new transient
+# signature is observed in the wild. Uses tr (not bash 4 ${var,,}) so the
+# library stays compatible with macOS-system bash 3.2.
+sg_is_retryable() {
+	local output="$1"
+	local lower
+	lower=$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')
+	case "$lower" in
+		*"rate limit"*|*"429"*|*"overloaded"* \
+			|*"overload_error"*|*"timeout"*|*"timed out"* \
+			|*"503 service unavailable"*|*"econnreset"*)
+			return 0
+			;;
+	esac
+	return 1
+}
+
+# =============================================================================
+# JSON output validation — extract the schema-validated payload from the
+# claude CLI's wrapped JSON response. Mirrors run_stage() in
+# implement-issue-orchestrator.sh; if these diverge, the validator stops
+# reflecting prod.
+#
+# sg_extract_payload OUTPUT
+#   Echoes the inner JSON object on stdout. Echoes "{}" (and writes a note to
+#   stderr) when the payload cannot be located or is not valid JSON. Always
+#   returns 0 — callers detect missing fields by inspecting the payload.
+# =============================================================================
+
+sg_extract_payload() {
+	local output="$1"
+	local payload
+
+	payload=$(printf '%s' "$output" | jq -c '
+		.structured_output
+		// (.result | if type == "string" then fromjson? else . end)
+		// .
+	' 2>/dev/null || echo '{}')
+
+	if ! printf '%s' "$payload" | jq -e . >/dev/null 2>&1; then
+		printf 'skill-golden: payload not valid JSON, treating as {}\n' >&2
+		payload='{}'
+	fi
+
+	printf '%s' "$payload"
+}
+
+# sg_get_field PAYLOAD FIELD [DEFAULT]
+#   Returns the string value of .FIELD on the payload, or DEFAULT if the
+#   field is absent. Default is "MISSING" only when the third arg is unset;
+#   passing an empty string explicitly (sg_get_field x y "") is honored —
+#   needed for optional fields like .summary where "" is a valid result.
+#   Stderr-silent. Uses --arg to avoid jq filter injection from field names.
+sg_get_field() {
+	local payload="$1"
+	local field="$2"
+	local default="${3-MISSING}"
+	local value
+	if ! value=$(printf '%s' "$payload" \
+		| jq -r --arg f "$field" --arg d "$default" \
+			'(.[$f] // $d) | tostring' \
+		2>/dev/null); then
+		value="$default"
+	fi
+	printf '%s' "$value"
+}
+
+# =============================================================================
+# Fixture runner — executes one manifest entry end-to-end: load fixture,
+# build prompt, call claude, extract payload, compare against expected.
+#
+# sg_run_fixture ENTRY FIXTURE_DIR SCHEMA_FILE MODEL PROMPT_BUILDER_FN
+#   ENTRY              — manifest line "fixture|route|criterion"
+#   FIXTURE_DIR        — directory containing "<fixture>.md"
+#   SCHEMA_FILE        — JSON schema for the skill's output
+#   MODEL              — model alias to invoke
+#   PROMPT_BUILDER_FN  — name of a shell function defined by the driver
+#                        that takes the fixture body on $1 and prints the
+#                        full prompt on stdout
+#
+# Prints one line per fixture (PASS / FAIL / WARN) to stdout. Returns:
+#   0 — PASS or WARN (route matched; criterion may have flipped)
+#   1 — FAIL (route mismatched or fixture/CLI failure)
+# =============================================================================
+
+sg_run_fixture() {
+	local entry="$1"
+	local fixture_dir="$2"
+	local schema_file="$3"
+	local model="$4"
+	local prompt_builder="$5"
+
+	local fixture expected_route expected_criterion
+	IFS='|' read -r fixture expected_route expected_criterion <<<"$entry"
+
+	# Try .md first (issue-body fixtures), then .json (structured-event
+	# fixtures such as escalation-policy stage results).
+	local body_file="$fixture_dir/${fixture}.md"
+	if [[ ! -f "$body_file" ]]; then
+		body_file="$fixture_dir/${fixture}.json"
+	fi
+	if [[ ! -f "$body_file" ]]; then
+		printf '  %s missing fixture: %s.{md,json}\n' \
+			"$(sg_red "FAIL")" "$fixture_dir/$fixture"
+		return 1
+	fi
+
+	if ! declare -F "$prompt_builder" >/dev/null 2>&1; then
+		printf '  %s %-28s prompt builder not defined: %s\n' \
+			"$(sg_red "FAIL")" "$fixture" "$prompt_builder"
+		return 1
+	fi
+
+	local body prompt output start end elapsed_ms timing_label
+	body=$(cat "$body_file")
+	prompt=$("$prompt_builder" "$body")
+
+	start=$(date +%s%N 2>/dev/null || echo 0)
+	if ! output=$(sg_invoke_claude "$prompt" "$model" "$schema_file"); then
+		printf '  %s %-28s claude invocation failed\n' \
+			"$(sg_red "FAIL")" "$fixture"
+		printf '%s\n' "$output" | head -5 | sed 's/^/      /'
+		return 1
+	fi
+	end=$(date +%s%N 2>/dev/null || echo 0)
+	elapsed_ms=$(( (end - start) / 1000000 ))
+	timing_label=$(printf '%6dms' "$elapsed_ms")
+
+	local payload route confidence criterion summary
+	payload=$(sg_extract_payload "$output")
+	route=$(sg_get_field "$payload" "$SG_ROUTE_FIELD" "MISSING")
+	confidence=$(sg_get_field "$payload" "$SG_CONFIDENCE_FIELD" "MISSING")
+	criterion=$(sg_get_field "$payload" "$SG_CRITERION_FIELD" "")
+	summary=$(sg_get_field "$payload" "$SG_SUMMARY_FIELD" "")
+
+	if [[ "$route" != "$expected_route" ]]; then
+		printf '  %s %-28s %s  expected=%s got=%s confidence=%s\n' \
+			"$(sg_red "FAIL")" "$fixture" "$timing_label" \
+			"$expected_route" "$route" "$confidence"
+		[[ -n "$summary" ]] && printf '      %s\n' \
+			"$(sg_dim "summary: $summary")"
+		return 1
+	fi
+
+	# Criterion check is secondary — the route is the contract. Mismatch
+	# is a WARN so operators see drift without flipping CI red.
+	if [[ -n "$expected_criterion" \
+		&& "$expected_criterion" != "*" \
+		&& "$criterion" != "$expected_criterion" ]]; then
+		printf '  %s %-28s %s  route=%s ok, but %s=%s expected=%s\n' \
+			"$(sg_yellow "WARN")" "$fixture" "$timing_label" \
+			"$route" "$SG_CRITERION_FIELD" \
+			"${criterion:-<empty>}" "$expected_criterion"
+		[[ -n "$summary" ]] && printf '      %s\n' \
+			"$(sg_dim "summary: $summary")"
+		return 0
+	fi
+
+	printf '  %s %-28s %s  %s=%s confidence=%s\n' \
+		"$(sg_green "PASS")" "$fixture" "$timing_label" \
+		"$SG_ROUTE_FIELD" "$route" "$confidence"
+	return 0
+}
+
+# =============================================================================
+# Manifest iteration — runs every entry, applies an optional fixture filter,
+# emits per-fixture lines, and prints a summary. Returns:
+#   0 — all matched fixtures passed (or warned)
+#   1 — at least one fixture flipped
+#   2 — filter matched no fixtures
+#
+# sg_run_manifest FIXTURE_DIR SCHEMA_FILE MODEL PROMPT_BUILDER FILTER ENTRIES...
+#   FILTER may be empty (run all). Otherwise only entries whose fixture
+#   basename equals FILTER run.
+# =============================================================================
+
+sg_run_manifest() {
+	local fixture_dir="$1"; shift
+	local schema_file="$1"; shift
+	local model="$1"; shift
+	local prompt_builder="$1"; shift
+	local filter="$1"; shift
+	# Remaining "$@" are manifest entries.
+
+	local total=0 passed=0 failed=0
+	local entry fixture run_start run_end elapsed
+
+	run_start=$(date +%s)
+
+	printf 'skill-golden: %d fixtures, model=%s\n' "$#" "$model"
+	printf '\n'
+
+	for entry in "$@"; do
+		fixture="${entry%%|*}"
+		if [[ -n "$filter" && "$fixture" != "$filter" ]]; then
+			continue
+		fi
+		total=$((total + 1))
+		if sg_run_fixture "$entry" "$fixture_dir" "$schema_file" \
+			"$model" "$prompt_builder"; then
+			passed=$((passed + 1))
+		else
+			failed=$((failed + 1))
+		fi
+	done
+
+	run_end=$(date +%s)
+	elapsed=$((run_end - run_start))
+
+	sg_print_summary "$total" "$passed" "$failed" "$elapsed" "$filter"
+}
+
+# =============================================================================
+# Reporter — prints summary line and final PASS/FAIL marker. Returns:
+#   0 — all passed
+#   1 — at least one failure
+#   2 — total == 0 (no fixtures matched)
+# =============================================================================
+
+sg_print_summary() {
+	local total="$1"
+	local passed="$2"
+	local failed="$3"
+	local elapsed="$4"
+	local filter="${5:-}"
+
+	printf '\n'
+	printf 'skill-golden: %d/%d passed in %ds\n' \
+		"$passed" "$total" "$elapsed"
+
+	if ((total == 0)); then
+		printf 'skill-golden: no fixtures matched filter: %s\n' \
+			"$filter" >&2
+		return 2
+	fi
+
+	if ((failed > 0)); then
+		printf '%s\n' "$(sg_red "FAIL")"
+		return 1
+	fi
+
+	printf '%s\n' "$(sg_green "PASS")"
+	return 0
+}

--- a/.claude/scripts/skill-golden.sh
+++ b/.claude/scripts/skill-golden.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+#
+# skill-golden.sh — generalized golden test runner for decision skills
+#
+# Usage:
+#   skill-golden.sh <skill-name>            run all fixtures for one skill
+#   skill-golden.sh <skill-name> <fixture>  run single fixture by basename
+#   skill-golden.sh --all                   run every skill with a manifest
+#
+# Golden test config is read from .claude/skills/<skill>/SKILL.md frontmatter:
+#
+#   golden:
+#     model:       haiku
+#     manifest:    .claude/skills/<skill>/golden.manifest.txt
+#     fixture_dir: .claude/scripts/implement-issue-test/fixtures/<skill>
+#     schema:      .claude/scripts/schemas/<skill>.json
+#
+# Paths in SKILL.md frontmatter are relative to the repository root.
+#
+# Prompt building: .claude/skills/<skill>/prompt-builder.sh is sourced when
+# present; it must define a build_prompt() shell function that accepts the
+# fixture body on $1 and prints the full Claude prompt on stdout.  Skills
+# without a prompt-builder.sh are skipped with a warning so a partially-wired
+# suite does not block CI.
+#
+# Discovery (--all): scans .claude/skills/*/golden.manifest.txt.  Skills that
+# have a manifest but are missing other required config (schema, prompt builder)
+# are skipped with a warning; only fixture-level failures propagate to exit 1.
+#
+# Environment:
+#   SKILLS_DIR     root of skill directories
+#                  (default: $SCRIPT_DIR/../skills relative to this script)
+#   SG_CLAUDE_CLI  path to claude CLI (default: claude)
+#
+# Exit codes:
+#   0 — all tested fixtures passed (skipped skills do not count as failures)
+#   1 — at least one fixture failed
+#   2 — setup / usage error
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)" || exit 2
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)" || exit 2
+readonly SCRIPT_DIR REPO_ROOT
+
+SKILLS_DIR="${SKILLS_DIR:-"$SCRIPT_DIR/../skills"}"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/skill-golden-lib.sh" || {
+	printf '%s: cannot source skill-golden-lib.sh\n' "$SCRIPT_NAME" >&2
+	exit 2
+}
+
+# ---------------------------------------------------------------------------
+# die — print error to stderr and exit 2
+# ---------------------------------------------------------------------------
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 2
+}
+
+# ---------------------------------------------------------------------------
+# usage
+# ---------------------------------------------------------------------------
+usage() {
+	cat <<EOF
+Usage: $SCRIPT_NAME <skill-name> [fixture]
+       $SCRIPT_NAME --all
+
+Run real-Claude golden tests for decision skills.
+
+Arguments:
+    <skill-name>    Skill directory name under .claude/skills/
+    <fixture>       Optional: run only this fixture basename (no extension)
+    --all           Discover and run all skills with golden.manifest.txt
+
+Environment:
+    SKILLS_DIR      Root of skill directories
+                    (default: \$SCRIPT_DIR/../skills)
+    SG_CLAUDE_CLI   Path to claude CLI (default: claude)
+
+Exit codes:
+    0   all tested fixtures passed; skipped skills do not count as failures
+    1   at least one fixture failed
+    2   setup error (missing skill, manifest, schema, or usage error)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# read_golden_field SKILL_FILE FIELD
+#
+# Extracts one field from the golden: block of a SKILL.md YAML frontmatter.
+# Prints the value on stdout. Exits (Ruby) 1 if the field is absent or the
+# file / frontmatter cannot be parsed — bash callers treat a non-zero exit
+# as "field not present" and keep the default.
+# ---------------------------------------------------------------------------
+read_golden_field() {
+	local skill_file="$1"
+	local field="$2"
+
+	ruby - "$skill_file" "$field" 2>/dev/null <<'RUBYEOF'
+require 'yaml'
+content = File.read(ARGV[0]) rescue exit(1)
+m = content.match(/\A---[ \t]*\r?\n(.*?)^---[ \t]*\r?$/m)
+exit(1) unless m
+begin
+  data = Psych.safe_load(m[1])
+rescue
+  exit(1)
+end
+exit(1) unless data.is_a?(Hash)
+golden = data['golden']
+exit(1) unless golden.is_a?(Hash)
+val = golden[ARGV[1]]
+exit(1) if val.nil?
+print val.to_s
+RUBYEOF
+}
+
+# ---------------------------------------------------------------------------
+# resolve_path RAW
+#
+# Turns a repo-root-relative path from SKILL.md frontmatter into an absolute
+# path.  Absolute paths are returned unchanged.
+# ---------------------------------------------------------------------------
+resolve_path() {
+	local raw="$1"
+	case "$raw" in
+		/*) printf '%s' "$raw" ;;
+		*)  printf '%s/%s' "$REPO_ROOT" "$raw" ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# parse_manifest MANIFEST_FILE
+#
+# Reads manifest entries from MANIFEST_FILE, skipping blank lines and lines
+# whose first non-whitespace character is '#'.  Prints one entry per line.
+# ---------------------------------------------------------------------------
+parse_manifest() {
+	local file="$1"
+	local line
+	while IFS= read -r line; do
+		[[ "$line" =~ ^[[:space:]]*$ ]]  && continue
+		[[ "$line" =~ ^[[:space:]]*'#' ]] && continue
+		printf '%s\n' "$line"
+	done < "$file"
+}
+
+# ---------------------------------------------------------------------------
+# run_skill SKILL_NAME [FILTER]
+#
+# Resolves the golden test config for SKILL_NAME, sources its prompt builder,
+# and dispatches to sg_run_manifest from skill-golden-lib.sh.
+#
+# Returns:
+#   0 — all fixtures passed (or skill skipped with a warning)
+#   1 — at least one fixture failed
+#   2 — configuration / setup error
+# ---------------------------------------------------------------------------
+run_skill() {
+	local skill_name="$1"
+	local filter="${2:-}"
+
+	local manifest_file="$SKILLS_DIR/$skill_name/golden.manifest.txt"
+	if [[ ! -f "$manifest_file" ]]; then
+		printf '%s: no golden.manifest.txt for skill: %s\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		return 2
+	fi
+
+	# ------------------------------------------------------------------
+	# Resolve config from SKILL.md frontmatter where present; fall back
+	# to conventions for any field that is not specified.
+	# ------------------------------------------------------------------
+	local model fixture_dir schema
+	model="haiku"
+	fixture_dir="$SCRIPT_DIR/implement-issue-test/fixtures/$skill_name"
+	schema=""
+
+	local skill_md="$SKILLS_DIR/$skill_name/SKILL.md"
+	if [[ -f "$skill_md" ]]; then
+		local fm_model fm_fixture_dir fm_schema
+		fm_model=$(read_golden_field "$skill_md" "model")       || fm_model=""
+		fm_fixture_dir=$(read_golden_field "$skill_md" "fixture_dir") \
+			|| fm_fixture_dir=""
+		fm_schema=$(read_golden_field "$skill_md" "schema")     || fm_schema=""
+
+		[[ -n "$fm_model" ]]       && model="$fm_model"
+		[[ -n "$fm_fixture_dir" ]] && fixture_dir="$(resolve_path "$fm_fixture_dir")"
+		[[ -n "$fm_schema" ]]      && schema="$(resolve_path "$fm_schema")"
+	fi
+
+	# Convention fallback: schemas/<skill-name>.json
+	if [[ -z "$schema" ]]; then
+		local candidate="$SCRIPT_DIR/schemas/$skill_name.json"
+		[[ -f "$candidate" ]] && schema="$candidate"
+	fi
+
+	if [[ -z "$schema" ]]; then
+		printf '%s: no schema found for skill: %s\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		printf '%s: add golden.schema to %s/SKILL.md or create %s\n' \
+			"$SCRIPT_NAME" "$skill_name" \
+			"$SCRIPT_DIR/schemas/$skill_name.json" >&2
+		return 2
+	fi
+
+	# ------------------------------------------------------------------
+	# Source the skill's prompt builder.  Without it we cannot invoke
+	# Claude.  Return 2 (setup error) so direct invocations get a
+	# non-zero exit and --all mode counts the skill as skipped (not
+	# failed), keeping partial-wired suites from blocking CI.
+	# ------------------------------------------------------------------
+	local prompt_builder_file="$SKILLS_DIR/$skill_name/prompt-builder.sh"
+	if [[ ! -f "$prompt_builder_file" ]]; then
+		printf '%s: [SKIP] %s — no prompt-builder.sh\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		return 2
+	fi
+
+	# Clear any previous build_prompt from a prior skill in --all mode.
+	unset -f build_prompt 2>/dev/null || true
+
+	# shellcheck source=/dev/null
+	source "$prompt_builder_file" || {
+		printf '%s: failed to source prompt-builder.sh for: %s\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		return 2
+	}
+
+	if ! declare -F build_prompt >/dev/null 2>&1; then
+		printf '%s: prompt-builder.sh for %s must define build_prompt()\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		return 2
+	fi
+
+	# ------------------------------------------------------------------
+	# Parse manifest entries.
+	# ------------------------------------------------------------------
+	local -a entries
+	while IFS= read -r entry; do
+		entries+=("$entry")
+	done < <(parse_manifest "$manifest_file")
+
+	if ((${#entries[@]} == 0)); then
+		printf '%s: manifest has no entries for skill: %s\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		return 2
+	fi
+
+	# ------------------------------------------------------------------
+	# Setup check (jq, claude CLI, schema path, fixture dir) then run.
+	# ------------------------------------------------------------------
+	sg_check_setup "$fixture_dir" "$schema" || return 2
+
+	sg_run_manifest \
+		"$fixture_dir" "$schema" "$model" \
+		build_prompt "$filter" \
+		"${entries[@]}"
+}
+
+# ---------------------------------------------------------------------------
+# run_all
+#
+# Discovers every skill that has a golden.manifest.txt file and runs each.
+# Skills that are not fully configured (missing prompt-builder.sh, missing
+# schema) are skipped with a warning and do not affect the overall exit code.
+# ---------------------------------------------------------------------------
+run_all() {
+	local -a skills
+	local manifest
+
+	for manifest in "$SKILLS_DIR"/*/golden.manifest.txt; do
+		[[ -f "$manifest" ]] || continue
+		skills+=("$(basename "$(dirname "$manifest")")")
+	done
+
+	if ((${#skills[@]} == 0)); then
+		printf '%s: no skills with golden.manifest.txt found in: %s\n' \
+			"$SCRIPT_NAME" "$SKILLS_DIR" >&2
+		return 2
+	fi
+
+	printf 'skill-golden: discovered %d skill(s): %s\n' \
+		"${#skills[@]}" "${skills[*]}"
+	printf '\n'
+
+	local overall=0 total=0 failed=0 skipped=0
+	local skill rc
+	for skill in "${skills[@]}"; do
+		printf '==> %s\n' "$skill"
+		total=$((total + 1))
+
+		run_skill "$skill"
+		rc=$?
+
+		if ((rc == 1)); then
+			failed=$((failed + 1))
+			overall=1
+		elif ((rc == 2)); then
+			skipped=$((skipped + 1))
+		fi
+
+		printf '\n'
+	done
+
+	printf 'skill-golden: %d skill(s) — %d failed, %d skipped\n' \
+		"$total" "$failed" "$skipped"
+
+	return "$overall"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	local mode=""
+	local skill_name=""
+	local filter=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--all)
+				mode="all"
+				shift
+				;;
+			-h|--help)
+				usage
+				exit 0
+				;;
+			--)
+				shift
+				break
+				;;
+			-*)
+				die "unknown option: $1"
+				;;
+			*)
+				if [[ -z "$skill_name" ]]; then
+					skill_name="$1"
+					mode="skill"
+				elif [[ -z "$filter" ]]; then
+					filter="$1"
+				else
+					die "unexpected argument: $1"
+				fi
+				shift
+				;;
+		esac
+	done
+
+	[[ -n "$mode" ]] || die "specify <skill-name> or --all"
+
+	case "$mode" in
+		skill) run_skill "$skill_name" "$filter" ;;
+		all)   run_all ;;
+	esac
+}
+
+main "$@"

--- a/.claude/scripts/skill-validate.sh
+++ b/.claude/scripts/skill-validate.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+#
+# skill-validate.sh — validate SKILL.md YAML frontmatter against schema
+#
+# Usage:
+#   skill-validate.sh --skill <name>   validate one skill by directory name
+#   skill-validate.sh --all            validate every skill in SKILLS_DIR
+#
+# Environment (both are overridable for testing):
+#   SKILLS_DIR   — root of skill directories
+#                  (default: ../skills relative to this script)
+#   SKILL_SCHEMA — path to the JSON schema file
+#                  (default: schemas/skill-frontmatter.json relative to
+#                  this script)
+#
+# Exit codes:
+#   0 — all validated skills passed
+#   1 — one or more skills failed validation
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+SKILLS_DIR="${SKILLS_DIR:-"$SCRIPT_DIR/../skills"}"
+SKILL_SCHEMA="${SKILL_SCHEMA:-"$SCRIPT_DIR/schemas/skill-frontmatter.json"}"
+
+# ---------------------------------------------------------------------------
+# die  — print error and exit 1
+# ---------------------------------------------------------------------------
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 1
+}
+
+# ---------------------------------------------------------------------------
+# usage
+# ---------------------------------------------------------------------------
+usage() {
+	cat <<EOF
+Usage: $SCRIPT_NAME --skill <name>
+       $SCRIPT_NAME --all
+       $SCRIPT_NAME <skill-file>
+
+Validate SKILL.md YAML frontmatter against the JSON schema.
+
+Options:
+    --skill <name>   Validate one skill directory in SKILLS_DIR
+    --all            Validate all skill directories in SKILLS_DIR
+    -h, --help       Show this message
+
+Arguments:
+    <skill-file>     Direct path to a SKILL.md file to validate
+
+Environment:
+    SKILLS_DIR       Root of skill directories
+                     (default: \$SCRIPT_DIR/../skills)
+    SKILL_SCHEMA     Path to the JSON schema
+                     (default: \$SCRIPT_DIR/schemas/skill-frontmatter.json)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# _validate_file <skill_file>
+#
+# Validates one SKILL.md file using Ruby (built-in YAML + JSON support).
+# Errors go to stderr.  Returns 0 on success, 1 on failure.
+# ---------------------------------------------------------------------------
+_validate_file() {
+	local skill_file="$1"
+
+	ruby - "$skill_file" "$SKILL_SCHEMA" 2>&1 <<'RUBYEOF'
+require 'yaml'
+require 'json'
+
+skill_path  = ARGV[0]
+schema_path = ARGV[1]
+
+# ---- read SKILL.md -------------------------------------------------------
+begin
+  content = File.read(skill_path)
+rescue SystemCallError => e
+  $stderr.puts "ERROR: #{skill_path}: cannot read file: #{e.message}"
+  exit 1
+end
+
+# ---- read schema ---------------------------------------------------------
+begin
+  schema = JSON.parse(File.read(schema_path))
+rescue SystemCallError => e
+  $stderr.puts "ERROR: cannot read schema #{schema_path}: #{e.message}"
+  exit 1
+rescue JSON::ParserError => e
+  $stderr.puts "ERROR: invalid schema JSON: #{e.message}"
+  exit 1
+end
+
+# ---- extract YAML frontmatter -------------------------------------------
+# Matches the first ---...--- block, with \A anchoring to the string start
+# and ^ matching line starts (Ruby's default multiline ^ / $).
+m = content.match(/\A---[ \t]*\r?\n(.*?)^---[ \t]*\r?$/m)
+unless m
+  $stderr.puts(
+    "ERROR: #{skill_path}: " \
+    "no YAML frontmatter delimiters (---) found"
+  )
+  exit 1
+end
+
+fm_text = m[1]
+if fm_text.strip.empty?
+  $stderr.puts "ERROR: #{skill_path}: empty frontmatter block"
+  exit 1
+end
+
+# ---- parse YAML ----------------------------------------------------------
+begin
+  data = Psych.safe_load(fm_text)
+rescue Psych::Exception => e
+  $stderr.puts(
+    "ERROR: #{skill_path}: invalid YAML: #{e.message.lines.first.chomp}"
+  )
+  exit 1
+end
+
+unless data.is_a?(Hash)
+  $stderr.puts(
+    "ERROR: #{skill_path}: " \
+    "frontmatter must be a YAML mapping (key: value pairs)"
+  )
+  exit 1
+end
+
+# ---- schema validation ---------------------------------------------------
+required = schema.fetch('required', [])
+allowed  = schema.fetch('properties', {}).keys
+
+errors = []
+required.each { |f| errors << "missing required field: '#{f}'" \
+  unless data.key?(f) }
+data.each_key { |k| errors << "unknown field: '#{k}'" \
+  unless allowed.include?(k) }
+
+if errors.any?
+  errors.each { |e| $stderr.puts "ERROR: #{skill_path}: #{e}" }
+  exit 1
+end
+
+exit 0
+RUBYEOF
+}
+
+# ---------------------------------------------------------------------------
+# validate_skill <name>
+#
+# Resolves SKILLS_DIR/<name>/SKILL.md and validates it.
+# ---------------------------------------------------------------------------
+validate_skill() {
+	local name="$1"
+	local skill_file="$SKILLS_DIR/$name/SKILL.md"
+
+	if [[ ! -f "$skill_file" ]]; then
+		printf 'ERROR: %s: SKILL.md not found\n' "$skill_file" >&2
+		return 1
+	fi
+
+	_validate_file "$skill_file"
+}
+
+# ---------------------------------------------------------------------------
+# validate_all
+#
+# Validates every SKILL.md found in SKILLS_DIR.
+# Continues past individual failures; returns 1 if any skill failed.
+# ---------------------------------------------------------------------------
+validate_all() {
+	local failed=0
+	local dir skill_file
+
+	for dir in "$SKILLS_DIR"/*/; do
+		[[ -d "$dir" ]] || continue
+		skill_file="${dir}SKILL.md"
+		[[ -f "$skill_file" ]] || continue
+
+		if ! _validate_file "$skill_file"; then
+			failed=1
+		fi
+	done
+
+	return "$failed"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	local mode=""
+	local skill_name=""
+	local skill_file_arg=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--skill)
+				[[ $# -ge 2 ]] || die "missing argument for --skill"
+				mode="skill"
+				skill_name="$2"
+				shift 2
+				;;
+			--all)
+				mode="all"
+				shift
+				;;
+			-h|--help)
+				usage
+				exit 0
+				;;
+			--)
+				shift
+				break
+				;;
+			-*)
+				die "unknown option: $1"
+				;;
+			*)
+				mode="file"
+				skill_file_arg="$1"
+				shift
+				;;
+		esac
+	done
+
+	[[ -n "$mode" ]] \
+		|| die "missing --skill <name>, --all, or <skill-file>"
+	[[ -f "$SKILL_SCHEMA" ]] || die "schema not found: $SKILL_SCHEMA"
+
+	case "$mode" in
+		skill)	validate_skill "$skill_name" ;;
+		all)	validate_all ;;
+		file)	_validate_file "$skill_file_arg" ;;
+	esac
+}
+
+main "$@"

--- a/.claude/scripts/surgical-fast-path.sh
+++ b/.claude/scripts/surgical-fast-path.sh
@@ -95,6 +95,7 @@ bail() {
         '.state = "failed" |
          .error = $err |
          .last_update = (now | todate)'
+    write_task_summary
     exit 1
 }
 
@@ -123,6 +124,41 @@ is_stage_completed() {
 
 read_pr_number_from_status() {
     jq -r '.stages.fast_path_pr.pr_number // empty' "$STATUS_FILE" 2>/dev/null
+}
+
+write_task_summary() {
+    [[ -f "$STATUS_FILE" ]] || return 0
+    local summary
+    summary=$(jq '
+        def size_points:
+            if . == "M" then 3
+            elif . == "L" then 5
+            else 1
+            end;
+        def extract_size:
+            if .description | test("\\*\\*\\(L\\)\\*\\*") then "L"
+            elif .description | test("\\*\\*\\(M\\)\\*\\*") then "M"
+            else "S"
+            end;
+        [.tasks[] | . + {size: extract_size}] as $tasks |
+        {
+            completed: {
+                S: [$tasks[] | select(.status == "completed" and .size == "S")] | length,
+                M: [$tasks[] | select(.status == "completed" and .size == "M")] | length,
+                L: [$tasks[] | select(.status == "completed" and .size == "L")] | length
+            },
+            failed: {
+                S: [$tasks[] | select(.status == "failed" and .size == "S")] | length,
+                M: [$tasks[] | select(.status == "failed" and .size == "M")] | length,
+                L: [$tasks[] | select(.status == "failed" and .size == "L")] | length
+            },
+            sp_completed: ([$tasks[] | select(.status == "completed") | .size | size_points] | add // 0),
+            sp_total: ([$tasks[] | .size | size_points] | add // 0)
+        }
+    ' "$STATUS_FILE" 2>/dev/null) || true
+    [[ -n "$summary" ]] || return 0
+    _jq_inplace "$STATUS_FILE" --argjson s "$summary" '.task_summary = $s' || true
+    cp "$STATUS_FILE" "$LOG_BASE/status.json" || true
 }
 
 # --- kill switch -----------------------------------------------------------
@@ -313,4 +349,5 @@ _jq_inplace "$STATUS_FILE" \
      .last_update = (now | todate)'
 
 log "Surgical fast-path complete. PR #$pr_number merged and branch deleted."
+write_task_summary
 exit 0

--- a/.claude/scripts/triage-validate.sh
+++ b/.claude/scripts/triage-validate.sh
@@ -1,45 +1,12 @@
 #!/usr/bin/env bash
 #
-# triage-validate.sh
-#
-# Real-Claude golden tests for the triage classifier prompt. Asks the live
-# Haiku model to classify each fixture in implement-issue-test/fixtures/triage/
-# and compares the returned route against the expected outcome encoded in
-# the manifest below.
-#
-# WHY THIS EXISTS (vs the bats mock tests):
-#   - test-surgical-fast-path.bats locks down the *shell logic* around the
-#     classifier (kill switch, confidence demotion, grep verification, status
-#     bookkeeping). It mocks the model — so it can't catch prompt regressions.
-#   - This script locks down the *prompt itself*. If a Haiku update or a
-#     prompt edit causes the model to flip a fixture's route, this is how
-#     we find out before shipping.
-#
-# RUN CADENCE (READ BEFORE TOUCHING):
-#   - Cost:    ~10 fixtures x 1 Haiku call = ~$0.05–$0.10 per run.
-#   - Latency: ~5–15s per fixture, ~60–150s total wall clock.
-#   - Run BEFORE merging changes to:
-#       * .claude/scripts/implement-issue-orchestrator.sh
-#         (build_triage_prompt, run_triage_stage, schema)
-#       * .claude/scripts/schemas/implement-issue-triage.json
-#       * .claude/scripts/model-config.sh (triage tier)
-#   - Run MONTHLY as a regression sweep against model drift.
-#   - Run after upgrading the Haiku tier model in model-config.sh.
-#
-# DO NOT AUTO-UPDATE FIXTURES OR EXPECTATIONS.
-#   If a fixture flips, that is signal — investigate before changing the
-#   manifest. The manifest is the contract; flips mean the prompt or the
-#   model changed behavior, and that needs a human decision.
+# triage-validate.sh — golden tests for the triage classifier prompt
 #
 # Usage:
-#   .claude/scripts/triage-validate.sh                  # run all fixtures
-#   .claude/scripts/triage-validate.sh issue-2836       # run one fixture
-#   TRIAGE_MODEL=sonnet .claude/scripts/triage-validate.sh   # override model
+#   triage-validate.sh [<fixture-basename>]
+#   TRIAGE_MODEL=sonnet triage-validate.sh
 #
-# Exit codes:
-#   0 — all fixtures classified as expected
-#   1 — one or more fixtures flipped
-#   2 — environment / setup error (claude CLI missing, jq missing, etc.)
+# Exit codes: 0 all passed, 1 one or more flipped, 2 setup error.
 #
 
 set -euo pipefail
@@ -47,228 +14,66 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURE_DIR="$SCRIPT_DIR/implement-issue-test/fixtures/triage"
 SCHEMA_FILE="$SCRIPT_DIR/schemas/implement-issue-triage.json"
-
-CLAUDE_CLI="${CLAUDE_CLI:-claude}"
 TRIAGE_MODEL="${TRIAGE_MODEL:-haiku}"
 
+# Propagate legacy CLAUDE_CLI to the library variable (lib default: "claude").
+: "${SG_CLAUDE_CLI:=${CLAUDE_CLI:-claude}}"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/skill-golden-lib.sh"
+
 # =============================================================================
-# MANIFEST: fixture -> expected_route[:expected_disqualifying_criterion]
+# Manifest: fixture -> expected_route|expected_disqualifying_criterion
+# Use "*" to accept any criterion; name a specific criterion to pin it.
 # =============================================================================
-#
-# Format: "fixture_basename|expected_route|expected_dq_or_*"
-#   expected_dq is checked only when route is "full". Use "*" to accept any
-#   reason (the route alone is the contract). Use a specific name when the
-#   prompt should pinpoint a particular criterion (e.g. auth-test must fail
-#   on no_security_concerns specifically — no other reason is acceptable).
-#
+
 MANIFEST=(
-    "issue-2836|fast-path|*"
-    "issue-2837|fast-path|*"
-    "issue-2838|fast-path|*"
-    "issue-2839|fast-path|*"
-    "issue-2752|full|test_only_scope"
-    "issue-2754|full|test_only_scope"
-    "issue-2776|full|test_only_scope"
-    "issue-auth-test|full|no_security_concerns"
-    "issue-vague|full|precise_specification"
-    "issue-novel-pattern|full|established_pattern"
+	"issue-2836|fast-path|*"
+	"issue-2837|fast-path|*"
+	"issue-2838|fast-path|*"
+	"issue-2839|fast-path|*"
+	"issue-2752|full|test_only_scope"
+	"issue-2754|full|test_only_scope"
+	"issue-2776|full|test_only_scope"
+	"issue-auth-test|full|no_security_concerns"
+	"issue-vague|full|precise_specification"
+	"issue-novel-pattern|full|established_pattern"
 )
 
 # =============================================================================
-
-red()    { printf '\033[31m%s\033[0m' "$1"; }
-green()  { printf '\033[32m%s\033[0m' "$1"; }
-yellow() { printf '\033[33m%s\033[0m' "$1"; }
-dim()    { printf '\033[2m%s\033[0m' "$1"; }
-
-require_cmd() {
-    command -v "$1" >/dev/null 2>&1 || {
-        printf 'error: required command not found: %s\n' "$1" >&2
-        exit 2
-    }
-}
-
-require_cmd jq
-require_cmd "$CLAUDE_CLI"
-[[ -f "$SCHEMA_FILE" ]] || { printf 'error: schema not found: %s\n' "$SCHEMA_FILE" >&2; exit 2; }
-[[ -d "$FIXTURE_DIR" ]] || { printf 'error: fixture dir not found: %s\n' "$FIXTURE_DIR" >&2; exit 2; }
-
-# Build the same prompt the orchestrator uses. Kept verbatim with
-# build_triage_prompt() in implement-issue-orchestrator.sh — if you edit one,
-# edit the other and re-run this script.
-build_prompt() {
-    local issue_body="$1"
-    cat <<TRIAGE_PROMPT
-You are the triage classifier for an issue-implementation pipeline. Classify
-the GitHub issue below into one of two routes:
-
-  "fast-path" — surgical, test-only, well-specified change. Pipeline runs:
-                branch -> implement -> commit -> PR -> squash-merge. Skips
-                test loop, code review, deploy verify, docs.
-  "full"      — default. Runs the full verification pipeline.
-
-Be CONSERVATIVE. False negatives (missing a fast-path opportunity) cost time.
-False positives (skipping verification when it was needed) cost quality. Bias
-hard toward "full" whenever uncertain.
-
-Check ALL SIX criteria. Every criterion must be true for "fast-path". If ANY
-criterion is false, route is "full".
-
-CRITERIA:
-
-1. test_only_scope — All file paths in the issue's Implementation Tasks
-   section match: tests/**, playwright/**, **/*.spec.ts, **/*.test.ts,
-   **/*.e2e.ts. Any reference to apps/, packages/, src/, or migration files
-   disqualifies.
-
-2. surgical_size — Estimated diff under 30 lines net, across no more than
-   3 files.
-
-3. established_pattern — The change applies a pattern that already exists in
-   the codebase. Identify the pattern as a grep-able regex and place it in
-   "established_pattern_grep". The shell wrapper will run \`git grep -lE\` and
-   verify >= 3 matching files. Set to null if you cannot identify one
-   specific regex (this criterion then fails).
-
-4. precise_specification — Issue body has an "## Implementation Tasks"
-   section AND each task names specific file paths AND (line numbers OR
-   exact code snippets).
-
-5. benign_failure_mode — Worst outcome of a wrong change is "a test still
-   fails" or "a test skips" — NOT "production breaks", "data corrupts", or
-   "users see incorrect behavior". Test files always pass; production code
-   never passes.
-
-6. no_security_concerns — Skip fast-path for: auth flows, RBAC, encryption,
-   secret handling, input validation, CORS, CSP, session management, token
-   handling. Auth tests deserve review even if test-only.
-
-CONFIDENCE: high (all criteria clearly evaluated) | medium (some criteria
-required inference) | low (vague issue). If confidence is medium or low,
-route MUST be "full".
-
-OUTPUT: schema-enforced JSON with route, criteria.{test_only_scope,
-surgical_size, established_pattern, precise_specification,
-benign_failure_mode, no_security_concerns}.{passed, reason},
-established_pattern_grep, confidence, disqualifying_criterion, summary,
-status.
-
-ISSUE BODY:
-<<<
-${issue_body}
->>>
-TRIAGE_PROMPT
-}
-
-run_one() {
-    local entry="$1"
-    local fixture expected_route expected_dq
-    IFS='|' read -r fixture expected_route expected_dq <<<"$entry"
-
-    local body_file="$FIXTURE_DIR/${fixture}.md"
-    if [[ ! -f "$body_file" ]]; then
-        printf '  %s missing fixture: %s\n' "$(red "FAIL")" "$body_file"
-        return 1
-    fi
-
-    local prompt schema_compact start end elapsed_ms output
-    prompt=$(build_prompt "$(cat "$body_file")")
-    schema_compact=$(jq -c . "$SCHEMA_FILE")
-
-    start=$(date +%s%N 2>/dev/null || echo 0)
-    if ! output=$(env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
-        --model "$TRIAGE_MODEL" \
-        --dangerously-skip-permissions \
-        --output-format json \
-        --json-schema "$schema_compact" 2>&1); then
-        printf '  %s %-28s claude invocation failed\n' "$(red "FAIL")" "$fixture"
-        printf '%s\n' "$output" | head -5 | sed 's/^/      /'
-        return 1
-    fi
-    end=$(date +%s%N 2>/dev/null || echo 0)
-    elapsed_ms=$(( (end - start) / 1000000 ))
-
-    local result_payload route confidence dq summary
-    # Claude CLI with --json-schema returns the validated payload as a JSON
-    # object on .structured_output. Older CLIs put it on .result (sometimes
-    # as a stringified JSON). Fall back to the top-level object if neither
-    # field exists. This MUST mirror run_stage's extraction in the
-    # orchestrator — if these diverge, the validator stops reflecting prod.
-    result_payload=$(printf '%s' "$output" \
-        | jq -c '.structured_output // (.result | if type == "string" then fromjson? else . end) // .' \
-        2>/dev/null || echo '{}')
-    if ! printf '%s' "$result_payload" | jq -e . >/dev/null 2>&1; then
-        result_payload='{}'
-    fi
-
-    route=$(printf '%s' "$result_payload" | jq -r '.route // "MISSING"' 2>/dev/null || echo "PARSE_ERROR")
-    confidence=$(printf '%s' "$result_payload" | jq -r '.confidence // "MISSING"' 2>/dev/null || echo "PARSE_ERROR")
-    dq=$(printf '%s' "$result_payload" | jq -r '.disqualifying_criterion // ""' 2>/dev/null || echo "")
-    summary=$(printf '%s' "$result_payload" | jq -r '.summary // ""' 2>/dev/null || echo "")
-
-    local label="$fixture" timing_label
-    timing_label=$(printf '%6dms' "$elapsed_ms")
-
-    if [[ "$route" != "$expected_route" ]]; then
-        printf '  %s %-28s %s  expected=%s got=%s confidence=%s\n' \
-            "$(red "FAIL")" "$label" "$timing_label" "$expected_route" "$route" "$confidence"
-        [[ -n "$summary" ]] && printf '      %s\n' "$(dim "summary: $summary")"
-        return 1
-    fi
-
-    if [[ "$expected_route" == "full" && "$expected_dq" != "*" && "$dq" != "$expected_dq" ]]; then
-        printf '  %s %-28s %s  route=full ok, but dq=%s expected=%s\n' \
-            "$(yellow "WARN")" "$label" "$timing_label" "${dq:-<empty>}" "$expected_dq"
-        [[ -n "$summary" ]] && printf '      %s\n' "$(dim "summary: $summary")"
-        # WARN does not fail the run — the route is the primary contract.
-        # Tighten manifest entries to "*" if a specific dq is too brittle.
-        return 0
-    fi
-
-    printf '  %s %-28s %s  route=%s confidence=%s\n' \
-        "$(green "PASS")" "$label" "$timing_label" "$route" "$confidence"
-    return 0
-}
-
+# Prompt builder
 # =============================================================================
 
-filter="${1:-}"
-total=0
-passed=0
-failed=0
-run_start=$(date +%s)
+# shellcheck source=prompts/triage-prompt.sh
+source "$SCRIPT_DIR/prompts/triage-prompt.sh"
 
-printf 'triage-validate: %d fixtures, model=%s\n' "${#MANIFEST[@]}" "$TRIAGE_MODEL"
-printf '\n'
+# =============================================================================
+# Argument parsing
+# =============================================================================
 
-for entry in "${MANIFEST[@]}"; do
-    fixture="${entry%%|*}"
-    if [[ -n "$filter" && "$fixture" != "$filter" ]]; then
-        continue
-    fi
-    total=$((total + 1))
-    if run_one "$entry"; then
-        passed=$((passed + 1))
-    else
-        failed=$((failed + 1))
-    fi
+filter=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--)
+			shift
+			break
+			;;
+		-*)
+			printf '%s: unknown option: %s\n' "${0##*/}" "$1" >&2
+			exit 2
+			;;
+		*)
+			filter="$1"
+			shift
+			;;
+	esac
 done
 
-run_end=$(date +%s)
-elapsed=$((run_end - run_start))
+# =============================================================================
+# Dispatch
+# =============================================================================
 
-printf '\n'
-printf 'triage-validate: %d/%d passed in %ds\n' "$passed" "$total" "$elapsed"
-
-if (( total == 0 )); then
-    printf 'no fixtures matched filter: %s\n' "$filter" >&2
-    exit 2
-fi
-
-if (( failed > 0 )); then
-    printf '%s\n' "$(red "FAIL")"
-    exit 1
-fi
-
-printf '%s\n' "$(green "PASS")"
-exit 0
+sg_check_setup "$FIXTURE_DIR" "$SCHEMA_FILE" || exit 2
+sg_run_manifest "$FIXTURE_DIR" "$SCHEMA_FILE" "$TRIAGE_MODEL" \
+	build_prompt "$filter" "${MANIFEST[@]}"
+exit $?

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/sync-reminder.sh\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/skills/pipeline-sync/scripts/detect-core-edit.sh\"",
+            "timeout": 10
           }
         ]
       },
@@ -35,6 +40,11 @@
             "type": "command",
             "command": "python3 -c \"import json,sys; d=json.load(sys.stdin); p=d.get('tool_input',{}).get('file_path',''); sys.exit(2 if any(x in p for x in ['.env','.git/','credentials','package-lock.json']) else 0)\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-skill-validate.sh\"",
+            "timeout": 15
           }
         ]
       },
@@ -83,7 +93,8 @@
       "Edit(.claude/**)",
       "Write(.claude/**)",
       "Edit(logs/**)",
-      "Write(logs/**)"
+      "Write(logs/**)",
+      "Bash(gh *)"
     ]
   }
 }

--- a/.claude/skills/adapting-claude-pipeline/SKILL.md
+++ b/.claude/skills/adapting-claude-pipeline/SKILL.md
@@ -1,6 +1,21 @@
 ---
 name: adapting-claude-pipeline
 description: Use when adapting the generic .claude pipeline folder to a specific codebase - adjusting skills, agents, hooks, scripts, prompts, and settings for the target project's tech stack and workflows
+side_effects:
+  - modifies_claude_local_directory
+  - runs_apply_local_sh
+composes:
+  - brainstorming
+  - writing-plans
+  - writing-skills
+  - writing-agents
+  - subagent-driven-development
+  - dispatching-parallel-agents
+failure_modes:
+  - id: orphaned_references
+    mitigation: Grep for deleted skill and agent names in all remaining .claude/ files and update or remove broken references before completing
+  - id: skip_web_research
+    mitigation: Always WebSearch for domain-specific best practices and anti-patterns before creating or modifying agents
 ---
 
 # Adapting Claude Pipeline to a Codebase

--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: brainstorming
 description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+outputs:
+  - name: design_document
+    type: file_path
+    description: Validated design saved to docs/plans/YYYY-MM-DD-<topic>-design.md (standalone invocation only)
+side_effects:
+  - writes_file: "docs/plans/YYYY-MM-DD-<topic>-design.md"
+  - commits_to_git
+composes:
+  - writing-plans
 ---
 
 # Brainstorming Ideas Into Designs

--- a/.claude/skills/complete-summary/SKILL.md
+++ b/.claude/skills/complete-summary/SKILL.md
@@ -1,3 +1,30 @@
+---
+name: complete-summary
+description: Generate a structured completion summary for a PR comment using only the issue number, branch name, PR number, and prompt context — no file exploration
+inputs:
+  - name: issue_number
+    type: string
+    required: true
+    description: GitHub issue number being closed by this PR
+  - name: branch_name
+    type: string
+    required: true
+    description: Feature branch name that was implemented
+  - name: pr_number
+    type: string
+    required: true
+    description: Pull request number to reference in the summary
+outputs:
+  - name: pr_comment
+    type: string
+    description: Formatted PR comment text ready to post, following the standard Implementation Complete template
+side_effects: []
+composes: []
+failure_modes:
+  - id: missing_context
+    mitigation: request the missing issue_number, branch_name, or pr_number from the caller before generating output; do not guess or explore
+---
+
 # Complete Summary
 
 Generate a structured completion summary for a PR comment. Fill in the template from data already available — do not explore.

--- a/.claude/skills/create-session-summary/SKILL.md
+++ b/.claude/skills/create-session-summary/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: create-session-summary
 description: Create Session Summary
+inputs: []
+outputs:
+  - name: session_file
+    type: file_path
+    description: Written session file at .claude/sessions/session-YYYY-MM-DD-HHMM.md
+side_effects:
+  - writes_file: .claude/sessions/session-<timestamp>.md
+  - creates_directory: .claude/sessions/ (if absent)
+composes: []
+failure_modes:
+  - id: git_unavailable
+    mitigation: skip the git state section and note "no git repo" in the session file; still write the summary
+  - id: sessions_dir_unwritable
+    mitigation: surface the mkdir or write error to the user; ask them to create .claude/sessions/ manually
 ---
 
 # Create Session Summary

--- a/.claude/skills/dispatching-parallel-agents/SKILL.md
+++ b/.claude/skills/dispatching-parallel-agents/SKILL.md
@@ -1,6 +1,27 @@
 ---
 name: dispatching-parallel-agents
 description: Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies
+inputs:
+  - name: problem_domains
+    type: array
+    required: true
+    description: List of independent failures or tasks to investigate concurrently; each must be solvable without context from the others
+outputs:
+  - name: agent_summaries
+    type: array
+    description: Summaries returned by each dispatched agent describing root cause findings and changes made
+side_effects:
+  - spawns_parallel_subagents
+  - modifies_repository_files
+  - creates_git_commits
+composes: []
+failure_modes:
+  - id: agent_conflict
+    mitigation: Check summaries for overlapping file edits before integrating; resolve conflicts manually
+  - id: related_failures
+    mitigation: Switch to single-agent investigation — fixing one failure may fix others
+  - id: agent_returns_no_fix
+    mitigation: Re-dispatch with a more specific scope or fall back to sequential debugging
 ---
 
 # Dispatching Parallel Agents

--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -2,6 +2,29 @@
 name: executing-plans
 description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
 argument-hint: "[plan-file-path or GH-issue-number]"
+inputs:
+  - name: plan_source
+    type: string
+    required: true
+    description: File path to a plan file or a GitHub issue number containing an Implementation Tasks section
+outputs:
+  - name: batch_report
+    type: string
+    description: Summary of implemented tasks and verification output, reported after each batch completes
+side_effects:
+  - modifies_repository_files
+  - creates_git_commits
+  - writes_session_summary
+composes:
+  - create-session-summary
+  - finishing-a-development-branch
+failure_modes:
+  - id: plan_load_failed
+    mitigation: Stop and report error — verify the file path exists or the issue number is valid
+  - id: blocker_mid_batch
+    mitigation: Stop executing immediately and ask for clarification; do not guess or skip steps
+  - id: verification_failed_repeatedly
+    mitigation: Stop and ask for help rather than forcing through the blocker
 ---
 
 # Executing Plans

--- a/.claude/skills/explore/SKILL.md
+++ b/.claude/skills/explore/SKILL.md
@@ -2,6 +2,25 @@
 name: explore
 description: Turn a vague idea or bug observation into a fully-planned issue with research, evaluation, implementation tasks, and acceptance criteria
 argument-hint: "<description of idea or problem>"
+inputs:
+  - name: description
+    type: string
+    required: true
+    description: Vague idea, bug observation, or feature request to research and plan
+outputs:
+  - name: issue_url
+    type: url
+    description: GitHub issue URL created and ready for /implement-issue
+side_effects:
+  - creates_github_issue
+  - writes_log: logs/explore/explore-<issue>-<ts>/status.json
+composes:
+  - mcp-tools
+failure_modes:
+  - id: gh_api_unauthorized
+    mitigation: surface the gh auth error to the operator, do not retry
+  - id: vague_input_unanswered
+    mitigation: ask 1-2 AskUserQuestion clarifications then proceed; do not block indefinitely
 ---
 
 # Explore
@@ -59,6 +78,7 @@ Break the chosen approach into implementable tasks:
 - Each task should target 5-30 minutes of subagent execution time
 - If a task requires reading more than 3 files or modifying more than 2 files, split it
 - Add a complexity hint: `- [ ] \`[agent]\` **(S)** Description` where S=small (~5 min), M=medium (~15 min), L=large (~30 min)
+- **Parseable format required:** Every task line in `## Implementation Tasks` MUST begin with `- [ ] \`[agent-name]\``. Prose lines such as "Task 1: Do something" are **silently skipped** by the orchestrator — no error is raised and no warning is emitted; the task simply never executes.
 - Frontend and backend changes in the same task should be split — backend first (data layer), then frontend (presentation)
 - **E2E tests (REQUIRED for UI changes):** If `TEST_E2E_CMD` is configured in `.claude/config/platform.sh`, include an E2E task for ANY issue touching user-visible UI — CSS, components, layouts, forms, navigation, visual regressions. This is NOT optional for UI work.
   `- [ ] \`[playwright-test-developer]\` **(S)** Write Playwright E2E test for [flow description]`
@@ -105,11 +125,11 @@ PLATFORM_DIR=".claude/scripts/platform"
 - [alternative 2] — rejected because [reason]
 
 ## Implementation Tasks
-- [ ] `[agent-name]` **(S)** Description of task 1
-- [ ] `[agent-name]` **(M)** Description of task 2
-- [ ] `[agent-name]` **(L)** Description of task 3
-- [ ] `[default]` **(S)** Description of general task (e.g., tests, config)
-- [ ] `[playwright-test-developer]` **(S)** Write E2E test for [user flow] (if TEST_E2E_CMD configured)
+- [ ] `[agent-name]` **(S)** Description of task 1 — `src/services/auth.ts:L45-80`
+- [ ] `[agent-name]` **(M)** Description of task 2 — `src/components/Dashboard.tsx:L120-155`
+- [ ] `[agent-name]` **(L)** Description of task 3 — `src/api/users.ts:L30-65`
+- [ ] `[default]` **(S)** Description of general task (e.g., tests, config) — `tests/unit/auth.test.ts:L10-40`
+- [ ] `[playwright-test-developer]` **(S)** Write E2E test for [user flow] (if TEST_E2E_CMD configured) — `tests/e2e/dashboard.spec.ts:L22-55`
 
 ## Deploy Verification
 [Include if this issue involves bugs in specific environments or requires deployment testing]
@@ -173,8 +193,10 @@ Ready for implementation: /implement-issue NNN main
 The `## Implementation Tasks` section must use this parseable convention:
 
 ```markdown
-- [ ] `[agent-name]` **(M)** Task description
+- [ ] `[agent-name]` **(M)** Task description — `src/path/file.ts:L10-40`
 ```
+
+**Files suffix:** Append ` — \`path/to/file.ts:L10-40\`` (em dash, space, backtick-quoted path with optional line range) to every task description. Multiple files: ` — \`file1.ts:L5\`, \`file2.ts:L20-35\``. This tells subagents exactly where to look, eliminating broad codebase scans.
 
 **Agent values** (adapt to your project's agents):
 - Use whatever agent names are configured in `.claude/agents/`
@@ -196,9 +218,9 @@ The `## Implementation Tasks` section must use this parseable convention:
 
 Task sizing directly controls model cost via `model-config.sh`:
 
-- **Prefer S-complexity tasks** — they use haiku (cheapest model). Only use M/L when the work genuinely requires it.
+- **Prefer S-complexity tasks** — S and M tasks use sonnet; only L tasks use opus. Prefer S over M/L for smaller scope, not model savings.
 - **Split M/L tasks into multiple S tasks** when the work is decomposable into independent steps.
-- **Point tasks to specific files and line numbers** — vague descriptions cause subagents to explore broadly, triggering 19x more tool calls.
+- **Every task MUST include at least one file path. Tasks without file paths will cause subagents to scan broadly — this is the #1 token waste in the pipeline.**
 - **Each task's affected file list reduces subagent exploration cost** — include file paths in the task description.
 
 ## Integration
@@ -217,3 +239,4 @@ Task sizing directly controls model cost via `model-config.sh`:
 | Combine multiple concerns in one issue | One issue = one problem = one PR |
 | Ask too many clarifying questions | 0-2 questions max; research answers most questions |
 | Single task modifies 5+ files | Split into focused subtasks |
+| Task has no file paths | Subagent reads 13+ files to orient; include at least 1 file path per task |

--- a/.claude/skills/fix-from-review/SKILL.md
+++ b/.claude/skills/fix-from-review/SKILL.md
@@ -1,3 +1,30 @@
+---
+name: fix-from-review
+description: Use when applying code review feedback — reads specific file and line locations from review comments and applies targeted fixes
+inputs:
+  - name: review_feedback
+    type: string
+    required: true
+    description: Code review comments containing file paths, line numbers, and descriptions of what to fix
+outputs:
+  - name: fixes_applied
+    type: json
+    description: Summary of each review item and the fix applied
+  - name: commit_sha
+    type: string
+    description: SHA of the single commit containing all fixes
+side_effects:
+  - modifies_source_files
+  - runs_lint_on_changed_files
+  - creates_git_commit
+composes: []
+failure_modes:
+  - id: fix_requires_broad_context
+    mitigation: For minor issues defer and note in the summary. For major issues read the minimum additional context needed.
+  - id: review_item_ambiguous
+    mitigation: Note the item as ambiguous in the summary. Do not guess at the file or line location.
+---
+
 # Fix From Review
 
 Address code review feedback by making targeted fixes. Work from the review comments — do not explore.

--- a/.claude/skills/handle-issues/SKILL.md
+++ b/.claude/skills/handle-issues/SKILL.md
@@ -2,6 +2,35 @@
 name: handle-issues
 description: Batch process issues via batch-orchestrator.sh with rate limit handling and session resumption
 argument-hint: "[context query]"
+inputs:
+  - name: context_query
+    type: string
+    required: true
+    description: Natural language query describing which issues to process and how (e.g. "issues assigned to @me ordered by priority")
+outputs:
+  - name: status_json
+    type: file
+    description: Batch status with per-issue results written to status.json
+  - name: per_issue_prs
+    type: url[]
+    description: One pull request URL per successfully processed issue
+side_effects:
+  - spawns_background_process: batch-orchestrator.sh
+  - creates_git_branches
+  - creates_pull_requests
+  - merges_pull_requests
+  - writes_manifest: logs/handle-issues/manifest-<ts>.json
+  - writes_logs: logs/batch-*/
+composes:
+  - implement-issue
+  - process-pr
+failure_modes:
+  - id: circuit_breaker
+    mitigation: fix the failing issues then run /handle-issues "resume" to continue the batch
+  - id: rate_limit
+    mitigation: orchestrator handles automatically — waits for reset then resumes; no operator action needed
+  - id: incomplete_batch
+    mitigation: on next run operator is offered resume or fresh start; choose resume to skip completed issues
 ---
 
 # Handle Issues
@@ -592,6 +621,13 @@ fi
 
 echo ""
 echo "**Logs:** $LOG_DIR"
+
+# Extract and report follow-up issues
+FOLLOWUPS=$(jq -r '[.issues[].follow_ups // [] | .[]] | unique | join(" ")' status.json)
+if [[ -n "$FOLLOWUPS" ]]; then
+    echo ""
+    echo "Follow-up issues found: ${FOLLOWUPS}. Run: /handle-issues ${FOLLOWUPS} on branch main"
+fi
 ```
 
 ## Files

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -2,6 +2,34 @@
 name: implement-issue
 description: Use when given an issue number/key and base branch to implement end-to-end
 argument-hint: "[issue-number] [base-branch]"
+inputs:
+  - name: issue_number
+    type: string
+    required: true
+    description: Issue number or key (e.g. "123" or "KIN-123")
+  - name: base_branch
+    type: string
+    required: true
+    description: Base branch to branch from and target for the PR
+outputs:
+  - name: pr_url
+    type: url
+    description: Pull request created upon successful completion
+  - name: status_json
+    type: file
+    description: Final orchestrator status snapshot at logs/implement-issue/issue-N-timestamp/status.json
+side_effects:
+  - creates_git_branch
+  - creates_pull_request
+  - writes_logs: logs/implement-issue/issue-<N>-<ts>/
+composes: []
+failure_modes:
+  - id: orchestrator_exit_1
+    mitigation: check stage logs in logs/implement-issue/issue-N-timestamp/stages/ for the failing stage
+  - id: orchestrator_exit_2
+    mitigation: reduce task complexity or split the issue into smaller tasks
+  - id: orchestrator_exit_3
+    mitigation: verify --issue and --branch arguments are correct and the issue exists
 ---
 
 # Implement Issue

--- a/.claude/skills/improvement-loop/SKILL.md
+++ b/.claude/skills/improvement-loop/SKILL.md
@@ -1,6 +1,26 @@
 ---
 name: improvement-loop
 description: Use after resolving a bug, failed task, or unexpected agent behavior to improve the pipeline skills, agents, hooks, or scripts that contributed to the problem. Also proactively suggest improvements when recurring patterns or inefficiencies are observed.
+inputs:
+  - name: resolved_issue
+    type: string
+    required: true
+    description: Description of the bug, failed task, or agent behavior that was just resolved and the root cause identified
+outputs:
+  - name: pipeline_diff
+    type: file
+    description: Minimal change committed to the affected pipeline file (skill, agent, hook, or script)
+side_effects:
+  - modifies_pipeline_file: .claude/{skills,agents,hooks,scripts}/
+composes:
+  - pipeline-feedback
+  - writing-skills
+  - writing-agents
+failure_modes:
+  - id: premature_invocation
+    mitigation: gate check prevents improvement work while issue is unresolved; stop and return to fixing the issue first
+  - id: improvement_drift
+    mitigation: make only the minimal change for the identified problem; flag additional opportunities as separate improvement cycles
 ---
 
 # The Improvement Loop
@@ -97,6 +117,8 @@ Would you like me to run an improvement cycle to update it? This would involve:
 
 ## The Five-Step Cycle
 
+> **Before improving, record the observation via `pipeline-feedback`**
+
 ### Step 1: Capture the Problem
 
 Document what happened before details fade:
@@ -169,6 +191,66 @@ Updated [file] with [change]. This prevents [problem] which occurred during [tas
 | **settings.json** | Edit directly |
 
 **For new skills and agents:** The writing-skills and writing-agents skills have their own TDD cycles. Follow them — don't shortcut.
+
+## Triage Misclassifications: Promoting to Golden Fixtures
+
+When the resolved issue is a triage misclassification, the highest-value improvement
+is promoting the case to a **golden fixture** in the triage-classify golden suite.
+Golden fixtures lock the correct route into the live regression suite so the same
+misroute cannot recur silently across model updates or prompt edits.
+
+**Source:** Check `logs/feedback/triage_misclassification.jsonl` for recorded observations
+(recorded via the `pipeline-feedback` skill).
+
+### Fixture Promotion Steps
+
+1. **Save the issue body as a fixture file**
+
+   ```bash
+   cp <issue-body-source> \
+     .claude/scripts/implement-issue-test/fixtures/triage/<issue-id>.md
+   ```
+
+   The file must contain the raw issue body that the triage classifier will see.
+
+2. **Determine the expected route and disqualifying criterion**
+
+   From the feedback record's `expected` field, derive:
+   - `expected_route` — `fast-path` or `full`
+   - `expected_dq` — the disqualifying criterion name if `full`, or `*` to accept any
+
+3. **Add a manifest entry to `.claude/skills/triage-classify/golden.manifest.txt`**
+
+   Append one pipe-delimited line:
+
+   ```
+   <issue-id>|<expected_route>|<expected_dq>
+   ```
+
+4. **Verify the new fixture passes**
+
+   ```bash
+   .claude/scripts/skill-golden.sh triage-classify <issue-id>
+   ```
+
+   The fixture must pass before committing. If it fails, the prompt or the expected
+   outcome needs investigation — do not update the manifest to match the wrong answer.
+
+5. **Commit both files**
+
+   ```bash
+   git add .claude/skills/triage-classify/golden.manifest.txt \
+           .claude/scripts/implement-issue-test/fixtures/triage/<issue-id>.md
+   git commit -m "improve: triage-classify — add golden fixture for <issue-id>"
+   ```
+
+### When to promote vs. when to fix the prompt
+
+| Situation | Action |
+|-----------|--------|
+| Misclassification was a one-off (unique issue structure) | Promote fixture only — no prompt change |
+| Misclassification reveals a criterion gap in the prompt | Fix the prompt AND promote fixture |
+| Multiple fixtures now flip after a prompt change | Investigate before changing the manifest |
 
 ## Preventing Improvement Drift
 

--- a/.claude/skills/investigating-codebase-for-user-stories/SKILL.md
+++ b/.claude/skills/investigating-codebase-for-user-stories/SKILL.md
@@ -1,6 +1,29 @@
 ---
 name: investigating-codebase-for-user-stories
 description: Use when asked to create user stories from a codebase, document existing features as stories, or reverse-engineer requirements from code
+inputs: []
+outputs:
+  - name: story_files
+    type: file_path
+    description: Individual user story markdown files written to docs/user-stories/<feature-area>/<story>.md
+  - name: readme_file
+    type: file_path
+    description: Coverage matrix and dependency graph index at docs/user-stories/README.md
+  - name: create_issues_script
+    type: file_path
+    description: Auto-generated batch script at docs/user-stories/create-issues.sh for creating GitHub issues from stories
+side_effects:
+  - writes_files: docs/user-stories/
+  - may_create_github_labels: true
+  - may_create_github_issues: true
+composes: []
+failure_modes:
+  - id: no_routes_found
+    mitigation: document what structure was found, produce partial stories, and note which feature areas could not be mapped
+  - id: no_auth_middleware
+    mitigation: label user types as "Unknown" in stories and ask the user to clarify roles before finalising
+  - id: circular_dependencies
+    mitigation: flag the circular chain in the README dependency graph and ask the user whether to split or merge the affected stories
 ---
 
 # Investigating Codebase for User Stories

--- a/.claude/skills/mcp-tools/SKILL.md
+++ b/.claude/skills/mcp-tools/SKILL.md
@@ -1,6 +1,32 @@
 ---
 name: mcp-tools
 description: Use when you need framework documentation, structured code navigation, or are unsure which exploration tool to use. Reference for available MCP tools and when to prefer each.
+inputs:
+  - name: query
+    type: string
+    required: true
+    description: What you are looking for — framework docs, code structure, or a text/file pattern
+  - name: library_name
+    type: string
+    required: false
+    description: Library or framework name when resolving documentation via Context7
+outputs:
+  - name: documentation
+    type: string
+    description: Framework API reference or usage patterns retrieved from Context7
+  - name: code_structure
+    type: string
+    description: Class hierarchy, method signatures, or call graph from Serena
+  - name: search_results
+    type: string
+    description: Matching file paths or text lines from Grep or Glob
+side_effects: []
+composes: []
+failure_modes:
+  - id: tool_not_found
+    mitigation: Fall back to the next option in the decision matrix (Context7 → web search; Serena → Grep + manual reading); note the unavailability in output
+  - id: library_not_in_context7
+    mitigation: If context7.resolve_library_id returns no match, fall back to web search for the library's documentation
 ---
 
 # MCP Tools Reference

--- a/.claude/skills/pipeline-sync/SKILL.md
+++ b/.claude/skills/pipeline-sync/SKILL.md
@@ -1,6 +1,29 @@
 ---
 name: pipeline-sync
 description: Sync core pipeline files between claude-pipeline and project repos. Use when the user says "sync pipeline", "upstream this fix", "pull latest pipeline", "push to upstream", or when they've fixed a bug in a project's .claude/scripts/ that should be shared. Also use proactively after editing core files (scripts, hooks, schemas) to remind the user to sync. Includes a PostToolUse hook that auto-detects core file edits.
+inputs:
+  - name: direction
+    type: string
+    required: true
+    description: Sync direction — "to" pushes core files from claude-pipeline into the project, "from" pulls a fix from the project back to claude-pipeline, "diff" shows what differs without modifying anything
+  - name: project_path
+    type: file_path
+    required: true
+    description: Absolute path to the project repository to sync with (e.g. ~/Projects/my-project)
+outputs:
+  - name: diff_output
+    type: string
+    description: List of files that differ between the pipeline and the project (always produced; non-empty only when files diverge)
+side_effects:
+  - may_modify_project_files: syncs core scripts/hooks/schemas into the project when direction is "to"
+  - may_modify_pipeline_files: pulls changed core files into the claude-pipeline repo when direction is "from"
+  - may_create_git_commits: commits the pulled fix in claude-pipeline when direction is "from"
+composes: []
+failure_modes:
+  - id: sync_sh_missing
+    mitigation: verify the claude-pipeline repo location and that sync.sh exists at its root; if missing, ask the user to locate or reinstall the pipeline
+  - id: project_dir_not_found
+    mitigation: confirm the project_path with the user; do not attempt to create the directory
 ---
 
 # Pipeline Sync

--- a/.claude/skills/playwright-testing/SKILL.md
+++ b/.claude/skills/playwright-testing/SKILL.md
@@ -1,6 +1,38 @@
 ---
 name: playwright-testing
 description: Use when writing, reviewing, or debugging Playwright E2E tests. Use when converting manual test scripts to automated tests. Use when test failures involve browser interaction, page navigation, or UI assertions.
+inputs:
+  - name: test_target
+    type: string
+    required: true
+    description: The feature, page, or user interaction to cover with Playwright E2E tests
+  - name: base_url
+    type: url
+    description: Base URL of the application under test
+outputs:
+  - name: test_spec
+    type: file_path
+    description: E2E test spec file created under e2e/tests/
+  - name: page_object
+    type: file_path
+    description: Page Object Model class file created under e2e/pages/
+  - name: test_results
+    type: string
+    description: Playwright test runner output with pass/fail counts
+side_effects:
+  - writes_test_spec_files
+  - writes_page_object_files
+  - spawns_browser_process
+  - may_capture_screenshots
+composes:
+  - test-driven-development
+failure_modes:
+  - id: flaky_tests
+    mitigation: Replace waitForTimeout with condition-based waiting such as waitForResponse or expect().toBeVisible().
+  - id: selector_breaks_on_refactor
+    mitigation: Replace CSS selectors with data-testid attributes or role-based selectors.
+  - id: test_interdependence
+    mitigation: Ensure each test sets up its own state and does not share cookies, localStorage, or global state with other tests.
 ---
 
 # Playwright Testing

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -1,3 +1,26 @@
+---
+name: pr-creation
+description: Create a pull request or merge request by executing the provided push-and-create command
+inputs:
+  - name: command
+    type: string
+    required: true
+    description: The exact git push and platform create-mr/create-pr command to run, with the <description> placeholder substituted from the issue context
+outputs:
+  - name: pr_number
+    type: string
+    description: The PR/MR number extracted from the command output
+side_effects:
+  - pushes_git_branch
+  - creates_pr_mr
+composes: []
+failure_modes:
+  - id: push_failed
+    mitigation: Check for remote conflicts or permission issues; do not retry blindly
+  - id: pr_creation_failed
+    mitigation: Check platform CLI authentication and connectivity; report error
+---
+
 # PR Creation
 
 Create a merge request / pull request by executing the provided command. Nothing else.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,3 +1,31 @@
+---
+name: pr-review
+description: Review a pull request diff against issue requirements and return an approved or changes_requested verdict
+inputs:
+  - name: diff
+    type: string
+    required: true
+    description: The PR diff to review, provided inline in the prompt
+  - name: issue_number
+    type: integer
+    required: true
+    description: GitHub issue number to fetch acceptance criteria and requirements from
+outputs:
+  - name: verdict
+    type: string
+    description: Review outcome — approved or changes_requested
+  - name: issues
+    type: array
+    description: List of findings with severity (major or minor) and supporting evidence from the diff
+side_effects: []
+composes: []
+failure_modes:
+  - id: review_timeout
+    mitigation: Stop exploring the codebase — review only the provided diff; complete in 3-5 turns maximum
+  - id: issue_fetch_failed
+    mitigation: Stop and report error — cannot review without fetching the requirements
+---
+
 # PR Review
 
 Review a pull request diff against the issue requirements. Produce a verdict (approved / changes_requested) with evidence.

--- a/.claude/skills/process-pr/SKILL.md
+++ b/.claude/skills/process-pr/SKILL.md
@@ -2,6 +2,44 @@
 name: process-pr
 description: Process PR/MR based on code review - if approved, create follow-up issues, merge, close; if changes requested, re-run implement-issue
 argument-hint: "<pr_number> <issue_number> <base_branch>"
+inputs:
+  - name: pr_number
+    type: integer
+    required: true
+    description: PR/MR number to process
+  - name: issue_number
+    type: integer
+    required: true
+    description: Issue number that the PR/MR addresses
+  - name: base_branch
+    type: string
+    required: true
+    description: Base branch for re-implementation if changes are requested
+outputs:
+  - name: status
+    type: string
+    description: Outcome — one of merged, changes_requested, error, or rate_limit
+  - name: follow_up_issues
+    type: array
+    description: Issue numbers created from follow-up items found in review comments
+side_effects:
+  - merges_pr
+  - closes_github_issue
+  - deletes_branch
+  - creates_github_issues
+  - comments_on_issue
+  - spawns_claude_subprocess
+composes:
+  - implement-issue
+failure_modes:
+  - id: validation_failed
+    mitigation: Stop and report error — verify PR/MR and issue numbers are correct and open
+  - id: no_review_status
+    mitigation: Stop and report — a code review comment with Status line is required before processing
+  - id: merge_failed
+    mitigation: Stop and return failure; do NOT close the issue
+  - id: rerun_failed
+    mitigation: Log error and include in output; do not retry automatically
 ---
 
 # Process PR/MR
@@ -210,6 +248,29 @@ Scan all review comments for indicators of follow-up work:
 - "nice to have:"
 - "consider adding:"
 
+**Follow-up classification — determine type before extracting:**
+
+| Classification | Criteria | Action |
+|---|---|---|
+| **precise** | References a specific file or function AND covers ≤2 files in scope | Create issue immediately — enough context to implement |
+| **vague** | No file/function reference, broad scope, or uses open-ended trigger phrases alone | Attempt to expand via /explore; fall back to direct create with needs-explore label if /explore fails |
+
+Open-ended trigger phrases that signal a **vague** follow-up (do not auto-create):
+`"consider adding:"`, `"nice to have:"`, `"future improvement:"`, `"we could also..."`
+
+Examples:
+
+```
+# PRECISE — create issue
+"follow-up needed: extract retry logic in scripts/merge-mr.sh:handle_merge() into a shared helper"
+"technical debt: auth/token.sh:validate_token doesn't handle clock skew — add leeway param"
+
+# VAGUE — skip, do not auto-create
+"consider adding more tests"
+"future improvement: better error handling throughout"
+"nice to have: improve logging"
+```
+
 **Extract for each:**
 - Title (short description)
 - Body (full context from comment)
@@ -217,7 +278,38 @@ Scan all review comments for indicators of follow-up work:
 
 ### Step 4f: Create Follow-up Issues
 
-For each extracted issue:
+**Before creating each issue, run a deduplication check:**
+
+```bash
+TITLE_LOWER=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]')
+EXISTING=$(gh issue list --search "$ISSUE_TITLE" --state open \
+  --json number,title \
+  | jq -r --arg t "$TITLE_LOWER" '.[] | select(.title | ascii_downcase | contains($t)) | .number' \
+  | head -1)
+if [ -n "$EXISTING" ]; then
+  echo "Skipping duplicate: similar open issue already exists (#$EXISTING for \"$ISSUE_TITLE\")"
+  # continue to next extracted issue
+fi
+```
+
+Only proceed to create the issue when no duplicate is found.
+
+**Implementation Tasks format — REQUIRED format:**
+
+Every task line in the `## Implementation Tasks` block MUST use the checkbox + agent-prefix format. The task parser silently skips prose-style `Task N:` lines — this is the failure mode that caused production incidents.
+
+```
+# CORRECT — task parser picks this up:
+- [ ] `[default]` **(S)** $INFERRED_TASK_DESCRIPTION
+
+# ANTI-PATTERN — task parser silently skips these:
+Task 1: $INFERRED_TASK_DESCRIPTION
+Task 2: $INFERRED_TASK_DESCRIPTION
+```
+
+For each extracted issue (after deduplication check passes), route by classification:
+
+**Precise follow-up** — create issue immediately:
 
 ```bash
 PLATFORM_DIR=".claude/scripts/platform"
@@ -228,6 +320,9 @@ Created from code review of PR/MR #$PR_NUMBER (Issue #$ISSUE_NUMBER)
 ## Description
 $EXTRACTED_DESCRIPTION
 
+## Implementation Tasks
+- [ ] `[default]` **(S)** $INFERRED_TASK_DESCRIPTION
+
 ## References
 - Parent Issue: #$ISSUE_NUMBER
 - PR/MR: #$PR_NUMBER
@@ -237,6 +332,40 @@ EOF
 ```
 
 Log each: `Created follow-up issue #XXX: "$TITLE"`
+
+**Vague follow-up** — invoke `/explore` to flesh out context before creating the issue:
+
+```bash
+PLATFORM_DIR=".claude/scripts/platform"
+
+# Attempt to expand the vague item via /explore
+EXPLORE_OUTPUT=$(claude --dangerously-skip-permissions --print "/explore $(printf '%s' "$EXTRACTED_DESCRIPTION")" 2>&1)
+EXPLORE_EXIT=$?
+
+if [ $EXPLORE_EXIT -eq 0 ]; then
+  # /explore succeeded — it creates a fully-formed issue internally; log and continue
+  echo "Explored and created issue from vague item: \"$ISSUE_TITLE\""
+else
+  # /explore failed — fall back to direct creation with needs-explore label
+  echo "Warning: /explore failed (exit $EXPLORE_EXIT) for \"$ISSUE_TITLE\"; falling back to direct create with needs-explore label"
+  "$PLATFORM_DIR/create-issue.sh" --title "$ISSUE_TITLE" --body "$(cat <<'EOF'
+## Context
+Created from code review of PR/MR #$PR_NUMBER (Issue #$ISSUE_NUMBER)
+
+## Description
+$EXTRACTED_DESCRIPTION
+
+> **Note:** This item was classified as vague. The /explore subprocess failed to expand it.
+> A human should research and flesh out the implementation tasks before acting on this issue.
+
+## References
+- Parent Issue: #$ISSUE_NUMBER
+- PR/MR: #$PR_NUMBER
+- Reviewer: @$REVIEWER
+EOF
+)" --labels "${LABELS:+$LABELS,}needs-explore"
+fi
+```
 
 ---
 

--- a/.claude/skills/resume-session/SKILL.md
+++ b/.claude/skills/resume-session/SKILL.md
@@ -2,6 +2,24 @@
 name: resume-session
 description: Resume Previous Session
 argument-hint: "[session-file-path]"
+inputs:
+  - name: session_file_path
+    type: file_path
+    required: false
+    description: Path to session summary file; defaults to the most recent file in .claude/sessions/ if omitted
+outputs: []
+side_effects:
+  - may_checkout_git_branch: switches to the branch recorded in the session file if it differs from the current branch
+composes: []
+failure_modes:
+  - id: session_file_not_found
+    mitigation: list available files in .claude/sessions/ and ask the user to pick one; if none exist, inform user and stop
+  - id: branch_mismatch
+    mitigation: inform the user of the discrepancy and offer to checkout the session branch or proceed on the current branch
+  - id: malformed_session_file
+    mitigation: show the raw file contents and ask the user for guidance; do not attempt to infer missing sections
+  - id: no_session_files
+    mitigation: inform the user that no session files exist in .claude/sessions/ and suggest running /create-session-summary first
 ---
 
 # Resume Session

--- a/.claude/skills/subagent-driven-development/SKILL.md
+++ b/.claude/skills/subagent-driven-development/SKILL.md
@@ -1,6 +1,33 @@
 ---
 name: subagent-driven-development
 description: Use when executing implementation plans with independent tasks in the current session
+inputs:
+  - name: issue_number
+    type: integer
+    required: true
+    description: GitHub issue number containing the implementation plan with tasks in an Implementation Tasks section
+  - name: feature_branch
+    type: string
+    required: true
+    description: Git branch name where all implementation commits must land; included in every subagent dispatch
+outputs:
+  - name: completed_tasks
+    type: array
+    description: Tasks completed and verified through two-stage review (spec compliance then code quality), each committed to the feature branch
+side_effects:
+  - creates_git_commits
+  - modifies_repository_files
+  - writes_session_summary
+composes:
+  - finishing-a-development-branch
+  - create-session-summary
+failure_modes:
+  - id: subagent_on_wrong_branch
+    mitigation: Verify branch with git branch --show-current after each task; re-dispatch to correct branch if needed
+  - id: review_rejected_repeatedly
+    mitigation: Escalate to human partner with full context; do not loop indefinitely
+  - id: headless_question_unanswerable
+    mitigation: Answer from plan/issue context autonomously and track the decision for PR comment
 ---
 
 # Subagent-Driven Development

--- a/.claude/skills/systematic-debugging/SKILL.md
+++ b/.claude/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,38 @@
 ---
 name: systematic-debugging
 description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+inputs:
+  - name: bug_description
+    type: string
+    required: true
+    description: The bug, test failure, or unexpected behaviour to investigate
+  - name: error_output
+    type: string
+    description: Error messages, stack traces, or test failure output to analyze
+outputs:
+  - name: root_cause
+    type: string
+    description: The identified root cause of the bug
+  - name: failing_test
+    type: file_path
+    description: Minimal automated test case that reproduces the bug
+  - name: fix_description
+    type: string
+    description: Description of the fix applied at the root cause
+side_effects:
+  - adds_diagnostic_instrumentation
+  - runs_test_suite
+  - modifies_production_code
+composes:
+  - test-driven-development
+  - verification-before-completion
+failure_modes:
+  - id: three_fixes_failed
+    mitigation: Stop attempting further fixes. Question the architecture and discuss with your human partner before proceeding.
+  - id: unable_to_reproduce
+    mitigation: Gather evidence from all component boundaries before forming any hypothesis. Do not guess.
+  - id: symptom_fix_not_root_cause
+    mitigation: Return to Phase 1, trace the data flow upward to find the true source of the problem.
 ---
 
 # Systematic Debugging

--- a/.claude/skills/test-driven-development/SKILL.md
+++ b/.claude/skills/test-driven-development/SKILL.md
@@ -1,6 +1,33 @@
 ---
 name: test-driven-development
 description: Use when implementing any feature or bugfix, before writing implementation code
+inputs:
+  - name: task_description
+    type: string
+    required: true
+    description: The feature, bug fix, or behaviour change to implement
+outputs:
+  - name: test_file
+    type: file_path
+    description: Test file written first, containing the failing test(s)
+  - name: implementation_file
+    type: file_path
+    description: Implementation file written to make the failing tests pass
+  - name: test_results
+    type: string
+    description: Test runner output confirming all tests pass after implementation
+side_effects:
+  - writes_test_files
+  - writes_implementation_files
+  - runs_test_suite
+composes: []
+failure_modes:
+  - id: test_passes_immediately
+    mitigation: Test is testing existing behaviour, not the new feature. Rewrite the test to target the missing behaviour.
+  - id: implementation_written_before_test
+    mitigation: Delete all implementation code and start over with a failing test first.
+  - id: test_errors_on_run
+    mitigation: Fix the setup or import error and re-run until the test fails for the expected reason before writing implementation.
 ---
 
 # Test-Driven Development (TDD)

--- a/.claude/skills/test-validation/SKILL.md
+++ b/.claude/skills/test-validation/SKILL.md
@@ -1,3 +1,31 @@
+---
+name: test-validation
+description: Use when tests need to be run and validated for quality — checks for hollow assertions, missing assertions, and commented-out tests in changed files
+inputs:
+  - name: test_command
+    type: string
+    required: true
+    description: The test command to execute, provided in the invoking prompt
+outputs:
+  - name: result
+    type: string
+    description: Overall test outcome — "passed" or "failed"
+  - name: validation_result
+    type: string
+    description: Validation outcome — "passed" or "failed" based on assertion quality checks
+  - name: validation_issues
+    type: json
+    description: Array of hollow assertion, empty body, or commented-out test findings with file and line
+side_effects:
+  - runs_test_suite
+composes: []
+failure_modes:
+  - id: test_command_fails
+    mitigation: Report failure details (count, messages) and stop. Do not proceed to validation checks.
+  - id: validation_issue_found
+    mitigation: Report all findings in the structured JSON output. Do not fix the issues; report only.
+---
+
 # Test Validation
 
 Run the test suite and validate test quality. Execute commands, check results, report findings — do not explore the codebase.

--- a/.claude/skills/using-git-worktrees/SKILL.md
+++ b/.claude/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,37 @@
 ---
 name: using-git-worktrees
 description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees in .worktrees/
+inputs:
+  - name: branch_name
+    type: string
+    required: true
+    description: Name for the new feature branch and worktree directory
+  - name: base_branch
+    type: string
+    required: true
+    description: Existing branch to base the new worktree on (e.g. main, aw-next)
+outputs:
+  - name: worktree_path
+    type: string
+    description: Absolute path to the newly created worktree directory
+  - name: branch
+    type: string
+    description: Name of the branch checked out in the worktree
+  - name: test_summary
+    type: string
+    description: Baseline test results confirming the worktree is clean before work begins
+side_effects:
+  - creates_git_worktree
+  - modifies_gitignore
+  - installs_dependencies
+composes: []
+failure_modes:
+  - id: worktrees_not_ignored
+    mitigation: Add .worktrees/ to .gitignore and commit before creating the worktree
+  - id: missing_bootstrap_cache
+    mitigation: Run mkdir -p bootstrap/cache before composer install in Laravel projects
+  - id: baseline_tests_fail
+    mitigation: Verify vendor/, node_modules/, and Vite manifest all exist; compare failures with main branch to identify pre-existing issues
 ---
 
 > **Note:** This skill is not used by the automated pipeline (`implement-issue`, `handle-issues`). The pipeline uses feature branches instead. This skill remains available for manual use when workspace isolation is needed.

--- a/.claude/skills/using-skills/SKILL.md
+++ b/.claude/skills/using-skills/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: using-skills
 description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+inputs: []
+outputs: []
+side_effects:
+  - creates_todowrite_todos
+composes: []
+failure_modes:
+  - id: rationalization_bypass
+    mitigation: Stop, restart the response, and invoke the Skill tool before taking any action or asking any question
 ---
 
 <EXTREMELY-IMPORTANT>

--- a/.claude/skills/writing-agents/SKILL.md
+++ b/.claude/skills/writing-agents/SKILL.md
@@ -1,6 +1,19 @@
 ---
 name: writing-agents
 description: Use when creating new agents, editing existing agents, or defining specialized subagent roles for the Task tool
+inputs: []
+outputs:
+  - name: agent_file
+    type: file_path
+    description: Agent definition created at .claude/agents/<agent-name>.md
+side_effects:
+  - writes_agent_file
+composes:
+  - test-driven-development
+  - writing-skills
+failure_modes:
+  - id: missing_session_restart
+    mitigation: Always prompt user to restart Claude Code session after creating or modifying an agent — agents are loaded at session start and won't be available until restart
 ---
 
 # Writing Agents

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -1,6 +1,25 @@
 ---
 name: writing-plans
 description: Use when you have a spec or requirements for a multi-step task, before touching code
+inputs:
+  - name: github_mode
+    type: boolean
+    required: false
+    description: When true, outputs plan as a structured GitHub Issue body instead of saving to a local file
+outputs:
+  - name: plan_file
+    type: file_path
+    description: Implementation plan saved to docs/plans/YYYY-MM-DD-<feature-name>.md (local mode only)
+  - name: github_issue_body
+    type: string
+    description: Structured GitHub Issue body with parseable task list (--github mode only)
+side_effects:
+  - writes_file: "docs/plans/YYYY-MM-DD-<feature-name>.md"
+  - commits_to_git
+composes:
+  - subagent-driven-development
+  - executing-plans
+failure_modes: []
 ---
 
 # Writing Plans

--- a/.claude/skills/writing-skills/SKILL.md
+++ b/.claude/skills/writing-skills/SKILL.md
@@ -1,6 +1,21 @@
 ---
 name: writing-skills
 description: Use when creating new skills, editing existing skills, or verifying skills work before deployment
+inputs: []
+outputs:
+  - name: skill_file
+    type: file_path
+    description: SKILL.md written to skills/<skill-name>/SKILL.md
+side_effects:
+  - writes_skill_file
+  - commits_to_git
+composes:
+  - test-driven-development
+failure_modes:
+  - id: skip_red_phase
+    mitigation: Delete the skill and restart from RED phase — run baseline scenario without the skill before writing it
+  - id: deploy_without_test
+    mitigation: Run pressure scenarios with and without the skill before committing or sharing
 ---
 
 # Writing Skills
@@ -93,19 +108,45 @@ skills/
 ## SKILL.md Structure
 
 **Frontmatter (YAML):**
-- Only two fields supported: `name` and `description`
-- Max 1024 characters total
-- `name`: Use letters, numbers, and hyphens only (no parentheses, special chars)
+
+Required fields:
+- `name`: Letters, numbers, and hyphens only (no parentheses, special chars)
 - `description`: Third-person, describes ONLY when to use (NOT what it does)
   - Start with "Use when..." to focus on triggering conditions
   - Include specific symptoms, situations, and contexts
   - **NEVER summarize the skill's process or workflow** (see CSO section for why)
   - Keep under 500 characters if possible
 
-```markdown
+Optional fields (fill in when the skill will be composed by other skills or meta-skills):
+- `argument-hint`: Short hint shown to the operator when invoking this skill with an argument
+- `inputs`: List of named inputs the skill consumes (enables pre-invocation validation)
+- `outputs`: List of named outputs callers can rely on (enables piping to other skills)
+- `side_effects`: List of external changes (files written, issues created, processes spawned)
+- `composes`: List of sub-skill names invoked via the Skill tool (builds dependency graph)
+- `failure_modes`: Known failure ids and mitigations (enables recovery skills to take action)
+
+```yaml
 ---
-name: Skill-Name-With-Hyphens
+name: skill-name
 description: Use when [specific triggering conditions and symptoms]
+argument-hint: "<optional short hint for CLI invocation>"
+inputs:
+  - name: param_name
+    type: string          # string | url | file_path | boolean | number
+    required: true
+    description: What this input represents
+outputs:
+  - name: result_name
+    type: url             # string | url | file_path | boolean | number
+    description: What callers can rely on receiving
+side_effects:
+  - creates_github_issue
+  - writes_log: logs/<skill>/<skill>-<id>-<ts>/status.json
+composes:
+  - other-skill-name
+failure_modes:
+  - id: short_snake_case_id
+    mitigation: What callers should do when this failure occurs
 ---
 
 # Skill Name
@@ -287,6 +328,70 @@ Use skill name only, with explicit requirement markers:
 
 **Why no @ links:** `@` syntax force-loads files immediately, consuming 200k+ context before you need them.
 
+## Sub-Skill Invocation
+
+When invoking another skill from within a skill, use the **isolation decision rule**:
+
+- **Subprocess** (`claude --print "/skill args"`) — worktree-isolated, parallel fanout, or sandbox execution
+- **Skill tool** — everything else (orchestration, routing, planning, review)
+
+### Composition Taxonomy (Canonical Reference)
+
+| Path | Method | Use When | Examples |
+|------|--------|----------|---------|
+| Skill-tool | Skill tool | Non-isolated: decision-making, routing, orchestration | `process-pr`, `code-reviewer` |
+| Subprocess | `claude --print` | Isolated: worktree, parallel, sandbox | `implement-issue` |
+
+**Default (no isolated arg):** routes to Skill tool path.
+
+> **Architectural constraint — Skill tool only works inside interactive sessions.**
+> The Skill tool is a Claude Code harness feature. Bash scripts that call `claude -p` (or
+> `claude --print`) create non-interactive subprocess sessions where the Skill tool is **not
+> available**. You cannot invoke a skill via the Skill tool from within a bash orchestration
+> script. Use the Subprocess path (`claude --print "/skill-name"`) or embed skill content
+> directly in the prompt instead.
+
+**Kill-switch:** `COMPOSITION_BACKEND` env var overrides auto-routing:
+- `skill` → routes to `run_composition_standard()` (bash subprocess, non-sandboxed; legacy alias — does NOT invoke the Skill tool)
+- `subprocess` → forces subprocess even for non-isolated work
+- Unknown value → exits non-zero with error
+
+**Frontmatter:** List Skill-tool sub-skills in `composes:`. Subprocess sub-skills are not listed (they run in separate agent sessions).
+
+**Reference implementation:** `dispatch_composition()` in `.claude/scripts/batch-orchestrator.sh`
+**Test coverage:** `.claude/scripts/implement-issue-test/test-orchestrator-composition.bats`
+
+### Canary Measurement (gates merge of backend changes)
+
+Before merging changes that alter the composition backend, run a 10-issue canary
+and verify regressions are within budget:
+
+| Metric             | Budget                                  | Source                                                            |
+|--------------------|-----------------------------------------|-------------------------------------------------------------------|
+| Tokens per issue   | ≤10% median regression vs. baseline     | summed from per-session transcripts in `~/.claude/projects/`      |
+| Wall-clock per issue | ≤25% median regression vs. baseline   | `total_duration_seconds` from each issue's `metrics.json`         |
+
+**Procedure (use `.claude/scripts/canary-measure.sh`):**
+
+1. Select 10 representative issues.
+2. Baseline run: `COMPOSITION_BACKEND=subprocess ./batch-orchestrator.sh …` against the chosen issues, then capture results:
+   ```bash
+   ./canary-measure.sh --logs-dir logs/ --label baseline > canary-baseline.json
+   ```
+3. Candidate run: same issues with default auto-routing (or `COMPOSITION_BACKEND=skill`):
+   ```bash
+   ./canary-measure.sh --logs-dir logs/ --label candidate > canary-candidate.json
+   ```
+4. Compute deltas and gate decision:
+   ```bash
+   ./canary-measure.sh --compute-deltas \
+       --before canary-baseline.json --after canary-candidate.json \
+       --format markdown
+   ```
+5. **Block merge** if `gates.tokens_within_limit` is `false` (>10% median) or `gates.wall_clock_within_limit` is `false` (>25% median). Otherwise paste the markdown report into the PR description.
+
+**Test coverage:** `.claude/scripts/implement-issue-test/test-canary-measure.bats`
+
 ## Flowchart Usage
 
 ```dot
@@ -343,6 +448,74 @@ Choose most relevant language:
 - Write contrived examples
 
 You're good at porting - one great example is enough.
+
+## Pipeline Event Stream
+
+**When your skill observes pipeline behavior, consume `events.jsonl` — never parse `orchestrator.log`.**
+
+The pipeline emits structured JSONL to `logs/implement-issue/<run_id>/events.jsonl`. Each line is a self-contained JSON object validated against `.claude/scripts/schemas/pipeline-event.json` before write. Text logs continue to exist for human debugging but are brittle data sources for skills.
+
+### Event Envelope
+
+Every event shares this envelope:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ts` | ISO 8601 | Timestamp of event |
+| `run_id` | string | e.g. `issue-158-20260409-183459` |
+| `stage` | string | `implement`, `test`, `review`, … |
+| `event` | string | Event type (see below) |
+| `task` | integer? | Present when stage is task-scoped |
+
+### Event Types
+
+| Event | When emitted | Key payload fields |
+|-------|-------------|-------------------|
+| `stage_start` | Stage begins | `model` |
+| `stage_end` | Stage completes | `status`, `duration_seconds` |
+| `escalation` | Model escalated | `from_model`, `to_model`, `reason` |
+| `retry` | Stage retried | `reason`, `attempt`, `max_attempts` |
+| `model_call` | LLM invoked | `model`, `stage_attempt` |
+| `rate_limit_hit` | 429 received | `model`, `retry_after_seconds` |
+| `schema_validation_fail` | Output rejected | `schema`, `errors` |
+| `status_change` | `status.json` updated | `from_state`, `to_state` |
+
+Batch-level events (`batch_start`, `batch_end`, `issue_start`, `issue_end`, `batch_paused`) follow the same envelope without a `task` field.
+
+### Consumer Pattern
+
+```bash
+# Filter by event type
+jq 'select(.event == "rate_limit_hit")' logs/implement-issue/<run_id>/events.jsonl
+
+# Stream live events
+tail -f logs/implement-issue/<run_id>/events.jsonl | jq 'select(.event == "escalation")'
+
+# Count rate-limit hits in last 60 seconds (portable: macOS + Linux)
+cutoff=$(date -u -v-60S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+         || date -u -d '-60 seconds' +%Y-%m-%dT%H:%M:%SZ)
+jq --arg cutoff "$cutoff" \
+   'select(.event == "rate_limit_hit" and .ts >= $cutoff)' \
+   logs/implement-issue/<run_id>/events.jsonl | wc -l
+```
+
+Consumer robustness rules:
+- **Tolerate truncated final lines** — the producer may be mid-write; skip lines that fail `jq` parse
+- **Filter by `run_id`** when multiple runs share a log directory
+- **`status.json` is a crash-resume checkpoint; `events.jsonl` is canonical history** — use events for sequencing and counting
+
+### ❌ Anti-Pattern: Log Parsing
+
+```bash
+# ❌ Never — brittle, breaks on log-format changes
+grep -c "consecutive timeout" logs/implement-issue/<run_id>/orchestrator.log
+
+# ✅ Always — structured, schema-validated, stable
+jq 'select(.event == "escalation" and .reason == "consecutive_timeout")' \
+   logs/implement-issue/<run_id>/events.jsonl | wc -l
+```
+
+See `.claude/skills/pipeline-recovery/SKILL.md` for a worked example of a skill that reacts to a rate-limit cluster from `events.jsonl`.
 
 ## File Organization
 
@@ -604,7 +777,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 
 **GREEN Phase - Write Minimal Skill:**
 - [ ] Name uses only letters, numbers, hyphens (no parentheses/special chars)
-- [ ] YAML frontmatter with only name and description (max 1024 chars)
+- [ ] YAML frontmatter: required `name` and `description`; add `inputs`, `outputs`, `side_effects`, `composes`, `failure_modes` when skill will be composed or orchestrated
 - [ ] Description starts with "Use when..." and includes specific triggers/symptoms
 - [ ] Description written in third person
 - [ ] Keywords throughout for search (errors, symptoms, tools)


### PR DESCRIPTION
## Summary

- Syncs `implement-issue-orchestrator.sh` watchdog fix from claude-pipeline issue #310 / PR #311
- Three-part fix prevents post-merge stall caused by orphaned `sleep` holding pipe fds open:
  1. `set -m` before watchdog launch gives it its own process group
  2. `> /dev/null 2>&1` on the watchdog subshell breaks pipe inheritance into `sleep`
  3. `kill -- -"$_watchdog_pid"` kills the entire process group on cleanup
- Also includes new BATS regression test `tests/watchdog-fd-inheritance.bats`
- All other upstream changes from claude-pipeline main through 2026-05-12

## Test plan

- [ ] Verify `implement-issue-orchestrator.sh` contains `> /dev/null 2>&1` on watchdog line
- [ ] Verify `kill -- -"$_watchdog_pid"` pattern is present
- [ ] Confirm `tests/watchdog-fd-inheritance.bats` exists and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)