### PR TITLE
fix(process-pr): fix agent lookup table + Deploy Verification in follow-up issues

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -100,6 +100,24 @@ If there are no follow-up items, write: `_None._`
 
 > **Rule:** Any issue that does not appear in `## Blocking Issues` MUST appear in `## Follow-up Only`, or be explicitly omitted with a reason. Do NOT mix blocking and non-blocking items in the same section.
 
+## Follow-up Issue Format
+
+When `process-pr` creates issues from your `## Follow-up Only` items, the `## Implementation Tasks` section is **machine-parsed by the implement-issue orchestrator**. Wrong agent names or missing file paths cause tasks to be silently skipped or routed to the wrong specialist.
+
+**Valid pipeline agents — use ONLY these names:**
+
+| Agent | Use for |
+|-------|---------|
+| `[fastify-backend-developer]` | API routes, services, backend logic |
+| `[react-frontend-developer]` | React components, pages, CSS, hooks |
+| `[bash-script-craftsman]` | Shell scripts, CI scripts |
+| `[playwright-test-developer]` | Playwright E2E tests ONLY |
+| `[default]` | Unit tests, config, documentation |
+
+**NEVER write:** `[fullstack-engineer]` (not a pipeline agent — silently demoted to `[default]`), `[test-engineer]` (legacy alias — use `[playwright-test-developer]` for E2E or `[default]` for unit tests).
+
+Your `## Follow-up Only` item format (file and line) maps directly to the `$FILE_PATH` and `$AGENT` in the created issue. The more precise your file reference, the better the auto-created issue will be routed.
+
 <!-- STACK-SPECIFIC: Add technology-specific review checklists below for your project's stack.
 Example checklist format:
 

--- a/.claude/skills/process-pr/SKILL.md
+++ b/.claude/skills/process-pr/SKILL.md
@@ -373,10 +373,16 @@ Before building either template, extract these two values from the review commen
    | File pattern | `$AGENT` |
    |---|---|
    | `*.sh`, `*.bash`, `*.bats` | `bash-script-craftsman` |
-   | `*.test.*`, `*.spec.*` | `test-engineer` |
-   | `.claude/skills/**/*.md` | `default` |
-   | `src/routes/**`, `src/api/**` | `api-design-specialist` |
+   | `apps/frontend/**`, `src/components/**`, `*.tsx` (non-test) | `react-frontend-developer` |
+   | `apps/backend/**`, `src/routes/**`, `src/services/**`, `src/api/**` | `fastify-backend-developer` |
+   | `*.test.*`, `*.spec.*` (Playwright/E2E) | `playwright-test-developer` |
+   | `*.test.*`, `*.spec.*` (Jest/unit) | `default` |
+   | `.claude/skills/**/*.md`, `.claude/scripts/**` | `default` |
    | Fallback (any other) | `default` |
+
+   **NEVER write these agent names** — they are invalid and will silently downgrade tasks to `[default]`, losing specialist routing:
+   - `[fullstack-engineer]` — not a pipeline agent; split into `[fastify-backend-developer]` (data layer) + `[react-frontend-developer]` (UI layer)
+   - `[test-engineer]` — legacy alias; use `[playwright-test-developer]` for E2E tests, `[default]` for unit tests
 
 3. **Measurable ACs** — replace generic placeholders with specific, observable outcomes:
    - Name the exact function or behaviour: prefer `$FUNCTION_NAME in $FILE_PATH handles $EDGE_CASE` over `$ISSUE_TITLE is implemented`
@@ -402,6 +408,9 @@ For each extracted issue (after deduplication check passes), route by classifica
 
 ```bash
 PLATFORM_DIR=".claude/scripts/platform"
+# Read DEPLOY_VERIFY_CMD so the issue body includes the correct verification command
+DEPLOY_VERIFY_CMD=$(bash -c 'source .claude/config/platform.sh 2>/dev/null; echo "${DEPLOY_VERIFY_CMD:-}"')
+
 "$PLATFORM_DIR/create-issue.sh" --title "$ISSUE_TITLE" --body "$(cat <<'EOF'
 <!-- pipeline-autocreated -->
 ## Context
@@ -412,6 +421,10 @@ $EXTRACTED_DESCRIPTION
 
 ## Implementation Tasks
 - [ ] `[$AGENT]` **(S)** $INFERRED_TASK_DESCRIPTION — `$FILE_PATH`
+
+## Deploy Verification
+
+**Verification command:** $DEPLOY_VERIFY_CMD
 
 ## Acceptance Criteria
 - [ ] `$FILE_PATH`: $INFERRED_TASK_DESCRIPTION produces the expected behaviour (specify the exact output or observable state change)
@@ -424,6 +437,10 @@ $EXTRACTED_DESCRIPTION
 EOF
 )" --labels "${LABELS}"
 ```
+
+Where `$AGENT` is selected from the agent table above based on what `$FILE_PATH` touches, and `$FILE_PATH` includes the line number from the review comment (e.g. `apps/backend/src/routes/scenarios.ts:L4948`).
+
+If `$DEPLOY_VERIFY_CMD` is empty, omit the `## Deploy Verification` section entirely.
 
 Log each: `Created follow-up issue #XXX: "$TITLE"`
 


### PR DESCRIPTION
## Summary

- `process-pr` agent table mapped `*.test.*` → `test-engineer` (legacy alias) and lacked `apps/frontend/**` and `apps/backend/**` entries — auto-created follow-up issues used `[fullstack-engineer]` and `[test-engineer]`, which the orchestrator normaliser silently demotes to `[default]`
- Precise follow-up template was missing `## Deploy Verification`, which the orchestrator body-scan gate requires when `DEPLOY_VERIFY_CMD` is set
- `code-reviewer.md` had no guidance on valid agent names when writing follow-up items

## Changes

**`skills/process-pr/SKILL.md`**
- Fix `$AGENT` lookup table: `*.test.*` → `playwright-test-developer` (E2E) or `default` (unit), add `apps/frontend/**` → `react-frontend-developer`, `apps/backend/**`/`src/routes/**` → `fastify-backend-developer`
- Add explicit NEVER write guard for `[fullstack-engineer]` and `[test-engineer]`
- Add `DEPLOY_VERIFY_CMD` read + `## Deploy Verification` block to precise follow-up template

**`agents/code-reviewer.md`**
- Add `## Follow-up Issue Format` section with the same valid-agent table and NEVER write guard

## Evidence

Batch run 2026-06-21 on beegee-farm-3 produced 6 auto-created follow-up issues; 4 had wrong agents and missing Deploy Verification sections, requiring manual repair before `/implement-issue` could execute them:

| Issue | Wrong agent(s) | Root cause |
|-------|---------------|------------|
| #4191 | 3× `[fullstack-engineer]` | No backend path in table |
| #4192 | `[test-engineer]` | Legacy alias in test row |
| #4195 | `[fullstack-engineer]` + `[test-engineer]` | No frontend path; legacy test alias |
| #4204 | (agent ok, but missing Deploy Verification) | Template lacked the section |

## Test plan
- [ ] Run `process-pr` on a test branch; verify follow-up issues use `[fastify-backend-developer]` for backend findings and `[react-frontend-developer]` for frontend findings
- [ ] Verify `## Deploy Verification` appears in created issues when `DEPLOY_VERIFY_CMD` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)