### PR TITLE
feat(hooks): PreToolUse guard forbidding direct gh-issue-creation

### DIFF
--- a/.claude/hooks/block-gh-issue-create.sh
+++ b/.claude/hooks/block-gh-issue-create.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# block-gh-issue-create.sh — PreToolUse(Bash) guard.
+#
+# Hard-blocks any agent Bash command that invokes `gh issue create`
+# directly, forcing all issue creation through create-followup-issue.sh /
+# platform/create-issue.sh, which run `assert_issue_valid` fail-closed.
+#
+# Rationale: #501 made "never call gh issue create" a SKILL instruction and
+# #513 removed the permission friction that drove the fallback, but neither
+# is a hard technical gate — a confused agent could still shell out to
+# `gh issue create` with an unvalidated (prose) body, producing malformed
+# issues that stall the pipeline. This hook makes that impossible.
+#
+# Why this does NOT block the legitimate scripts:
+#   PreToolUse(Bash) fires on the command the AGENT runs. When the agent runs
+#   `.claude/scripts/create-followup-issue.sh ...`, that is the command the
+#   hook inspects; the script's INTERNAL `gh issue create` runs as a
+#   subprocess of the script, never as a Bash-tool call, so the hook never
+#   sees it. Only a direct agent `gh issue create` is matched.
+#
+# Code is passed via `python3 -c` (not a heredoc) so the hook's stdin remains
+# the PreToolUse JSON payload. Exit 2 blocks (stderr surfaced to the model);
+# exit 0 allows. Malformed payloads fail OPEN (never block unrelated tools).
+
+exec python3 -c '
+import json, re, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+cmd = (data.get("tool_input", {}) or {}).get("command", "") or ""
+# Match `gh issue create` only at a COMMAND position: start of command or
+# after a separator (; & | && || newline opening-paren), tolerant of leading
+# env-var assignments and env/sudo/command/nice/nohup wrappers (including the
+# `env -u VAR` / `env --unset VAR` two-token option forms).
+#
+# Anchoring to a command boundary is deliberate: a bare \bgh...\b search also
+# matches the phrase inside a quoted argument (e.g. a git commit message or an
+# echo/grep that merely mentions "gh issue create"), causing annoying false
+# blocks. The wrapper scripts are invoked by PATH (".../create-issue.sh") so
+# their command never starts with `gh issue create`; their INTERNAL gh call is
+# a script subprocess the hook never sees.
+pattern = re.compile(
+    r"(?:^|[;&|\n(]|&&|\|\|)\s*"
+    r"(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*"
+    r"(?:(?:sudo|command|nohup|nice)\s+)*"
+    r"(?:env\s+(?:-u\s+\S+\s+|--unset\s+\S+\s+|-\S+\s+|[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?"
+    r"gh\s+issue\s+create\b")
+if pattern.search(cmd):
+    sys.stderr.write(
+        "BLOCKED: direct gh issue create is prohibited. Create issues via "
+        ".claude/scripts/create-followup-issue.sh (follow-ups) or "
+        ".claude/scripts/platform/create-issue.sh — they run assert_issue_valid "
+        "fail-closed so every issue has parseable tasks + acceptance criteria. "
+        "See .claude/skills/process-pr/SKILL.md Step 4g.\n")
+    sys.exit(2)
+sys.exit(0)
+'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,6 +55,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-destructive-db-commands.sh\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-gh-issue-create.sh\"",
+            "timeout": 5
           }
         ]
       }

--- a/tests/block-gh-issue-create.bats
+++ b/tests/block-gh-issue-create.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+#
+# block-gh-issue-create.bats
+# Verifies the PreToolUse(Bash) guard at
+# .claude/hooks/block-gh-issue-create.sh hard-blocks direct `gh issue create`
+# invocations (exit 2) while allowing the validated wrapper scripts and every
+# other gh subcommand (exit 0).
+#
+# The hook exists because #501 (SKILL instruction) and #513 (permission
+# allowlist) are soft guardrails; this hook is the hard technical gate that
+# forces all issue creation through create-followup-issue.sh /
+# platform/create-issue.sh, which run assert_issue_valid fail-closed.
+
+HOOK="${BATS_TEST_DIRNAME}/../.claude/hooks/block-gh-issue-create.sh"
+
+# Run the hook with a given Bash command as the PreToolUse payload.
+# Sets $status (0 = allow, 2 = block).
+_run_hook() {
+	local cmd="$1"
+	run bash -c "printf '%s' \"\$1\" | jq -Rn '{tool_input:{command:input}}' | bash '$HOOK'" _ "$cmd"
+}
+
+@test "hook exists and is executable" {
+	[ -f "$HOOK" ]
+	[ -x "$HOOK" ]
+}
+
+# ---------------------------------------------------------------------------
+# BLOCK — direct gh issue create in any form
+# ---------------------------------------------------------------------------
+
+@test "blocks plain gh issue create" {
+	_run_hook 'gh issue create --title x --body y'
+	[ "$status" -eq 2 ]
+}
+
+@test "blocks gh issue create with leading env-var assignment" {
+	_run_hook 'FOO=bar gh issue create --title x'
+	[ "$status" -eq 2 ]
+}
+
+@test "blocks gh issue create chained after another command" {
+	_run_hook 'cd /tmp && gh issue create --title x'
+	[ "$status" -eq 2 ]
+}
+
+@test "blocks gh issue create behind an env -u prefix" {
+	_run_hook 'env -u CLAUDECODE gh issue create --title x'
+	[ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# ALLOW — validated wrappers and unrelated gh subcommands
+# ---------------------------------------------------------------------------
+
+@test "allows the create-followup-issue.sh wrapper" {
+	_run_hook '.claude/scripts/create-followup-issue.sh --title x --file-path .'
+	[ "$status" -eq 0 ]
+}
+
+@test "allows the platform create-issue.sh wrapper" {
+	_run_hook '.claude/scripts/platform/create-issue.sh --title x'
+	[ "$status" -eq 0 ]
+}
+
+@test "allows gh issue list" {
+	_run_hook 'gh issue list --state open'
+	[ "$status" -eq 0 ]
+}
+
+@test "allows gh issue view" {
+	_run_hook 'gh issue view 506'
+	[ "$status" -eq 0 ]
+}
+
+@test "allows gh issue comment" {
+	_run_hook 'gh issue comment 5 --body hi'
+	[ "$status" -eq 0 ]
+}
+
+@test "allows gh pr create" {
+	_run_hook 'gh pr create --title x --body y'
+	[ "$status" -eq 0 ]
+}
+
+@test "allows an unrelated command" {
+	_run_hook 'echo hello'
+	[ "$status" -eq 0 ]
+}
+
+@test "allows the phrase inside a quoted argument (git commit message)" {
+	# The phrase appears only inside a -m argument, not at a command
+	# position — must NOT be blocked.
+	_run_hook 'git commit -m "feat: hard-block direct gh issue create"'
+	[ "$status" -eq 0 ]
+}
+
+@test "allows echo/grep that merely mention the phrase" {
+	_run_hook 'echo "do not run gh issue create directly"'
+	[ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Robustness — malformed payload must fail OPEN (never block unrelated tools)
+# ---------------------------------------------------------------------------
+
+@test "fails open on malformed JSON payload" {
+	run bash -c "printf 'not json' | bash '$HOOK'"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
Hard technical gate that blocks any agent Bash command invoking the gh issue-create subcommand directly, forcing all issue creation through `create-followup-issue.sh` / `platform/create-issue.sh` (which run `assert_issue_valid` fail-closed).

This is the third and strongest layer of the malformed-issue defense, after #501 (SKILL instruction) and #513 (permission allowlist) — both *soft* guardrails. With this hook, no agent can create an unvalidated issue regardless of instructions or permission state.

## Changes
- `.claude/hooks/block-gh-issue-create.sh` — PreToolUse(Bash) guard. Exit 2 blocks; exit 0 allows; malformed payloads fail open.
- `.claude/settings.json` — wired into the PreToolUse Bash matcher (propagates to consumer repos via sync).
- `tests/block-gh-issue-create.bats` — 15 cases.

## Design notes
- **Command-boundary anchored:** matches the subcommand only at a command position (start / after a separator), tolerant of env-var assignments and `env -u VAR`/`sudo` prefixes. The phrase inside a quoted argument (commit messages, echo/grep) is NOT blocked — verified by tests.
- **Wrappers stay allowed:** they're invoked by path, and their internal gh call is a script subprocess the PreToolUse hook never sees.

## Verification
`bats tests/block-gh-issue-create.bats` → 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)