### PR TITLE
fix(deploy): local-first deploy on migration changes + repair deploy-verify bats suite

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -2881,8 +2881,8 @@ poll_health_url() {
 #      Fail-safe: never silently downgrade on unknown scope.
 #   1. No apps/backend or packages/ files changed → DEPLOY_VERIFY_CMD --health-only
 #      Frontend-only change: skip rebuild, just poll the health endpoint.
-#   2. Backend changes with migration/schema/env files → full DEPLOY_VERIFY_CMD
-#      Migrations must run on NAS to catch DB-level failures.
+#   2. Backend changes with migration/schema/env files → DEPLOY_LOCAL_CMD && DEPLOY_VERIFY_CMD
+#      Local build catches app-level failures fast; NAS deploy runs migrations on real DB.
 #   3. Backend logic-only change, DEPLOY_LOCAL_CMD set → DEPLOY_LOCAL_CMD
 #      No migration risk: local Docker build gives same confidence in a fraction
 #      of the time (~5-10 min vs 60-120 min NAS deploy).
@@ -2927,11 +2927,17 @@ _select_deploy_cmd() {
         done <<< "$changed_files"
     fi
 
-    # Tier 2: migration detected → full NAS deploy
+    # Tier 2: migration detected → local first, then full NAS deploy
     if $has_migration; then
-        log "Migration files detected —" \
-            "using full NAS deploy."
-        printf '%s\n' "${DEPLOY_VERIFY_CMD}"
+        if [[ -n "${DEPLOY_LOCAL_CMD:-}" ]]; then
+            log "Migration files detected —" \
+                "running local deploy first, then full NAS deploy."
+            printf '%s\n' "${DEPLOY_LOCAL_CMD} && ${DEPLOY_VERIFY_CMD}"
+        else
+            log "Migration files detected, DEPLOY_LOCAL_CMD not set —" \
+                "using full NAS deploy."
+            printf '%s\n' "${DEPLOY_VERIFY_CMD}"
+        fi
         return 0
     fi
 

--- a/.claude/scripts/implement-issue-test/test-deploy-verify.bats
+++ b/.claude/scripts/implement-issue-test/test-deploy-verify.bats
@@ -735,7 +735,7 @@ src/pages/index.tsx"
 
     run _select_deploy_cmd "$changed"
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-nas.sh --health-only" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-nas.sh --health-only" ]
 }
 
 @test "_select_deploy_cmd: tier 3 — backend logic-only changes return local deploy cmd" {
@@ -748,10 +748,10 @@ apps/backend/src/routes/user.ts"
 
     run _select_deploy_cmd "$changed"
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-local-backend.sh" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-local-backend.sh" ]
 }
 
-@test "_select_deploy_cmd: tier 2 — backend changes with migration file return full deploy cmd" {
+@test "_select_deploy_cmd: tier 2 — backend changes with migration file with DEPLOY_LOCAL_CMD set runs local then full deploy" {
     export DEPLOY_VERIFY_CMD="./scripts/deploy-nas.sh"
     export DEPLOY_LOCAL_CMD="./scripts/deploy-local-backend.sh"
     export MIGRATION_PATH_PATTERNS="apps/backend/prisma/migrations/*|apps/backend/prisma/schema.prisma|.env*"
@@ -761,10 +761,10 @@ apps/backend/prisma/migrations/20260101_add_users.sql"
 
     run _select_deploy_cmd "$changed"
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-nas.sh" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-local-backend.sh && ./scripts/deploy-nas.sh" ]
 }
 
-@test "_select_deploy_cmd: tier 2 — schema.prisma change forces full deploy" {
+@test "_select_deploy_cmd: tier 2 — schema.prisma change with DEPLOY_LOCAL_CMD set runs local then full deploy (schema.prisma)" {
     export DEPLOY_VERIFY_CMD="./scripts/deploy-nas.sh"
     export DEPLOY_LOCAL_CMD="./scripts/deploy-local-backend.sh"
     export MIGRATION_PATH_PATTERNS="apps/backend/prisma/migrations/*|apps/backend/prisma/schema.prisma|.env*"
@@ -774,10 +774,10 @@ apps/backend/prisma/schema.prisma"
 
     run _select_deploy_cmd "$changed"
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-nas.sh" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-local-backend.sh && ./scripts/deploy-nas.sh" ]
 }
 
-@test "_select_deploy_cmd: tier 2 — .env file change forces full deploy" {
+@test "_select_deploy_cmd: tier 2 — .env file change with DEPLOY_LOCAL_CMD set runs local then full deploy (.env)" {
     export DEPLOY_VERIFY_CMD="./scripts/deploy-nas.sh"
     export DEPLOY_LOCAL_CMD="./scripts/deploy-local-backend.sh"
     export MIGRATION_PATH_PATTERNS="apps/backend/prisma/migrations/*|apps/backend/prisma/schema.prisma|.env*"
@@ -787,7 +787,7 @@ apps/backend/prisma/schema.prisma"
 
     run _select_deploy_cmd "$changed"
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-nas.sh" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-local-backend.sh && ./scripts/deploy-nas.sh" ]
 }
 
 @test "_select_deploy_cmd: packages/ change treated as backend (tier 3 when no migrations)" {
@@ -800,7 +800,7 @@ packages/api-client/src/client.ts"
 
     run _select_deploy_cmd "$changed"
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-local-backend.sh" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-local-backend.sh" ]
 }
 
 @test "_select_deploy_cmd: empty diff fail-safe returns full deploy cmd" {
@@ -810,7 +810,7 @@ packages/api-client/src/client.ts"
 
     run _select_deploy_cmd ""
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-nas.sh" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-nas.sh" ]
 }
 
 @test "_select_deploy_cmd: unset DEPLOY_LOCAL_CMD — backend logic change falls through to full deploy" {
@@ -822,7 +822,7 @@ packages/api-client/src/client.ts"
 
     run _select_deploy_cmd "$changed"
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-nas.sh" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-nas.sh" ]
 }
 
 @test "_select_deploy_cmd: empty DEPLOY_LOCAL_CMD — backend logic change falls through to full deploy" {
@@ -834,7 +834,7 @@ packages/api-client/src/client.ts"
 
     run _select_deploy_cmd "$changed"
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-nas.sh" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-nas.sh" ]
 }
 
 @test "_select_deploy_cmd: empty MIGRATION_PATH_PATTERNS — no downgrade (require explicit opt-in)" {
@@ -846,7 +846,7 @@ packages/api-client/src/client.ts"
 
     run _select_deploy_cmd "$changed"
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-nas.sh" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-nas.sh" ]
 }
 
 @test "_select_deploy_cmd: unset MIGRATION_PATH_PATTERNS — no downgrade (require explicit opt-in)" {
@@ -858,5 +858,5 @@ packages/api-client/src/client.ts"
 
     run _select_deploy_cmd "$changed"
     [ "$status" -eq 0 ]
-    [ "$output" = "./scripts/deploy-nas.sh" ]
+    [ "${lines[${#lines[@]}-1]}" = "./scripts/deploy-nas.sh" ]
 }


### PR DESCRIPTION
## Context
Two things, bundled because the test repair is what makes the behavior change verifiable.

## 1. Behavior change — Tier 2 runs local deploy before full NAS deploy
`_select_deploy_cmd` Tier 2 (backend change **with** a migration/schema/env file) previously went straight to the full NAS deploy. Now, when `DEPLOY_LOCAL_CMD` is configured, it runs the local deploy first (fast app-level failure detection) then the full NAS deploy (which runs migrations against the real DB):

```
DEPLOY_LOCAL_CMD && DEPLOY_VERIFY_CMD
```

Falls back to NAS-only when `DEPLOY_LOCAL_CMD` is unset. (`implement-issue-orchestrator.sh:2930-2942`)

## 2. Repair the deploy-verify bats suite (was merged red)
All 11 `_select_deploy_cmd` tier tests were **failing on main** — same bug class as #376: the assertions compared `$output` (which includes the function's own `log` line) against the bare command string. Fixed by asserting the **last output line**:

- `${lines[-1]}` errors under the macOS system bash (3.2 — no negative subscripts), so use `${lines[${#lines[@]}-1]}` (bash-3.2 portable).
- Updated the three Tier-2 expectations to the new `local && nas` command and clarified their titles.

## Verification
```
$ bats .claude/scripts/implement-issue-test/test-deploy-verify.bats
61 ok / 3 not-ok
```
All 11 `_select_deploy_cmd` tests now pass. The 3 remaining failures (`run_stage extracts …`, tests 48-50) are **pre-existing and unrelated** — they fail identically on clean `main` and concern a different code path. Flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)