### PR TITLE
fix: transition-issue.sh unbound JIRA_DONE_TRANSITION on GitHub tracker path

### DIFF
--- a/.claude/scripts/platform/transition-issue.sh
+++ b/.claude/scripts/platform/transition-issue.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../../config/platform.sh"
 
 ISSUE="$1"
-TRANSITION="${2:-$JIRA_DONE_TRANSITION}"
+TRANSITION="${2:-${JIRA_DONE_TRANSITION:-}}"
 
 case "$TRACKER" in
   github) gh issue close "$ISSUE" ;;


### PR DESCRIPTION
## Summary
Under `set -u`, `TRANSITION="${2:-$JIRA_DONE_TRANSITION}"` expands `JIRA_DONE_TRANSITION` even when `TRACKER=github`, so the script hard-fails with `unbound variable` on any GitHub-only project unless a transition name is passed as the second argument — even though the GitHub branch never uses it.

One-line fix: `TRANSITION="${2:-${JIRA_DONE_TRANSITION:-}}"`.

## Context
Surfaced during a handle-issues batch in the AA-astro project: process-pr's issue transition step errored after merging a PR. It was masked there because GitHub auto-closed the issue via the closing keyword, but the script fails hard on any repo where the PR body doesn't auto-close the issue.

## Test plan
- `bash -n` passes
- With a mocked `gh` on PATH and no second argument: `transition-issue.sh 999` → `gh issue close 999` (previously: unbound variable error)
- Jira path unchanged: explicit second argument still wins; `JIRA_DONE_TRANSITION` still used as default when set