### PR TITLE
test(quality-loop): fix convergence assertion to read .state (last red test → suite green)

### DIFF
--- a/.claude/scripts/implement-issue-test/test-quality-loop.bats
+++ b/.claude/scripts/implement-issue-test/test-quality-loop.bats
@@ -1140,11 +1140,12 @@ HIST_EOF
         fail "Expected DEGRADED_STAGES to contain quality:convergence_failure entry; got: ${DEGRADED_STAGES[*]:-<empty>}"
 
     # set_final_state must have been called with convergence_failure_quality so
-    # the status file reflects the degraded outcome.
+    # the status file reflects the degraded outcome. set_final_state writes the
+    # value to the `.state` field (not `.final_state`).
     local final_state
-    final_state=$(jq -r '.final_state // empty' "$STATUS_FILE")
+    final_state=$(jq -r '.state // empty' "$STATUS_FILE")
     [[ "$final_state" == "convergence_failure_quality" ]] || \
-        fail "Expected final_state=convergence_failure_quality in status.json, got: $final_state"
+        fail "Expected .state=convergence_failure_quality in status.json, got: $final_state"
 }
 
 @test "convergence detection does NOT exit when <=33% issues are repeats" {


### PR DESCRIPTION
The final failing test in the implement-issue-test suite. `set_final_state()` writes to `.state`, but the test read `.final_state` → always empty → fail. One-line key fix.

After #535 (143→1) + this, `run-tests.sh` is **0 failures**. Confirmed locally: test-quality-loop.bats 77/77 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)