### PR TITLE
fix(issue-374): separate stderr in create-issue parent bats helper

### DIFF
--- a/.claude/scripts/implement-issue-test/test-create-issue-parent.bats
+++ b/.claude/scripts/implement-issue-test/test-create-issue-parent.bats
@@ -9,6 +9,9 @@
 #   3. --parent <non-numeric> (e.g. a Jira key) → no sub_issues POST, exits 0
 #
 
+# Stream separation on `run` (--separate-stderr) requires bats >= 1.5.0
+bats_require_minimum_version 1.5.0
+
 # Absolute path to the real script under test
 # BATS_TEST_FILENAME is .claude/scripts/implement-issue-test/test-*.bats
 # ../../.. from implement-issue-test reaches the repo root
@@ -78,7 +81,10 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 _run_create_issue() {
-    run bash "$CREATE_ISSUE_SH" "$@"
+    # --separate-stderr keeps WARNING lines (emitted to stderr on linkage
+    # failure / non-numeric parent) out of $output, so stdout-only assertions
+    # like [[ "$output" == "99" ]] verify the issue-number contract correctly.
+    run --separate-stderr bash "$CREATE_ISSUE_SH" "$@"
 }
 
 # =============================================================================


### PR DESCRIPTION
## Context
Follow-up to #375 (issue #374). The `--parent` sub-issue linking fix itself is correct and merged, but **3 of 15 tests in `test-create-issue-parent.bats` were failing on `main`** — the suite was merged red.

## Root cause: test bug, not implementation bug
The helper used `run bash ...`, which merges stdout+stderr into `$output`. The script *correctly* emits `WARNING` lines to **stderr** on linkage failure or a non-numeric parent — and those polluted the `[[ "$output" == "99" ]]` assertions that verify the stdout issue-number contract (AC2/AC3).

The implementation already satisfied the ACs; the tests just conflated the two streams.

## Fix
- `_run_create_issue` now uses `run --separate-stderr` so `$output` is stdout-only — which makes "prints only the issue number on stdout" genuinely testable.
- Added `bats_require_minimum_version 1.5.0` (required to enable `run` flags).

## Verification
```
$ bats .claude/scripts/implement-issue-test/test-create-issue-parent.bats
1..15
ok 1..15   # all pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)