### PR TITLE
fix(orchestrator): no-op guard + full-suite check + e2e-unvalidated guard + stage-capture wedge fix

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -1689,7 +1689,15 @@ run_stage() {
     local output
     local exit_code=0
 
-    output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
+    # Capture via a temp FILE, not $(...). The CLI can leave a backgrounded
+    # child (e.g. an MCP server) holding the stdout pipe after it exits; command
+    # substitution then blocks forever waiting for that pipe to close — the
+    # orchestrator "wedge" (no claude child, idle wait). A file redirect returns
+    # as soon as the CLI process exits, regardless of lingering writers; `cat`
+    # then reads the complete result at EOF without blocking.
+    local _stage_raw
+    _stage_raw=$(mktemp)
+    timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
         ${agent_args[@]+"${agent_args[@]}"} \
         --model "$model" \
         ${fallback_args[@]+"${fallback_args[@]}"} \
@@ -1697,7 +1705,9 @@ run_stage() {
         --dangerously-skip-permissions \
         --output-format json \
         --json-schema "$schema" \
-        2>&1) || exit_code=$?
+        > "$_stage_raw" 2>&1 || exit_code=$?
+    output=$(cat "$_stage_raw")
+    rm -f "$_stage_raw"
 
     printf '%s\n' "=== $stage_name output ===" >> "$stage_log"
     printf '%s\n' "$output" >> "$stage_log"
@@ -1764,7 +1774,10 @@ run_stage() {
             "stage_attempt:=2"
 
         exit_code=0
-        output=$(timeout "$retry_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
+        # Temp-file capture (see the primary launch above) — avoids the
+        # command-substitution pipe-wedge when the CLI leaves a lingering child.
+        _stage_raw=$(mktemp)
+        timeout "$retry_timeout" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
             ${agent_args[@]+"${agent_args[@]}"} \
             --model "$model" \
             ${fallback_args[@]+"${fallback_args[@]}"} \
@@ -1772,7 +1785,9 @@ run_stage() {
             --dangerously-skip-permissions \
             --output-format json \
             --json-schema "$schema" \
-            2>&1) || exit_code=$?
+            > "$_stage_raw" 2>&1 || exit_code=$?
+        output=$(cat "$_stage_raw")
+        rm -f "$_stage_raw"
 
         printf '%s\n' "$output" >> "$stage_log"
         printf '%s\n' "=== timeout retry exit code: $exit_code ===" >> "$stage_log"
@@ -2031,7 +2046,10 @@ for m in re.finditer(r'\[\s*\{', t):
             # the stage log.  Flow control is handled via structured output
             # extraction below, not via this value.
             local _esc_exit_code=0
-            output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
+            # Temp-file capture (see run_stage's primary launch) — avoids the
+            # command-substitution pipe-wedge when the CLI leaves a lingering child.
+            local _esc_raw; _esc_raw=$(mktemp)
+            timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
                 -p "$prompt" \
                 ${agent_args[@]+"${agent_args[@]}"} \
                 --model "$_esc_model" \
@@ -2040,7 +2058,8 @@ for m in re.finditer(r'\[\s*\{', t):
                 --dangerously-skip-permissions \
                 --output-format json \
                 --json-schema "$schema" \
-                2>&1) || _esc_exit_code=$?
+                > "$_esc_raw" 2>&1 || _esc_exit_code=$?
+            output=$(cat "$_esc_raw"); rm -f "$_esc_raw"
 
             result_model="$_esc_model"
             printf '%s\n' "=== $stage_name escalation output ===" >> "$stage_log"
@@ -2106,7 +2125,10 @@ for m in re.finditer(r'\[\s*\{', t):
                 "stage_attempt:=2"
 
             local _retry_exit_code=0
-            output=$(timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
+            # Temp-file capture (see run_stage's primary launch) — avoids the
+            # command-substitution pipe-wedge when the CLI leaves a lingering child.
+            local _retry_raw; _retry_raw=$(mktemp)
+            timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
                 -p "$prompt" \
                 ${agent_args[@]+"${agent_args[@]}"} \
                 --model "$model" \
@@ -2115,7 +2137,8 @@ for m in re.finditer(r'\[\s*\{', t):
                 --dangerously-skip-permissions \
                 --output-format json \
                 --json-schema "$schema" \
-                2>&1) || _retry_exit_code=$?
+                > "$_retry_raw" 2>&1 || _retry_exit_code=$?
+            output=$(cat "$_retry_raw"); rm -f "$_retry_raw"
 
             printf '%s\n' "=== $stage_name retry output ===" >> "$stage_log"
             printf '%s\n' "$output" >> "$stage_log"

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -7099,6 +7099,30 @@ $full_scope_failures
             fi
         fi
 
+        # ---------------------------------------------------------------------
+        # E2E-UNVALIDATED GUARD: the test loop above is unit-only when
+        # TEST_E2E_CMD is unset. If this branch changed Playwright e2e infra or
+        # specs, NONE of it was executed here — a runtime-only bug (e.g. #481's
+        # `await import()` of a .ts in globalSetup) passes tsc/lint/jest and
+        # merges broken. Surface it loudly (non-blocking) so a human runs
+        # Playwright before trusting the PR.
+        # ---------------------------------------------------------------------
+        if [[ -z "${TEST_E2E_CMD:-}" ]]; then
+            local e2e_changed
+            e2e_changed=$(git diff "$BASE_BRANCH"...HEAD --name-only 2>/dev/null \
+                | grep -E '^(tests/e2e/|playwright\.config\.)' || true)
+            if [[ -n "$e2e_changed" ]]; then
+                DEGRADED_STAGES+=("test:e2e_unvalidated")
+                comment_issue "E2E NOT validated by the test loop" \
+                    "⚠️ This branch changes Playwright e2e files, but \`TEST_E2E_CMD\` is unset so the test loop ran **unit tests only** — the e2e specs/infra here were **not executed**. tsc/lint/jest cannot catch runtime-only e2e bugs (e.g. a dynamic import of a \`.ts\` in globalSetup). **Run Playwright manually before trusting this PR.**
+
+\`\`\`
+$e2e_changed
+\`\`\`" "default"
+                log "WARN: e2e files changed but not validated (TEST_E2E_CMD unset) — recorded as degraded"
+            fi
+        fi
+
         set_stage_completed "test_loop"
         log "Test loop complete."
     fi

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -4325,6 +4325,20 @@ execute_batch_parallel() {
 			continue
 		fi
 
+		# Silent no-op guard: a subagent can self-report
+		# {"status":"success"} yet commit nothing to its worktree. Merging an
+		# empty branch is a git no-op ("Already up to date", rc 0), so without
+		# this check the task is counted "completed" and the issue sails to a
+		# false-green PR with the intended changes never landed. Treat an empty
+		# worktree branch as a failed task so it surfaces in the task summary.
+		if [[ -z "$(git rev-list "${feature_branch}..${wb}" 2>/dev/null)" ]]; then
+			log_error "Task $tid reported success but produced no commits" \
+				"— marking failed (silent no-op guard)"
+			failed+=("$tid")
+			cleanup_worktree "$wp" "$wb"
+			continue
+		fi
+
 		# Attempt merge
 		if merge_worktree_branch \
 			"$feature_branch" "$wb" "$tid"; then
@@ -7048,23 +7062,29 @@ $impl_summary" "$tagent"
             "$branch_scope" "$max_task_size" "$pipeline_profile"
 
         # ---------------------------------------------------------------------
-        # NON-BLOCKING FULL-SCOPE CHECK (informational only)
-        # After PR tests pass, run jest --changedSince once to surface any
-        # pre-existing failures pulled in by the dependency graph.  This does
-        # NOT block the pipeline — failures are posted as an informational
-        # issue comment so maintainers are aware.
+        # NON-BLOCKING FULL-SUITE CHECK (informational + degraded-stage signal)
+        # The smart-targeted test_loop only runs tests related to the changed
+        # files, so a suite broken without a related change — e.g. a task that
+        # should have fixed it but produced nothing (see #468) — can pass the
+        # loop yet leave `npm test` red. Run the FULL suite ($TEST_UNIT_CMD)
+        # once here to surface that; --changedSince shares the same dependency-
+        # graph blind spot and would miss it. Kept NON-BLOCKING because the base
+        # branch itself may legitimately be red; failures are posted as a comment
+        # AND recorded in DEGRADED_STAGES so they show up in the pipeline summary
+        # instead of being silently reported green.
         # ---------------------------------------------------------------------
         if [[ "$branch_scope" == "typescript" || "$branch_scope" == "mixed" || "$branch_scope" == "ts-frontend" ]]; then
-            log "Running informational full-scope check (non-blocking)..."
+            log "Running informational full-suite check (non-blocking)..."
             local full_scope_output full_scope_rc
-            full_scope_output=$(cd "." && npx jest --passWithNoTests --changedSince="$BASE_BRANCH" 2>&1) || true
+            full_scope_output=$(cd "." && eval "${TEST_UNIT_CMD:-npm test}" 2>&1) || true
             full_scope_rc=$?
 
             if (( full_scope_rc != 0 )); then
                 local full_scope_failures
                 full_scope_failures=$(printf '%s' "$full_scope_output" | tail -40)
-                comment_issue "Full-Scope Check: Pre-existing Failures (informational)" \
-                    "ℹ️ A full \`jest --changedSince=$BASE_BRANCH\` run found additional failures outside the PR-changed test files. These are **pre-existing** and do **not** block this pipeline.
+                DEGRADED_STAGES+=("test:full_suite_red")
+                comment_issue "Full-Suite Check: test suite is RED (non-blocking)" \
+                    "⚠️ The full \`${TEST_UNIT_CMD:-npm test}\` run failed on this branch. The smart-targeted test loop only runs tests related to the changed files, so these failures were not caught there. They may be **pre-existing on \`$BASE_BRANCH\`** OR failures this PR was expected to fix — **review before merge; do not assume green.**
 
 <details>
 <summary>Failure details (last 40 lines)</summary>
@@ -7073,9 +7093,9 @@ $impl_summary" "$tagent"
 $full_scope_failures
 \`\`\`
 </details>" "default"
-                log "INFO: Full-scope check found pre-existing failures (non-blocking)"
+                log "WARN: Full-suite check found failures (non-blocking, recorded as degraded)"
             else
-                log "Full-scope check passed — no additional failures"
+                log "Full-suite check passed — $TEST_UNIT_CMD is green on this branch"
             fi
         fi
 

--- a/.claude/scripts/implement-issue-test/test-task-batching.bats
+++ b/.claude/scripts/implement-issue-test/test-task-batching.bats
@@ -864,6 +864,68 @@ _setup_parallel_stage_mocks() {
 	git branch -D wt-task-11 2>/dev/null || true
 }
 
+@test "execute_batch_parallel: success-reported task with no commit lands in failed (no-op guard)" {
+	cd "$TEST_TMP/repo" || exit 1
+	# Clean slate: drop any residue from a prior run so the result is deterministic.
+	git checkout -q main 2>/dev/null || true
+	git worktree prune 2>/dev/null || true
+	git branch -D feature/noop-guard 2>/dev/null || true
+	git branch -D wt-task-20 2>/dev/null || true
+	git checkout -q -b feature/noop-guard main
+
+	mkdir -p "$LOG_BASE/stages"
+	mkdir -p "$LOG_BASE/worktrees"
+
+	printf 'base\n' > base.ts
+	git add base.ts
+	git commit -q -m "add base"
+
+	# A subagent that claims success but commits NOTHING to its worktree.
+	# Without the no-op guard the empty branch merges as "Already up to date"
+	# and the task is wrongly counted completed.
+	run_task_in_worktree() {
+		local task_id="$1"
+		local wt_path="$5"
+		local result_file="$8"
+		cd "$wt_path" || {
+			printf '%s' '{"status":"failed","review_attempts":0}' > "$result_file"
+			return 1
+		}
+		# Intentionally no git commit — branch stays at the feature base.
+		printf '{"status":"success","review_attempts":1,"commit":"none","summary":"claimed done but changed nothing"}' \
+			> "$result_file"
+	}
+	extract_task_size() { printf '%s' "S"; }
+	export -f run_task_in_worktree
+	export -f extract_task_size
+
+	local tasks
+	tasks='[
+		{"id":20,"description":"Should change something","agent":"default","batch":1}
+	]'
+
+	local result
+	result=$(execute_batch_parallel 1 "$tasks" \
+		"feature/noop-guard" "main" \
+		2>/dev/null) || true
+
+	local failed_count completed_count
+	failed_count=$(printf '%s' "$result" | jq '.failed | length' 2>/dev/null)
+	completed_count=$(printf '%s' "$result" | jq '.completed | length' 2>/dev/null)
+
+	# Clean up BEFORE asserting so the assertions are the test's last commands
+	# (bats only fails a test on its final command's exit code — trailing
+	# cleanup would otherwise mask an assertion failure).
+	git worktree prune 2>/dev/null || true
+	git checkout -q main 2>/dev/null || true
+	git branch -D feature/noop-guard 2>/dev/null || true
+	git branch -D wt-task-20 2>/dev/null || true
+
+	# The no-op task must be classified failed, NOT completed.
+	[[ "$failed_count" -eq 1 ]]
+	[[ "$completed_count" -eq 0 ]]
+}
+
 @test "conflicted tasks from parallel can be re-run serially with same outcome" {
 	cd "$TEST_TMP/repo" || exit 1
 	git checkout -q -b feature/conf-retry main


### PR DESCRIPTION
## Context
Surfaced in a project run (RTR Hubspot-CurrentRMS, issue #468) where `implement-issue` shipped a **green PR that fixed only 2 of 5 target test suites** — the pipeline reported success while `npm test` was still red.

## Two root causes + fixes

### 1. Silent no-op parallel tasks counted as completed
`execute_batch_parallel` gated only on a task's self-reported `{"status":"success"}`, then merged its worktree branch. A subagent that claims success but **commits nothing** leaves an empty branch; `git merge` returns "Already up to date" (rc 0), so the task was counted `completed` and the issue sailed to a false-green PR.

**Fix:** before merging, if the task's worktree branch has no commits ahead of the feature branch, mark it **failed** (surfaced via `_process_batch_results`).

### 2. Post-loop 'full-scope check' wasn't full-scope
The smart-targeted `test_loop` only runs tests related to changed files. The existing post-loop check used `jest --changedSince`, which shares the **same dependency-graph blind spot** — a suite broken without a related change (e.g. one a dropped task should have fixed) was never run.

**Fix:** run the real full suite (`$TEST_UNIT_CMD`) and record `DEGRADED_STAGES+=(test:full_suite_red)` on failure so it shows in the pipeline summary. **Kept non-blocking** — the base branch can legitimately be red, so blocking here would freeze the pipeline.

## Test plan
- `bash -n` clean on the orchestrator.
- New **RED-GREEN** regression test in `test-task-batching.bats`: `not ok` without the guard (no-op task lands in `.completed`), `ok` with it (lands in `.failed`). Verified by reverting the guard.
- `test-smart-test-targeting.bats` green; no new regressions (the pre-existing `execute_batch_serial` / `implement loop` reds fail on the base commit too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)