### PR TITLE
feat(issue-580): per-stage token/cost accounting in status.json/metrics

### DIFF
--- a/.claude/scripts/batch-orchestrator.sh
+++ b/.claude/scripts/batch-orchestrator.sh
@@ -423,7 +423,8 @@ init_status() {
             "deploy_verify_failed": false,
             "started_at": null,
             "stage_started_at": null,
-            "completed_at": null
+            "completed_at": null,
+            "cost_usd": 0
         }]')
     done
 
@@ -453,6 +454,9 @@ init_status() {
                 in_progress: 0
             },
             issues: $issues,
+            cost_summary: {
+                total_cost_usd: ($issues | map(.cost_usd // 0) | add // 0)
+            },
             rate_limit: {
                 waiting: false,
                 resume_at: null,
@@ -505,6 +509,8 @@ update_progress() {
             ([.issues[] | select(.status == "in_progress")] | length) |
         .progress.pending =
             ([.issues[] | select(.status == "pending")] | length) |
+        .cost_summary.total_cost_usd =
+            ([.issues[] | (.cost_usd // 0)] | add // 0) |
         .last_update = (now | todate)' \
         "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
 }
@@ -1136,6 +1142,19 @@ process_issue() {
 
     log "implement-issue status: $impl_status, PR: ${pr_number:-none}"
 
+    # Cost accounting: the sub-orchestrator aggregates the cost of every
+    # CLI call it makes into a run-level cost_summary on its own status
+    # file. Record it now — before any early return below — so partial
+    # runs (skipped/merge_blocked/failed) still surface their spend in
+    # the batch cost_summary rollup. `// 0` degrades to zero when the
+    # field is absent rather than corrupting status.json.
+    local impl_cost_usd="0"
+    if [[ -f "$issue_status_file" ]]; then
+        impl_cost_usd=$(jq -r '.cost_summary.total_cost_usd // 0' \
+            "$issue_status_file" 2>/dev/null) || impl_cost_usd="0"
+    fi
+    update_issue_field "$issue_num" "cost_usd" "$impl_cost_usd" "true"
+
     # Log location of metrics.json emitted by the orchestrator's EXIT trap
     if [[ -f "$issue_status_file" ]]; then
         local issue_log_dir
@@ -1491,7 +1510,8 @@ sweep_implement_followups() {
 					"deploy_verify_failed": false,
 					"started_at": null,
 					"stage_started_at": null,
-					"completed_at": null
+					"completed_at": null,
+					"cost_usd": 0
 				}]
 				| .progress.total = (.progress.total + 1)
 				| .progress.pending = (.progress.pending + 1)

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -730,7 +730,27 @@ set_stage_completed() {
     sync_status_to_log
     # Schema enum for stage_end.status is ["success","error","rate_limit"];
     # "completed" is the status.json column name, not the event-stream value.
-    emit_event "stage_end" "stage=$stage" "status=success"
+    #
+    # When per-stage token/cost data is available, thread it onto the
+    # stage_end event so events.jsonl carries per-stage spend (issue #580).
+    # `:=` passes JSON-typed (numeric) values; the schema's stage_end branch
+    # declares these fields optional so events without them still validate.
+    local -a _stage_end_args=("stage=$stage" "status=success")
+    if [[ -n "$tokens_json" ]]; then
+        local _end_in _end_out _end_cache_creation _end_cache_read
+        _end_in=$(printf '%s' "$tokens_json" | jq -r '.input_tokens // 0' 2>/dev/null)
+        _end_out=$(printf '%s' "$tokens_json" | jq -r '.output_tokens // 0' 2>/dev/null)
+        _end_cache_creation=$(printf '%s' "$tokens_json" | jq -r '.cache_creation_input_tokens // 0' 2>/dev/null)
+        _end_cache_read=$(printf '%s' "$tokens_json" | jq -r '.cache_read_input_tokens // 0' 2>/dev/null)
+        _stage_end_args+=(
+            "input_tokens:=${_end_in:-0}"
+            "output_tokens:=${_end_out:-0}"
+            "cache_creation_input_tokens:=${_end_cache_creation:-0}"
+            "cache_read_input_tokens:=${_end_cache_read:-0}"
+            "estimated_cost:=${estimated_cost:-0}"
+        )
+    fi
+    emit_event "stage_end" "${_stage_end_args[@]}"
 }
 
 set_stage_failed() {

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -818,12 +818,37 @@ set_stage_completed() {
             .stages[$stage].status = "completed" |
             .stages[$stage].tokens = $tokens |
             .stages[$stage].estimated_cost = $estimated_cost |
+            # Roll every stage'"'"'s tokens/estimated_cost up into the run-level
+            # top-level cost_summary NOW (issue #580). Recomputed from .stages[]
+            # on every completion — idempotent and resume-safe (re-derived, not
+            # incremented, so re-running a stage never double-counts). This
+            # makes status.json the canonical live per-run cost source that
+            # batch-orchestrator.sh reads (metrics.json stays the final
+            # artifact, written by export_metrics). Field names match
+            # init_status'"'"'s seed and metrics.json. `// 0` guards throughout.
+            .cost_summary = {
+                total_input_tokens:          ([.stages[]?.tokens.input_tokens // 0] | add // 0),
+                total_output_tokens:         ([.stages[]?.tokens.output_tokens // 0] | add // 0),
+                total_cache_read_tokens:     ([.stages[]?.tokens.cache_read_input_tokens // 0] | add // 0),
+                total_cache_creation_tokens: ([.stages[]?.tokens.cache_creation_input_tokens // 0] | add // 0),
+                total_cost_usd:              ([.stages[]?.estimated_cost // 0] | add // 0)
+            } |
             .last_update = (now | todate)' \
            "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
     else
+        # No token data for this stage — still recompute the top-level
+        # cost_summary from .stages[] so it stays consistent with whatever
+        # other stages have recorded (issue #580).
         jq --arg stage "$stage" \
            '.stages[$stage].completed_at = (now | todate) |
             .stages[$stage].status = "completed" |
+            .cost_summary = {
+                total_input_tokens:          ([.stages[]?.tokens.input_tokens // 0] | add // 0),
+                total_output_tokens:         ([.stages[]?.tokens.output_tokens // 0] | add // 0),
+                total_cache_read_tokens:     ([.stages[]?.tokens.cache_read_input_tokens // 0] | add // 0),
+                total_cache_creation_tokens: ([.stages[]?.tokens.cache_creation_input_tokens // 0] | add // 0),
+                total_cost_usd:              ([.stages[]?.estimated_cost // 0] | add // 0)
+            } |
             .last_update = (now | todate)' \
            "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
     fi

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -1561,6 +1561,22 @@ _extract_usage() {
 #   $5 - model:            resolved model id (e.g. haiku|sonnet|opus)
 #   $6 - error_kind_json:  "null" or JSON-encoded string (e.g. "\"timeout\"")
 #   $7 - elapsed_ms:       integer milliseconds
+#   $8 - usage_json:       (optional) JSON object from _extract_usage — token
+#                          counts + the CLI's reported total_cost_usd. Defaults
+#                          to a zeroed object when omitted so older/partial
+#                          call sites still produce a valid envelope.
+#
+# The envelope carries two cost-accounting fields derived from $8 (issue #580):
+#   .tokens - token counts only (input/output/cache_creation/cache_read),
+#             lifted straight out of usage_json for downstream persistence
+#             (e.g. set_stage_completed's tokens arg).
+#   .cost   - {reported_usd, computed_usd, estimated_usd}. reported_usd is
+#             the CLI's own total_cost_usd; computed_usd is priced from the
+#             token counts via _model_cost (model-config.sh) using the
+#             envelope's resolved model; estimated_usd prefers reported_usd
+#             and falls back to computed_usd when the CLI didn't report one
+#             (e.g. a response emitted before usage accrued) — see the
+#             risk mitigation in issue #580's evaluation section.
 _emit_stage_result() {
     local status="$1"
     local output_json="$2"
@@ -1569,6 +1585,24 @@ _emit_stage_result() {
     local model="$5"
     local error_kind_json="$6"
     local elapsed_ms="$7"
+    local usage_json="${8:-}"
+
+    if [[ -z "$usage_json" || "$usage_json" == "null" ]]; then
+        usage_json='{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"total_cost_usd":0}'
+    fi
+
+    local input_tokens output_tokens cache_creation_tokens cache_read_tokens reported_usd
+    input_tokens=$(printf '%s' "$usage_json" | jq -r '.input_tokens // 0' 2>/dev/null)
+    output_tokens=$(printf '%s' "$usage_json" | jq -r '.output_tokens // 0' 2>/dev/null)
+    cache_creation_tokens=$(printf '%s' "$usage_json" | jq -r '.cache_creation_input_tokens // 0' 2>/dev/null)
+    cache_read_tokens=$(printf '%s' "$usage_json" | jq -r '.cache_read_input_tokens // 0' 2>/dev/null)
+    reported_usd=$(printf '%s' "$usage_json" | jq -r '.total_cost_usd // 0' 2>/dev/null)
+
+    local computed_usd
+    computed_usd=$(_model_cost "$model" \
+        "${input_tokens:-0}" "${output_tokens:-0}" \
+        "${cache_creation_tokens:-0}" "${cache_read_tokens:-0}" 2>/dev/null)
+    computed_usd="${computed_usd:-0}"
 
     jq -nc \
         --arg status "$status" \
@@ -1578,8 +1612,19 @@ _emit_stage_result() {
         --arg model "$model" \
         --argjson error_kind "$error_kind_json" \
         --argjson elapsed_ms "$elapsed_ms" \
+        --argjson input_tokens "${input_tokens:-0}" \
+        --argjson output_tokens "${output_tokens:-0}" \
+        --argjson cache_creation_tokens "${cache_creation_tokens:-0}" \
+        --argjson cache_read_tokens "${cache_read_tokens:-0}" \
+        --argjson reported_usd "${reported_usd:-0}" \
+        --argjson computed_usd "$computed_usd" \
         '{status: $status, output: $output, raw: $raw, denials: $denials,
-          model: $model, error_kind: $error_kind, elapsed_ms: $elapsed_ms}'
+          model: $model, error_kind: $error_kind, elapsed_ms: $elapsed_ms,
+          tokens: {input_tokens: $input_tokens, output_tokens: $output_tokens,
+                    cache_creation_input_tokens: $cache_creation_tokens,
+                    cache_read_input_tokens: $cache_read_tokens},
+          cost: {reported_usd: $reported_usd, computed_usd: $computed_usd,
+                 estimated_usd: (if $reported_usd > 0 then $reported_usd else $computed_usd end)}}'
 }
 
 # Apply a stage outcome action to a stage_result envelope.
@@ -1903,7 +1948,8 @@ run_stage() {
                 "success" "$timeout_structured" "$output" \
                 "$(_extract_denials "$output")" \
                 "$result_model" "null" \
-                "$(( $(_epoch_ms) - result_start_ms ))")
+                "$(( $(_epoch_ms) - result_start_ms ))" \
+                "$_stage_usage")
             _apply_stage_action "$_sr" "accept"
             return $?
         fi
@@ -1923,7 +1969,8 @@ run_stage() {
                 "success" "$timeout_fallback_result" "$output" \
                 "$(_extract_denials "$output")" \
                 "$result_model" "null" \
-                "$(( $(_epoch_ms) - result_start_ms ))")
+                "$(( $(_epoch_ms) - result_start_ms ))" \
+                "$_stage_usage")
             _apply_stage_action "$_sr" "accept"
             return $?
         fi
@@ -1998,6 +2045,10 @@ run_stage() {
 
         output=$(< "$_retry_out_tmp")
         rm -f "$_retry_out_tmp"
+
+        # Re-extract usage — output now reflects the retry attempt, not the
+        # original (likely-zeroed) timed-out attempt captured above.
+        _stage_usage=$(_extract_usage "$output")
 
         printf '%s\n' "$output" >> "$stage_log"
         printf '%s\n' "=== timeout retry exit code: $exit_code ===" >> "$stage_log"
@@ -2185,7 +2236,8 @@ for m in re.finditer(r'\[\s*\{', t):
         "$_interim_status" "${_interim_structured}" "$output" \
         "$(_extract_denials "$output")" \
         "$result_model" "$_error_kind_json" \
-        "$(( $(_epoch_ms) - result_start_ms ))")
+        "$(( $(_epoch_ms) - result_start_ms ))" \
+        "$_stage_usage")
 
     # Escalation history from status file
     local _history="[]"
@@ -2219,7 +2271,8 @@ for m in re.finditer(r'\[\s*\{', t):
                 "success" "$_interim_structured" "$output" \
                 "$(_extract_denials "$output")" \
                 "$result_model" "null" \
-                "$(( $(_epoch_ms) - result_start_ms ))")
+                "$(( $(_epoch_ms) - result_start_ms ))" \
+                "$_stage_usage")
             _apply_stage_action "$_sr_accept" "accept"
             return $?
             ;;
@@ -2285,6 +2338,11 @@ for m in re.finditer(r'\[\s*\{', t):
                 > "$_esc_raw" 2>&1 || _esc_exit_code=$?
             output=$(cat "$_esc_raw"); rm -f "$_esc_raw"
 
+            # Re-extract usage — output now reflects the escalated (pricier)
+            # model's attempt, so its tokens/cost must replace the original
+            # pre-escalation usage in the emitted envelope (issue #580).
+            _stage_usage=$(_extract_usage "$output")
+
             result_model="$_esc_model"
             printf '%s\n' "=== $stage_name escalation output ===" >> "$stage_log"
             printf '%s\n' "$output" >> "$stage_log"
@@ -2317,7 +2375,8 @@ for m in re.finditer(r'\[\s*\{', t):
                     "success" "$_esc_structured" "$output" \
                     "$(_extract_denials "$output")" \
                     "$result_model" "null" \
-                    "$(( $(_epoch_ms) - result_start_ms ))")
+                    "$(( $(_epoch_ms) - result_start_ms ))" \
+                    "$_stage_usage")
             else
                 emit_event "schema_validation_fail" \
                     "stage=$stage_name" \
@@ -2330,7 +2389,8 @@ for m in re.finditer(r'\[\s*\{', t):
                     "error" "null" "$output" \
                     "$(_extract_denials "$output")" \
                     "$result_model" '"no_structured_output"' \
-                    "$(( $(_epoch_ms) - result_start_ms ))")
+                    "$(( $(_epoch_ms) - result_start_ms ))" \
+                    "$_stage_usage")
             fi
             _apply_stage_action "$_sr_esc" "escalate" "$_da_reason"
             return $?
@@ -2369,6 +2429,11 @@ for m in re.finditer(r'\[\s*\{', t):
                 > "$_retry_raw" 2>&1 || _retry_exit_code=$?
             output=$(cat "$_retry_raw"); rm -f "$_retry_raw"
 
+            # Re-extract usage — output now reflects the retry attempt, not the
+            # rate-limited original, so the emitted envelope carries the retry's
+            # tokens/cost (issue #580).
+            _stage_usage=$(_extract_usage "$output")
+
             printf '%s\n' "=== $stage_name retry output ===" >> "$stage_log"
             printf '%s\n' "$output" >> "$stage_log"
             printf '%s\n' \
@@ -2392,13 +2457,15 @@ for m in re.finditer(r'\[\s*\{', t):
                     "success" "$_retry_structured" "$output" \
                     "$(_extract_denials "$output")" \
                     "$result_model" "null" \
-                    "$(( $(_epoch_ms) - result_start_ms ))")
+                    "$(( $(_epoch_ms) - result_start_ms ))" \
+                    "$_stage_usage")
             else
                 _sr_retry=$(_emit_stage_result \
                     "error" "null" "$output" \
                     "$(_extract_denials "$output")" \
                     "$result_model" '"no_structured_output"' \
-                    "$(( $(_epoch_ms) - result_start_ms ))")
+                    "$(( $(_epoch_ms) - result_start_ms ))" \
+                    "$_stage_usage")
             fi
             _apply_stage_action "$_sr_retry" "retry_same" "$_da_reason"
             return $?

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -637,7 +637,14 @@ init_status() {
             last_update: (now | todate),
             log_dir: $log_dir,
             merge_blocked_reason: null,
-            escalations: []
+            escalations: [],
+            cost_summary: {
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                total_cache_read_tokens: 0,
+                total_cache_creation_tokens: 0,
+                total_cost_usd: 0
+            }
         }' > "$STATUS_FILE"
 
     log "Initialized status file: $STATUS_FILE"

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -696,11 +696,30 @@ set_stage_started() {
 
 set_stage_completed() {
     local stage="$1"
-    jq --arg stage "$stage" \
-       '.stages[$stage].completed_at = (now | todate) |
-        .stages[$stage].status = "completed" |
-        .last_update = (now | todate)' \
-       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    local tokens_json="${2:-}"
+    local estimated_cost="${3:-}"
+
+    if [[ -n "$tokens_json" ]]; then
+        # Mirror the existing `.model` write (see run_stage's resolved-model
+        # persistence above): thread the stage_result envelope's tokens
+        # object and estimated cost onto the stage entry so per-stage spend
+        # survives into status.json/metrics.json (issue #580).
+        jq --arg stage "$stage" \
+           --argjson tokens "$tokens_json" \
+           --argjson estimated_cost "${estimated_cost:-0}" \
+           '.stages[$stage].completed_at = (now | todate) |
+            .stages[$stage].status = "completed" |
+            .stages[$stage].tokens = $tokens |
+            .stages[$stage].estimated_cost = $estimated_cost |
+            .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    else
+        jq --arg stage "$stage" \
+           '.stages[$stage].completed_at = (now | todate) |
+            .stages[$stage].status = "completed" |
+            .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    fi
     sync_status_to_log
     # Schema enum for stage_end.status is ["success","error","rate_limit"];
     # "completed" is the status.json column name, not the event-stream value.

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -1523,6 +1523,32 @@ _extract_denials() {
     fi
 }
 
+# Extract token usage and reported cost from raw CLI output as a JSON
+# object. Every field is guarded with `// 0` so a missing/null value
+# (e.g. an error response emitted before usage accrued) degrades to zero
+# rather than corrupting downstream status.json / stage_result consumers.
+# Returns a zeroed object when raw is empty, malformed, or jq fails.
+#
+# See issue #580: usage/total_cost_usd are already present in every
+# --output-format json response but were previously dropped on the floor.
+_extract_usage() {
+    local raw="$1"
+    local usage
+    usage=$(printf '%s' "$raw" \
+        | jq -c '{
+            input_tokens: (.usage.input_tokens // 0),
+            output_tokens: (.usage.output_tokens // 0),
+            cache_creation_input_tokens: (.usage.cache_creation_input_tokens // 0),
+            cache_read_input_tokens: (.usage.cache_read_input_tokens // 0),
+            total_cost_usd: (.total_cost_usd // 0)
+          }' 2>/dev/null)
+    if [[ -z "$usage" || "$usage" == "null" ]]; then
+        printf '{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"total_cost_usd":0}\n'
+    else
+        printf '%s\n' "$usage"
+    fi
+}
+
 # Emit a stage_result JSON envelope on stdout. All payload args are
 # JSON-encoded so callers can pass nested objects/arrays safely via
 # --argjson without shell-quoting hazards.
@@ -1856,6 +1882,14 @@ run_stage() {
     printf '%s\n' "=== $stage_name output ===" >> "$stage_log"
     printf '%s\n' "$output" >> "$stage_log"
     printf '%s\n' "=== exit code: $exit_code ===" >> "$stage_log"
+
+    # Parse token usage and reported cost from the CLI's JSON envelope
+    # alongside the existing structured-output extraction below. Every
+    # field is `// 0` guarded (see _extract_usage) so a missing/null usage
+    # block degrades to zero. Threaded into the stage_result envelope by
+    # _emit_stage_result (issue #580).
+    local _stage_usage
+    _stage_usage=$(_extract_usage "$output")
 
     # Check timeout — but still try to extract structured output first.
     # The agent may have produced valid output before the timeout killed the CLI.

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -678,9 +678,92 @@ update_stage() {
     sync_status_to_log
 }
 
+# =============================================================================
+# PER-STAGE TOKEN/COST ACCUMULATOR (issue #580)
+# =============================================================================
+#
+# run_stage is always invoked as `result=$(run_stage ...)`, so it executes in a
+# command-substitution subshell — a shell-global accumulator assigned there
+# would not survive back to the parent. The bridge is therefore FILE-BACKED,
+# one file per LOGICAL stage under $LOG_BASE/.stage-acc:
+#
+#   set_stage_started     (re)initialises the current logical stage's file and
+#                         records the stage name in _STAGE_ACC_CURRENT, which
+#                         the run_stage subshell inherits via the environment.
+#   _apply_stage_action   on `accept`, appends the accepted stage_result's
+#                         tokens + cost.estimated_usd to that file (one JSONL
+#                         line per accepted run_stage call — so a stage with
+#                         several run_stage calls, e.g. test_loop / pr_review
+#                         iterations, ACCUMULATES rather than last-wins).
+#   set_stage_completed   sums the file to default its tokens/cost args when the
+#                         caller didn't pass them explicitly.
+#
+# Keying by logical stage (not the run_stage name, which is e.g. "test-iter-3")
+# means each set_stage_completed reads only its own stage's file: two completes
+# in a row (implement then quality_loop) never double-count, and a stage that
+# completes WITHOUT a preceding set_stage_started has no file and records ZERO —
+# so config-only-skip paths never inherit a previous stage's spend. Every jq
+# extraction is `// 0` / `// {}` guarded so a missing field degrades to zero.
+# bash-3.2 safe (no associative arrays; float sums done in jq).
+
+_stage_acc_dir() {
+    printf '%s/.stage-acc' "${LOG_BASE:-.}"
+}
+
+_stage_acc_file() {
+    local _s="${1//[^A-Za-z0-9_-]/_}"
+    printf '%s/%s.jsonl' "$(_stage_acc_dir)" "$_s"
+}
+
+# Truncate/create the accumulator file for a logical stage.
+_stage_acc_reset() {
+    local _dir
+    _dir=$(_stage_acc_dir)
+    mkdir -p "$_dir" 2>/dev/null || true
+    : > "$(_stage_acc_file "$1")" 2>/dev/null || true
+}
+
+# Append one accepted stage_result's tokens/cost to the current logical stage's
+# file. Safe to call from inside the run_stage subshell (it writes to a file,
+# which the parent can read). No-op when no logical stage is active.
+_stage_acc_add() {
+    local _sr="$1"
+    local _cur="${_STAGE_ACC_CURRENT:-}"
+    [[ -n "$_cur" ]] || return 0
+    local _line
+    _line=$(printf '%s' "$_sr" \
+        | jq -c '{tokens: (.tokens // {}), cost: (.cost.estimated_usd // 0)}' \
+        2>/dev/null) || return 0
+    [[ -n "$_line" ]] || return 0
+    printf '%s\n' "$_line" >> "$(_stage_acc_file "$_cur")" 2>/dev/null || true
+}
+
+# Sum a logical stage's accumulator file into one {tokens,cost} object. Prints
+# nothing when the file is absent or empty so callers can detect "no data".
+_stage_acc_sum() {
+    local _f
+    _f=$(_stage_acc_file "$1")
+    [[ -s "$_f" ]] || return 0
+    jq -cs '{
+        tokens: {
+            input_tokens:                (map(.tokens.input_tokens // 0) | add // 0),
+            output_tokens:               (map(.tokens.output_tokens // 0) | add // 0),
+            cache_creation_input_tokens: (map(.tokens.cache_creation_input_tokens // 0) | add // 0),
+            cache_read_input_tokens:     (map(.tokens.cache_read_input_tokens // 0) | add // 0)
+        },
+        cost: (map(.cost // 0) | add // 0)
+    }' "$_f" 2>/dev/null || true
+}
+
 set_stage_started() {
     local stage="$1"
     local model="${2:-}"
+
+    # issue #580: mark this the active logical stage and clear its accumulator
+    # so per-stage token/cost starts from zero for this run.
+    _STAGE_ACC_CURRENT="$stage"
+    _stage_acc_reset "$stage"
+
     jq --arg stage "$stage" \
        '.stages[$stage].started_at = (now | todate) |
         .stages[$stage].status = "in_progress" |
@@ -705,6 +788,23 @@ set_stage_completed() {
     local stage="$1"
     local tokens_json="${2:-}"
     local estimated_cost="${3:-}"
+
+    # issue #580 bridge: real call sites pass only the stage name, so default
+    # tokens/cost from the per-stage accumulator that run_stage populated via
+    # _apply_stage_action. Explicit args (used by unit tests and any direct
+    # caller) always win. A stage with no accumulator file — a config-only-skip
+    # path, or a stage that ran no CLI call — yields nothing here and is
+    # persisted as zero/absent, never inheriting a previous stage's spend.
+    if [[ -z "$tokens_json" || -z "$estimated_cost" ]]; then
+        local _acc_sum
+        _acc_sum=$(_stage_acc_sum "$stage")
+        if [[ -n "$_acc_sum" ]]; then
+            [[ -n "$tokens_json" ]] \
+                || tokens_json=$(printf '%s' "$_acc_sum" | jq -c '.tokens' 2>/dev/null)
+            [[ -n "$estimated_cost" ]] \
+                || estimated_cost=$(printf '%s' "$_acc_sum" | jq -r '.cost' 2>/dev/null)
+        fi
+    fi
 
     if [[ -n "$tokens_json" ]]; then
         # Mirror the existing `.model` write (see run_stage's resolved-model
@@ -1740,6 +1840,12 @@ _apply_stage_action() {
 
 	case "$action" in
 		accept)
+			# issue #580: record this accepted run_stage's final (post-
+			# escalation/retry) tokens + cost into the current logical stage's
+			# accumulator. accept is the single choke point every accepted
+			# run_stage exit funnels through, so one append happens per
+			# accepted run_stage call.
+			_stage_acc_add "$stage_result"
 			printf '%s\n' "$stage_result"
 			return 0
 			;;

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -977,7 +977,14 @@ write_task_summary_to_status() {
 #   },
 #   "escalations": [
 #     { "stage": string, "from_model": string, "to_model": string, "reason": string }, ...
-#   ]
+#   ],
+#   "cost_summary": {
+#     "total_input_tokens":          number,
+#     "total_output_tokens":         number,
+#     "total_cache_read_tokens":     number,
+#     "total_cache_creation_tokens": number,
+#     "total_cost_usd":              number
+#   }
 # }
 export_metrics() {
     local metrics_file="$LOG_BASE/metrics.json"
@@ -1011,6 +1018,27 @@ export_metrics() {
         def all_started: [.stages[].started_at // empty] | map(select(. != null));
         def all_completed: [.stages[].completed_at // empty] | map(select(. != null));
 
+        # Default cost_summary for status.json predating issue #580 (or any
+        # run where init_status has not yet seeded the object) so metrics.json
+        # always exposes the full schema rather than a null field.
+        def default_cost_summary:
+            { total_input_tokens: 0, total_output_tokens: 0,
+              total_cache_read_tokens: 0, total_cache_creation_tokens: 0,
+              total_cost_usd: 0 };
+
+        # Roll each per-stage tokens/estimated_cost (written by
+        # set_stage_completed) up into run-level totals. This is the run-level
+        # analogue of the batch-orchestrator per-issue cost rollup (issue #580).
+        # Missing tokens/estimated_cost on a stage coalesce to 0.
+        def stage_cost_rollup:
+            {
+                total_input_tokens:          ([.stages[]?.tokens.input_tokens // 0] | add // 0),
+                total_output_tokens:         ([.stages[]?.tokens.output_tokens // 0] | add // 0),
+                total_cache_read_tokens:     ([.stages[]?.tokens.cache_read_input_tokens // 0] | add // 0),
+                total_cache_creation_tokens: ([.stages[]?.tokens.cache_creation_input_tokens // 0] | add // 0),
+                total_cost_usd:              ([.stages[]?.estimated_cost // 0] | add // 0)
+            };
+
         . as $status |
 
         # Calculate overall start/end from earliest/latest stage timestamps
@@ -1036,7 +1064,19 @@ export_metrics() {
                 test_iterations:      ($status.test_iterations // 0),
                 pr_review_iterations: ($status.pr_review_iterations // 0)
             },
-            escalations: ($status.escalations // [])
+            escalations: ($status.escalations // []),
+            # Roll per-stage tokens/estimated_cost up into the run-level
+            # cost_summary (issue #580). When no stage carries token data
+            # (e.g. a pre-#580 status file, or a run that recorded only a
+            # top-level cost_summary), fall back to the seeded/persisted
+            # cost_summary rather than emitting all zeros.
+            cost_summary: (
+                ($status | stage_cost_rollup) as $rollup |
+                if ([$rollup[]] | add // 0) > 0
+                then $rollup
+                else ($status.cost_summary // default_cost_summary)
+                end
+            )
         }
     ' "$STATUS_FILE" > "$metrics_file" 2>/dev/null
 

--- a/.claude/scripts/implement-issue-test/cost-accounting.bats
+++ b/.claude/scripts/implement-issue-test/cost-accounting.bats
@@ -113,15 +113,17 @@ run_with_config() {
 }
 
 @test "_model_cost prices cache read tokens at 0.1x the input price" {
-	# sonnet: 1M cache-read tokens -> 0.1 * $3.00 = $0.30
-	run_with_config '_model_cost sonnet 0 0 1000000 0'
+	# Signature: _model_cost <model> <input> <output> <cache_creation> <cache_read>
+	# sonnet: 1M cache-read tokens (arg5) -> 0.1 * $3.00 = $0.30
+	run_with_config '_model_cost sonnet 0 0 0 1000000'
 	[ "$status" -eq 0 ]
 	assert_cost_equals "$output" "0.30"
 }
 
 @test "_model_cost prices cache creation tokens at 1.25x the input price" {
-	# sonnet: 1M cache-write tokens -> 1.25 * $3.00 = $3.75
-	run_with_config '_model_cost sonnet 0 0 0 1000000'
+	# Signature: _model_cost <model> <input> <output> <cache_creation> <cache_read>
+	# sonnet: 1M cache-write/creation tokens (arg4) -> 1.25 * $3.00 = $3.75
+	run_with_config '_model_cost sonnet 0 0 1000000 0'
 	[ "$status" -eq 0 ]
 	assert_cost_equals "$output" "3.75"
 }

--- a/.claude/scripts/implement-issue-test/cost-accounting.bats
+++ b/.claude/scripts/implement-issue-test/cost-accounting.bats
@@ -259,6 +259,33 @@ _setup_orchestrator_env() {
 	assert_cost_equals "$estimated_cost" "0.00105"
 }
 
+@test "export_metrics rolls per-stage tokens/cost up into cost_summary totals" {
+	_setup_orchestrator_env
+	init_status
+	# Two completed stages carrying tokens + estimated_cost, but no run-level
+	# cost_summary was ever accumulated (init_status seeds it at zero). The
+	# rollup in export_metrics must sum the per-stage figures.
+	jq '.stages.implement.tokens = {input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 10, cache_creation_input_tokens: 5} |
+	    .stages.implement.estimated_cost = 0.00105 |
+	    .stages.review.tokens = {input_tokens: 200, output_tokens: 25, cache_read_input_tokens: 0, cache_creation_input_tokens: 0} |
+	    .stages.review.estimated_cost = 0.00042' \
+		"$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+
+	export_metrics
+
+	local total_input total_output total_cache_read total_cache_creation total_cost
+	total_input=$(jq -r '.cost_summary.total_input_tokens' "$LOG_BASE/metrics.json")
+	total_output=$(jq -r '.cost_summary.total_output_tokens' "$LOG_BASE/metrics.json")
+	total_cache_read=$(jq -r '.cost_summary.total_cache_read_tokens' "$LOG_BASE/metrics.json")
+	total_cache_creation=$(jq -r '.cost_summary.total_cache_creation_tokens' "$LOG_BASE/metrics.json")
+	total_cost=$(jq -r '.cost_summary.total_cost_usd' "$LOG_BASE/metrics.json")
+	[ "$total_input" = "300" ]
+	[ "$total_output" = "75" ]
+	[ "$total_cache_read" = "10" ]
+	[ "$total_cache_creation" = "5" ]
+	assert_cost_equals "$total_cost" "0.00147"
+}
+
 # =============================================================================
 # BATCH-LEVEL cost_summary ROLLUP (batch-orchestrator.sh)
 # =============================================================================

--- a/.claude/scripts/implement-issue-test/cost-accounting.bats
+++ b/.claude/scripts/implement-issue-test/cost-accounting.bats
@@ -1,0 +1,312 @@
+#!/usr/bin/env bats
+#
+# cost-accounting.bats
+# Tests for per-stage/run-level token & cost accounting (issue #580).
+#
+# Covers:
+#   - _model_cost() pricing math in model-config.sh
+#   - run-level cost_summary seeded by init_status()
+#   - per-stage tokens/estimated_cost persisted on the stages[] entries
+#   - export_metrics() rolling cost_summary into metrics.json
+#   - batch-orchestrator.sh cost_summary rollup across issues
+#
+# Pricing reference (per-million-token, USD) at time of writing:
+#   haiku (claude-haiku-4-5):  $1.00 input  / $5.00 output
+#   sonnet (claude-sonnet-5):  $3.00 input  / $15.00 output
+#   opus (claude-opus-4-8):    $5.00 input  / $25.00 output
+# Cache pricing follows the standard Anthropic multipliers on the model's
+# input price: cache read = 0.1x, cache write (ephemeral/5m) = 1.25x.
+#
+# _model_cost() and the cost_summary/tokens/estimated_cost plumbing do not
+# exist yet — this file encodes the target contract from issue #580 so the
+# implementation (tracked as separate tasks in the same issue) has an
+# executable spec to satisfy.
+#
+
+load 'helpers/test-helper.bash'
+
+setup() {
+	setup_test_env
+	MODEL_CONFIG="$SCRIPT_DIR/model-config.sh"
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# Compare two decimal strings for equality within a small tolerance so the
+# tests don't depend on the exact string formatting (e.g. "1" vs "1.00" vs
+# "1.000000") a future implementation might choose.
+assert_cost_equals() {
+	local actual="$1" expected="$2" msg="${3:-cost should equal $expected}"
+	awk -v a="$actual" -v e="$expected" \
+		'BEGIN { diff = a - e; if (diff < 0) diff = -diff; exit !(diff < 0.0005) }' \
+		|| fail "$msg (got: $actual, expected: $expected)"
+}
+
+run_with_config() {
+	run bash -c "source '$MODEL_CONFIG' && $1"
+}
+
+# =============================================================================
+# _model_cost() — PRICING MATH (model-config.sh)
+# =============================================================================
+
+@test "_model_cost is defined after sourcing model-config.sh" {
+	run_with_config 'type _model_cost'
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"function"* ]]
+}
+
+@test "_model_cost haiku input-only tokens at \$1.00/MTok" {
+	run_with_config '_model_cost haiku 1000000 0'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "1.00"
+}
+
+@test "_model_cost haiku output-only tokens at \$5.00/MTok" {
+	run_with_config '_model_cost haiku 0 1000000'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "5.00"
+}
+
+@test "_model_cost sonnet input-only tokens at \$3.00/MTok" {
+	run_with_config '_model_cost sonnet 1000000 0'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "3.00"
+}
+
+@test "_model_cost sonnet output-only tokens at \$15.00/MTok" {
+	run_with_config '_model_cost sonnet 0 1000000'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "15.00"
+}
+
+@test "_model_cost opus input-only tokens at \$5.00/MTok" {
+	run_with_config '_model_cost opus 1000000 0'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "5.00"
+}
+
+@test "_model_cost opus output-only tokens at \$25.00/MTok" {
+	run_with_config '_model_cost opus 0 1000000'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "25.00"
+}
+
+@test "_model_cost sums input and output cost for the same call" {
+	run_with_config '_model_cost sonnet 1000000 1000000'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "18.00"
+}
+
+@test "_model_cost returns zero for zero tokens" {
+	run_with_config '_model_cost haiku 0 0'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "0"
+}
+
+@test "_model_cost scales linearly with token count" {
+	run_with_config '_model_cost opus 500000 0'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "2.50"
+}
+
+@test "_model_cost prices cache read tokens at 0.1x the input price" {
+	# sonnet: 1M cache-read tokens -> 0.1 * $3.00 = $0.30
+	run_with_config '_model_cost sonnet 0 0 1000000 0'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "0.30"
+}
+
+@test "_model_cost prices cache creation tokens at 1.25x the input price" {
+	# sonnet: 1M cache-write tokens -> 1.25 * $3.00 = $3.75
+	run_with_config '_model_cost sonnet 0 0 0 1000000'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "3.75"
+}
+
+@test "_model_cost combines input, output, cache-read and cache-creation tokens" {
+	# sonnet, 1M of each: 3.00 (input) + 0 (output) + 0.30 (cache read) + 3.75 (cache write)
+	run_with_config '_model_cost sonnet 1000000 0 1000000 1000000'
+	[ "$status" -eq 0 ]
+	assert_cost_equals "$output" "7.05"
+}
+
+@test "_model_cost returns a safe non-negative fallback for an unknown model" {
+	run_with_config '_model_cost totally-unknown-model 1000000 1000000'
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ ^[0-9]+(\.[0-9]+)?$ ]] || fail "expected a plain non-negative number, got: $output"
+}
+
+@test "_model_cost output is a single line with no extra whitespace" {
+	run_with_config '_model_cost haiku 1000 1000 | wc -l'
+	[ "$status" -eq 0 ]
+	[[ "${output// /}" == "1" ]]
+}
+
+# =============================================================================
+# RUN-LEVEL cost_summary — init_status() SKELETON (implement-issue-orchestrator.sh)
+# =============================================================================
+
+_setup_orchestrator_env() {
+	export ISSUE_NUMBER=123
+	export BASE_BRANCH=test
+	export STATUS_FILE="$TEST_TMP/status.json"
+	export LOG_BASE="$TEST_TMP/logs/test"
+	export LOG_FILE="$LOG_BASE/orchestrator.log"
+	export STAGE_COUNTER=0
+	mkdir -p "$LOG_BASE/stages" "$LOG_BASE/context"
+	source_orchestrator_functions
+}
+
+@test "init_status seeds a top-level cost_summary object" {
+	_setup_orchestrator_env
+	init_status
+	local cost_summary_type
+	cost_summary_type=$(jq -r '.cost_summary | type' "$STATUS_FILE")
+	[ "$cost_summary_type" = "object" ]
+}
+
+@test "init_status seeds cost_summary totals at zero" {
+	_setup_orchestrator_env
+	init_status
+	local total_cost total_input total_output
+	total_cost=$(jq -r '.cost_summary.total_cost_usd' "$STATUS_FILE")
+	total_input=$(jq -r '.cost_summary.total_input_tokens' "$STATUS_FILE")
+	total_output=$(jq -r '.cost_summary.total_output_tokens' "$STATUS_FILE")
+	assert_cost_equals "$total_cost" "0"
+	[ "$total_input" = "0" ]
+	[ "$total_output" = "0" ]
+}
+
+# =============================================================================
+# PER-STAGE tokens/estimated_cost — set_stage_completed() (implement-issue-orchestrator.sh)
+# =============================================================================
+
+@test "set_stage_completed with no token args still marks the stage completed (backward compatible)" {
+	_setup_orchestrator_env
+	init_status
+	set_stage_completed "setup"
+	local status
+	status=$(jq -r '.stages.setup.status' "$STATUS_FILE")
+	[ "$status" = "completed" ]
+}
+
+@test "set_stage_completed persists a tokens object on the stage entry" {
+	_setup_orchestrator_env
+	init_status
+	local tokens='{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}'
+	set_stage_completed "implement" "$tokens" "0.00105"
+
+	local input_tokens output_tokens
+	input_tokens=$(jq -r '.stages.implement.tokens.input_tokens' "$STATUS_FILE")
+	output_tokens=$(jq -r '.stages.implement.tokens.output_tokens' "$STATUS_FILE")
+	[ "$input_tokens" = "100" ]
+	[ "$output_tokens" = "50" ]
+}
+
+@test "set_stage_completed persists estimated_cost as a number on the stage entry" {
+	_setup_orchestrator_env
+	init_status
+	local tokens='{"input_tokens":100,"output_tokens":50}'
+	set_stage_completed "implement" "$tokens" "0.00105"
+
+	local cost_type estimated_cost
+	cost_type=$(jq -r '.stages.implement.estimated_cost | type' "$STATUS_FILE")
+	estimated_cost=$(jq -r '.stages.implement.estimated_cost' "$STATUS_FILE")
+	[ "$cost_type" = "number" ]
+	assert_cost_equals "$estimated_cost" "0.00105"
+}
+
+# =============================================================================
+# export_metrics() ROLLS cost_summary INTO metrics.json
+# =============================================================================
+
+@test "export_metrics carries the run-level cost_summary through to metrics.json" {
+	_setup_orchestrator_env
+	init_status
+	jq '.cost_summary = {
+			total_input_tokens: 1000,
+			total_output_tokens: 500,
+			total_cache_read_tokens: 0,
+			total_cache_creation_tokens: 0,
+			total_cost_usd: 1.23
+		}' "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+
+	export_metrics
+
+	local total_cost
+	total_cost=$(jq -r '.cost_summary.total_cost_usd' "$LOG_BASE/metrics.json")
+	assert_cost_equals "$total_cost" "1.23"
+}
+
+@test "export_metrics carries per-stage tokens/estimated_cost through to metrics.json" {
+	_setup_orchestrator_env
+	init_status
+	jq '.stages.implement.tokens = {input_tokens: 100, output_tokens: 50} |
+	    .stages.implement.estimated_cost = 0.00105 |
+	    .stages.implement.started_at = "2024-01-01T10:00:00Z" |
+	    .stages.implement.completed_at = "2024-01-01T10:00:30Z"' \
+		"$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+
+	export_metrics
+
+	local input_tokens estimated_cost
+	input_tokens=$(jq -r '.stages.implement.tokens.input_tokens' "$LOG_BASE/metrics.json")
+	estimated_cost=$(jq -r '.stages.implement.estimated_cost' "$LOG_BASE/metrics.json")
+	[ "$input_tokens" = "100" ]
+	assert_cost_equals "$estimated_cost" "0.00105"
+}
+
+# =============================================================================
+# BATCH-LEVEL cost_summary ROLLUP (batch-orchestrator.sh)
+# =============================================================================
+#
+# Mirrors the existing static-analysis style used elsewhere in
+# test-batch-orchestrator.bats: extract the update_progress() function body
+# and assert its jq filter assigns a cost_summary rollup, then verify the
+# rollup math independently via a jq simulation of the target filter.
+
+@test "update_progress jq filter assigns a cost_summary field" {
+	local body
+	body=$(awk '/^update_progress\(\)/,/^\}$/' "$BATCH_ORCHESTRATOR_SCRIPT_PATH")
+	[[ "$body" == *"cost_summary"* ]] || fail "update_progress() does not populate cost_summary yet"
+}
+
+# Simulates the target rollup filter: sum each issue's cost_usd field into a
+# batch-level cost_summary.total_cost_usd. This is the oracle the real
+# update_progress() jq filter must match once implemented.
+_simulate_cost_summary_rollup() {
+	local status_file="$1"
+	jq '.cost_summary.total_cost_usd = ([.issues[].cost_usd // 0] | add)' "$status_file"
+}
+
+@test "cost_summary rollup sums per-issue cost_usd across the batch" {
+	local status_file="$TEST_TMP/batch-status.json"
+	jq -n '{
+		issues: [
+			{number: "1", status: "completed", cost_usd: 0.50},
+			{number: "2", status: "completed", cost_usd: 1.25},
+			{number: "3", status: "in_progress", cost_usd: 0.10}
+		]
+	}' > "$status_file"
+
+	local total
+	total=$(_simulate_cost_summary_rollup "$status_file" | jq -r '.cost_summary.total_cost_usd')
+	assert_cost_equals "$total" "1.85"
+}
+
+@test "cost_summary rollup treats missing per-issue cost_usd as zero" {
+	local status_file="$TEST_TMP/batch-status.json"
+	jq -n '{
+		issues: [
+			{number: "1", status: "pending"},
+			{number: "2", status: "completed", cost_usd: 2.00}
+		]
+	}' > "$status_file"
+
+	local total
+	total=$(_simulate_cost_summary_rollup "$status_file" | jq -r '.cost_summary.total_cost_usd')
+	assert_cost_equals "$total" "2.00"
+}

--- a/.claude/scripts/implement-issue-test/test-batch-orchestrator.bats
+++ b/.claude/scripts/implement-issue-test/test-batch-orchestrator.bats
@@ -417,6 +417,91 @@ _simulate_update_progress() {
 }
 
 # =============================================================================
+# TASK 10: batch-level cost_summary rollup in init_status/update_progress
+# =============================================================================
+
+# --- Static analysis ---
+
+@test "init_status seeds each issue object with a cost_usd field" {
+	local body
+	body=$(awk '/^init_status\(\)/,/^\}$/' "$BATCH_ORCHESTRATOR_SCRIPT")
+	[[ "$body" == *'"cost_usd": 0'* ]]
+}
+
+@test "init_status emits a cost_summary.total_cost_usd rollup" {
+	local body
+	body=$(awk '/^init_status\(\)/,/^\}$/' "$BATCH_ORCHESTRATOR_SCRIPT")
+	[[ "$body" == *'cost_summary'* ]]
+	[[ "$body" == *'total_cost_usd'* ]]
+}
+
+@test "update_progress recomputes cost_summary.total_cost_usd" {
+	local body
+	body=$(awk '/^update_progress\(\)/,/^\}$/' "$BATCH_ORCHESTRATOR_SCRIPT")
+	[[ "$body" == *'.cost_summary.total_cost_usd'* ]]
+}
+
+@test "process_issue records per-issue cost_usd from the sub-run status" {
+	grep -q 'cost_summary.total_cost_usd' "$BATCH_ORCHESTRATOR_SCRIPT"
+	grep -q 'update_issue_field "\$issue_num" "cost_usd"' \
+		"$BATCH_ORCHESTRATOR_SCRIPT"
+}
+
+# --- Functional simulation ---
+#
+# Verify the rollup jq sums each issue's cost_usd and degrades a missing
+# cost_usd to zero via `// 0`, matching the filter used in update_progress.
+
+_make_cost_status_json() {
+	local file="$1"
+	jq -n '{
+		state: "running",
+		issues: [
+			{number: "1", status: "completed", cost_usd: 1.25},
+			{number: "2", status: "failed", cost_usd: 0.50},
+			{number: "3", status: "pending"}
+		],
+		cost_summary: {total_cost_usd: 0}
+	}' > "$file"
+}
+
+_simulate_cost_rollup() {
+	local status_file="$1"
+	jq '.cost_summary.total_cost_usd =
+			([.issues[] | (.cost_usd // 0)] | add // 0)' \
+		"$status_file"
+}
+
+@test "cost simulation: rollup sums each issue's cost_usd" {
+	local status_file="$TEST_TMP/cost-status.json"
+	_make_cost_status_json "$status_file"
+	local total
+	total=$(_simulate_cost_rollup "$status_file" \
+		| jq '.cost_summary.total_cost_usd')
+	[[ "$total" == "1.75" ]]
+}
+
+@test "cost simulation: missing cost_usd degrades to zero, not null" {
+	local status_file="$TEST_TMP/cost-status.json"
+	_make_cost_status_json "$status_file"
+	# Issue 3 has no cost_usd — the rollup must still be numeric.
+	local total
+	total=$(_simulate_cost_rollup "$status_file" \
+		| jq -r '.cost_summary.total_cost_usd | type')
+	[[ "$total" == "number" ]]
+}
+
+@test "cost simulation: all-zero issues roll up to zero" {
+	local status_file="$TEST_TMP/cost-zero-status.json"
+	jq -n '{issues: [{cost_usd: 0}, {cost_usd: 0}],
+		cost_summary: {total_cost_usd: 99}}' > "$status_file"
+	local total
+	total=$(_simulate_cost_rollup "$status_file" \
+		| jq '.cost_summary.total_cost_usd')
+	[[ "$total" == "0" ]]
+}
+
+# =============================================================================
 # TASK 3: pre-flight else-branch warns when session key is unset
 # =============================================================================
 

--- a/.claude/scripts/implement-issue-test/test-json-parsing.bats
+++ b/.claude/scripts/implement-issue-test/test-json-parsing.bats
@@ -1200,3 +1200,60 @@ FIXTURE_EOF
 		echo "# PASS: log_error writes to stderr without tee" >&3
 	fi
 }
+
+# =============================================================================
+# _extract_usage — parse usage token counts and total_cost_usd (issue #580)
+# The CLI --output-format json envelope carries a .usage block and a
+# top-level .total_cost_usd. run_stage feeds raw stdout through this helper;
+# every field is `// 0` guarded so a missing/null value degrades to zero
+# instead of corrupting downstream status.json / stage_result consumers.
+# =============================================================================
+
+@test "_extract_usage parses full usage block and total_cost_usd" {
+	local raw='{"usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":2,"cache_read_input_tokens":3},"total_cost_usd":0.04}'
+	run _extract_usage "$raw"
+	[ "$status" -eq 0 ]
+	[ "$(printf '%s' "$output" | jq -r '.input_tokens')" = "10" ]
+	[ "$(printf '%s' "$output" | jq -r '.output_tokens')" = "5" ]
+	[ "$(printf '%s' "$output" | jq -r '.cache_creation_input_tokens')" = "2" ]
+	[ "$(printf '%s' "$output" | jq -r '.cache_read_input_tokens')" = "3" ]
+	[ "$(printf '%s' "$output" | jq -r '.total_cost_usd')" = "0.04" ]
+}
+
+@test "_extract_usage returns a zeroed object for empty input" {
+	run _extract_usage ""
+	[ "$status" -eq 0 ]
+	[ "$(printf '%s' "$output" | jq -r '.input_tokens')" = "0" ]
+	[ "$(printf '%s' "$output" | jq -r '.output_tokens')" = "0" ]
+	[ "$(printf '%s' "$output" | jq -r '.cache_creation_input_tokens')" = "0" ]
+	[ "$(printf '%s' "$output" | jq -r '.cache_read_input_tokens')" = "0" ]
+	[ "$(printf '%s' "$output" | jq -r '.total_cost_usd')" = "0" ]
+}
+
+@test "_extract_usage returns a zeroed object for malformed JSON" {
+	run _extract_usage 'not json at all'
+	[ "$status" -eq 0 ]
+	[ "$(printf '%s' "$output" | jq -r '.input_tokens')" = "0" ]
+	[ "$(printf '%s' "$output" | jq -r '.total_cost_usd')" = "0" ]
+}
+
+@test "_extract_usage // 0 guards each missing field independently" {
+	# Only input_tokens present; every other field must degrade to 0.
+	local raw='{"usage":{"input_tokens":7}}'
+	run _extract_usage "$raw"
+	[ "$status" -eq 0 ]
+	[ "$(printf '%s' "$output" | jq -r '.input_tokens')" = "7" ]
+	[ "$(printf '%s' "$output" | jq -r '.output_tokens')" = "0" ]
+	[ "$(printf '%s' "$output" | jq -r '.cache_creation_input_tokens')" = "0" ]
+	[ "$(printf '%s' "$output" | jq -r '.cache_read_input_tokens')" = "0" ]
+	[ "$(printf '%s' "$output" | jq -r '.total_cost_usd')" = "0" ]
+}
+
+@test "_extract_usage // 0 guards explicit null values" {
+	local raw='{"usage":{"input_tokens":null,"output_tokens":9},"total_cost_usd":null}'
+	run _extract_usage "$raw"
+	[ "$status" -eq 0 ]
+	[ "$(printf '%s' "$output" | jq -r '.input_tokens')" = "0" ]
+	[ "$(printf '%s' "$output" | jq -r '.output_tokens')" = "9" ]
+	[ "$(printf '%s' "$output" | jq -r '.total_cost_usd')" = "0" ]
+}

--- a/.claude/scripts/implement-issue-test/test-model-config.bats
+++ b/.claude/scripts/implement-issue-test/test-model-config.bats
@@ -1152,3 +1152,87 @@ JSON
 	[ "$status" -eq 0 ]
 	[[ "$output" == "opus" ]]
 }
+
+# =============================================================================
+# _model_cost() - PRICE TABLE / USD COST CALCULATION
+# =============================================================================
+
+@test "_model_cost computes haiku input-only cost" {
+	run_with_config '_model_cost haiku 1000000 0 0 0'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "1.000000" ]]
+}
+
+@test "_model_cost computes sonnet output-only cost" {
+	run_with_config '_model_cost sonnet 0 1000000 0 0'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "15.000000" ]]
+}
+
+@test "_model_cost computes opus combined input+output cost" {
+	run_with_config '_model_cost opus 1000000 1000000 0 0'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "30.000000" ]]
+}
+
+@test "_model_cost prices cache creation and cache read tokens" {
+	run_with_config '_model_cost opus 0 0 1000000 1000000'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "6.750000" ]]
+}
+
+@test "_model_cost sums input, output, and cache tokens together" {
+	run_with_config '_model_cost haiku 1000000 1000000 1000000 1000000'
+	[ "$status" -eq 0 ]
+	# 1.00 + 5.00 + 1.25 + 0.10
+	[[ "$output" == "7.350000" ]]
+}
+
+@test "_model_cost handles small token counts with correct precision" {
+	run_with_config '_model_cost haiku 100 50 0 0'
+	[ "$status" -eq 0 ]
+	# (100 * 1.00 + 50 * 5.00) / 1e6 = 350 / 1e6
+	[[ "$output" == "0.000350" ]]
+}
+
+@test "_model_cost falls back to opus pricing for an unknown model" {
+	run_with_config '_model_cost gpt-4 1000000 0 0 0'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "5.000000" ]]
+}
+
+@test "_model_cost falls back to opus pricing for empty model" {
+	run_with_config '_model_cost "" 1000000 0 0 0'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "5.000000" ]]
+}
+
+@test "_model_cost matches a full model ID containing the opus tier" {
+	run_with_config '_model_cost claude-opus-4-8 1000000 0 0 0'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "5.000000" ]]
+}
+
+@test "_model_cost matches a full model ID containing the sonnet tier" {
+	run_with_config '_model_cost claude-sonnet-4-6 0 1000000 0 0'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "15.000000" ]]
+}
+
+@test "_model_cost matches a full model ID containing the haiku tier" {
+	run_with_config '_model_cost claude-haiku-4-5 1000000 0 0 0'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "1.000000" ]]
+}
+
+@test "_model_cost defaults missing token-count arguments to zero" {
+	run_with_config '_model_cost haiku'
+	[ "$status" -eq 0 ]
+	[[ "$output" == "0.000000" ]]
+}
+
+@test "_model_cost output has no trailing newline beyond the single line" {
+	run_with_config '_model_cost opus 1000000 0 0 0'
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 1 ]
+}

--- a/.claude/scripts/implement-issue-test/test-stage-runner.bats
+++ b/.claude/scripts/implement-issue-test/test-stage-runner.bats
@@ -2243,3 +2243,107 @@ _repro_full_suite_bats_check() {
 	[[ "$script_content" == *'informational only, non-blocking'* ]] || \
 		fail "Orchestrator must retain informational-only label for mixed-scope bats_section"
 }
+
+# =============================================================================
+# INTEGRATION: per-stage token/cost accumulator bridge (issue #580)
+#
+# Drives a real stage through run_stage with a stubbed CLI response carrying a
+# usage block + total_cost_usd, then asserts the tokens/cost land on the stage
+# entry (via set_stage_completed defaulting from the accumulator) and roll up
+# into the run-level cost_summary (via export_metrics). Guards the blocking bug
+# where every set_stage_completed call site passes only the stage name, so
+# .stages[].tokens was never written and cost_summary was permanently zero.
+# =============================================================================
+
+@test "INTEGRATION: run_stage tokens/cost persist to stage entry + cost_summary (issue #580)" {
+	init_status
+
+	local mock_response="$TEST_TMP/mock-usage.json"
+	cat > "$mock_response" << 'EOF'
+{"result":"done","structured_output":{"status":"success","result":"done"},"usage":{"input_tokens":1234,"output_tokens":567,"cache_creation_input_tokens":10,"cache_read_input_tokens":20},"total_cost_usd":0.042}
+EOF
+	# Stub the CLI: bypass timeout(1)/claude and emit the usage-bearing JSON.
+	timeout() { shift; cat "$mock_response"; }
+	export -f timeout
+
+	set_stage_started "triage"
+	local result
+	result=$(run_stage "triage" "prompt" "test-schema.json" | grep '^{')
+	[ -n "$result" ] || fail "run_stage returned no JSON output"
+	set_stage_completed "triage"
+
+	# AC1: the stage entry carries the stubbed token counts.
+	local in_tok out_tok cache_read
+	in_tok=$(jq -r '.stages.triage.tokens.input_tokens' "$STATUS_FILE")
+	out_tok=$(jq -r '.stages.triage.tokens.output_tokens' "$STATUS_FILE")
+	cache_read=$(jq -r '.stages.triage.tokens.cache_read_input_tokens' "$STATUS_FILE")
+	[ "$in_tok" = "1234" ] || fail "expected input_tokens 1234, got '$in_tok'"
+	[ "$out_tok" = "567" ] || fail "expected output_tokens 567, got '$out_tok'"
+	[ "$cache_read" = "20" ] || fail "expected cache_read 20, got '$cache_read'"
+
+	# AC1: estimated_cost > 0 (prefers the CLI's reported total_cost_usd).
+	local cost
+	cost=$(jq -r '.stages.triage.estimated_cost' "$STATUS_FILE")
+	awk -v c="$cost" 'BEGIN { exit !((c + 0) > 0) }' \
+		|| fail "estimated_cost not > 0: '$cost'"
+
+	# AC2: export_metrics rolls the per-stage spend into a run-level total > 0.
+	export_metrics
+	[ -f "$LOG_BASE/metrics.json" ] || fail "metrics.json not written"
+	local total_cost total_input
+	total_cost=$(jq -r '.cost_summary.total_cost_usd' "$LOG_BASE/metrics.json")
+	total_input=$(jq -r '.cost_summary.total_input_tokens' "$LOG_BASE/metrics.json")
+	awk -v t="$total_cost" 'BEGIN { exit !((t + 0) > 0) }' \
+		|| fail "cost_summary.total_cost_usd not > 0: '$total_cost'"
+	[ "$total_input" = "1234" ] || fail "expected total_input_tokens 1234, got '$total_input'"
+}
+
+@test "INTEGRATION: multiple run_stage calls in one stage accumulate (issue #580)" {
+	init_status
+
+	local mock_response="$TEST_TMP/mock-usage.json"
+	cat > "$mock_response" << 'EOF'
+{"result":"done","structured_output":{"status":"success","result":"done"},"usage":{"input_tokens":1234,"output_tokens":567,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"total_cost_usd":0.042}
+EOF
+	timeout() { shift; cat "$mock_response"; }
+	export -f timeout
+
+	# One logical stage (test_loop), two run_stage iterations with distinct
+	# run_stage names — both must ACCUMULATE, not last-wins.
+	set_stage_started "test_loop"
+	local r1 r2
+	r1=$(run_stage "test-iter-1" "prompt" "test-schema.json" | grep '^{')
+	r2=$(run_stage "test-iter-2" "prompt" "test-schema.json" | grep '^{')
+	[ -n "$r1" ] && [ -n "$r2" ] || fail "run_stage returned no JSON output"
+	set_stage_completed "test_loop"
+
+	local in_tok
+	in_tok=$(jq -r '.stages.test_loop.tokens.input_tokens' "$STATUS_FILE")
+	[ "$in_tok" = "2468" ] || fail "expected accumulated input_tokens 2468, got '$in_tok'"
+}
+
+@test "INTEGRATION: skip-path set_stage_completed with no started reset records zero (issue #580)" {
+	init_status
+
+	# Prime an accumulator for a *different* stage, then complete a stage that
+	# was never started — it must record zero, not the primed stage's spend.
+	local mock_response="$TEST_TMP/mock-usage.json"
+	cat > "$mock_response" << 'EOF'
+{"result":"done","structured_output":{"status":"success","result":"done"},"usage":{"input_tokens":1234,"output_tokens":567,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"total_cost_usd":0.042}
+EOF
+	timeout() { shift; cat "$mock_response"; }
+	export -f timeout
+
+	set_stage_started "implement"
+	run_stage "implement" "prompt" "test-schema.json" > /dev/null
+	set_stage_completed "implement"
+	# quality_loop is completed without ever being started (real config-skip path)
+	set_stage_completed "quality_loop"
+
+	# implement carries the real spend; quality_loop must be zero / no bleed.
+	local impl_in ql_tokens
+	impl_in=$(jq -r '.stages.implement.tokens.input_tokens' "$STATUS_FILE")
+	[ "$impl_in" = "1234" ] || fail "expected implement input_tokens 1234, got '$impl_in'"
+	ql_tokens=$(jq -r '.stages.quality_loop.tokens // "absent"' "$STATUS_FILE")
+	[ "$ql_tokens" = "absent" ] || fail "quality_loop must not inherit spend, got '$ql_tokens'"
+}

--- a/.claude/scripts/implement-issue-test/test-stage-runner.bats
+++ b/.claude/scripts/implement-issue-test/test-stage-runner.bats
@@ -2287,6 +2287,18 @@ EOF
 	awk -v c="$cost" 'BEGIN { exit !((c + 0) > 0) }' \
 		|| fail "estimated_cost not > 0: '$cost'"
 
+	# AC3 (issue #580): the TOP-LEVEL cost_summary on status.json is rolled up
+	# LIVE during the run (not just in metrics.json) — this is the canonical
+	# per-run cost source batch-orchestrator.sh reads. Guards the gap where it
+	# stayed at the init_status-seeded zero.
+	local sj_cost sj_input
+	sj_cost=$(jq -r '.cost_summary.total_cost_usd' "$STATUS_FILE")
+	sj_input=$(jq -r '.cost_summary.total_input_tokens' "$STATUS_FILE")
+	awk -v t="$sj_cost" 'BEGIN { exit !((t + 0) > 0) }' \
+		|| fail "status.json cost_summary.total_cost_usd not > 0: '$sj_cost'"
+	[ "$sj_input" = "1234" ] \
+		|| fail "status.json cost_summary.total_input_tokens expected 1234, got '$sj_input'"
+
 	# AC2: export_metrics rolls the per-stage spend into a run-level total > 0.
 	export_metrics
 	[ -f "$LOG_BASE/metrics.json" ] || fail "metrics.json not written"

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -36,6 +36,51 @@ readonly _MODEL_advanced="opus"
 readonly _MODEL_default="opus"    # fallback for unknown tiers
 
 # =============================================================================
+# PER-MODEL PRICE TABLE
+# =============================================================================
+#
+# USD price per 1,000,000 tokens, by tier. Source: Anthropic published
+# pricing, cached 2026-07-21 (see plugins/pipeline-core skill "claude-api"
+# section "Current Models").
+#
+#   Tier    Input   Output
+#   haiku   $1.00   $5.00
+#   sonnet  $3.00   $15.00
+#   opus    $5.00   $25.00
+#
+# Cache write/read are not separately published per-tier; they scale off the
+# tier's input price using the documented multipliers (shared/prompt-caching.md):
+#   cache write (5m TTL, the CLI default) = 1.25x input
+#   cache read                            = 0.1x  input
+#
+# Update this table when Anthropic pricing changes — it is the single place
+# cost math lives; _model_cost is the only function that reads it.
+#
+# Lookup: _model_cost <model> <input> <output> [cache_creation] [cache_read]
+
+readonly _PRICE_INPUT_haiku="1.00"
+readonly _PRICE_OUTPUT_haiku="5.00"
+readonly _PRICE_CACHE_WRITE_haiku="1.25"
+readonly _PRICE_CACHE_READ_haiku="0.10"
+
+readonly _PRICE_INPUT_sonnet="3.00"
+readonly _PRICE_OUTPUT_sonnet="15.00"
+readonly _PRICE_CACHE_WRITE_sonnet="3.75"
+readonly _PRICE_CACHE_READ_sonnet="0.30"
+
+readonly _PRICE_INPUT_opus="5.00"
+readonly _PRICE_OUTPUT_opus="25.00"
+readonly _PRICE_CACHE_WRITE_opus="6.25"
+readonly _PRICE_CACHE_READ_opus="0.50"
+
+# Fallback for unknown/unrecognized models — priced at opus rates so an
+# unrecognized model never silently undercounts spend.
+readonly _PRICE_INPUT_default="$_PRICE_INPUT_opus"
+readonly _PRICE_OUTPUT_default="$_PRICE_OUTPUT_opus"
+readonly _PRICE_CACHE_WRITE_default="$_PRICE_CACHE_WRITE_opus"
+readonly _PRICE_CACHE_READ_default="$_PRICE_CACHE_READ_opus"
+
+# =============================================================================
 # COMPLEXITY-TO-TIER TABLE
 # =============================================================================
 #
@@ -313,6 +358,56 @@ _match_stage_prefix() {
 _next_model_up() {
 	local _var="_NEXT_MODEL_${1//[^a-zA-Z]/}"
 	printf '%s' "${!_var:-$_NEXT_MODEL_default}"
+}
+
+# _model_cost <model> <input_tokens> <output_tokens> \
+#             [cache_creation_tokens] [cache_read_tokens]
+# Prints the USD cost (6 decimal places) for the given model/tier and token
+# counts, using the price table above.
+#
+# <model> matches on tier name ("haiku"/"sonnet"/"opus") or any string
+# containing one as a substring (e.g. a concrete model ID such as
+# "claude-opus-4-8") — so callers can pass either the CLI's --model alias or
+# the model string a CLI JSON response echoes back. Unrecognized models fall
+# back to the opus price table (_PRICE_*_default) — see AC4.
+#
+# Missing token-count arguments default to 0. Non-numeric arguments are
+# rejected by awk's arithmetic context and print 0.000000 rather than
+# erroring, so a bad upstream value degrades to zero cost instead of
+# corrupting status.json.
+_model_cost() {
+	local _model="${1:-}"
+	local _input="${2:-0}" _output="${3:-0}"
+	local _cache_write="${4:-0}" _cache_read="${5:-0}"
+	local _tier
+
+	case "$_model" in
+		*opus*) _tier="opus" ;;
+		*sonnet*) _tier="sonnet" ;;
+		*haiku*) _tier="haiku" ;;
+		*) _tier="default" ;;
+	esac
+
+	local _price_input_var="_PRICE_INPUT_${_tier}"
+	local _price_output_var="_PRICE_OUTPUT_${_tier}"
+	local _price_cache_write_var="_PRICE_CACHE_WRITE_${_tier}"
+	local _price_cache_read_var="_PRICE_CACHE_READ_${_tier}"
+
+	awk \
+		-v input="$_input" -v output="$_output" \
+		-v cache_write="$_cache_write" -v cache_read="$_cache_read" \
+		-v price_input="${!_price_input_var}" \
+		-v price_output="${!_price_output_var}" \
+		-v price_cache_write="${!_price_cache_write_var}" \
+		-v price_cache_read="${!_price_cache_read_var}" \
+		'BEGIN {
+			cost = (input + 0) * price_input \
+				+ (output + 0) * price_output \
+				+ (cache_write + 0) * price_cache_write \
+				+ (cache_read + 0) * price_cache_read
+			cost = cost / 1000000
+			printf "%.6f\n", cost
+		}'
 }
 
 # =============================================================================

--- a/.claude/scripts/schemas/pipeline-event.json
+++ b/.claude/scripts/schemas/pipeline-event.json
@@ -185,6 +185,35 @@
         "duration_seconds": {
           "type": "number",
           "description": "Wall-clock seconds from stage_start to stage_end"
+        },
+        "error_kind": {
+          "type": "string",
+          "description": "Machine-readable error classification, present when status is error"
+        },
+        "input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Uncached input tokens billed for this stage (issue #580)"
+        },
+        "output_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Output tokens generated for this stage (issue #580)"
+        },
+        "cache_creation_input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Input tokens written to the prompt cache (issue #580)"
+        },
+        "cache_read_input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Input tokens served from the prompt cache (issue #580)"
+        },
+        "estimated_cost": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Estimated USD cost for this stage (issue #580)"
         }
       },
       "required": ["event", "status"]

--- a/.claude/scripts/schemas/stage-result.json
+++ b/.claude/scripts/schemas/stage-result.json
@@ -49,6 +49,53 @@
       "type": "integer",
       "minimum": 0,
       "description": "Wall-clock milliseconds from stage invocation to return"
+    },
+    "tokens": {
+      "type": "object",
+      "description": "Per-stage token counts lifted from the CLI response usage block (issue #580). All fields default to 0 when the CLI omits usage.",
+      "properties": {
+        "input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Uncached input tokens billed for this stage"
+        },
+        "output_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Output tokens generated for this stage"
+        },
+        "cache_creation_input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Input tokens written to the prompt cache (billed at the cache-write rate)"
+        },
+        "cache_read_input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Input tokens served from the prompt cache (billed at the cache-read rate)"
+        }
+      }
+    },
+    "cost": {
+      "type": "object",
+      "description": "Per-stage USD cost breakdown (issue #580). estimated_usd is the figure persisted as .stages[<stage>].estimated_cost.",
+      "properties": {
+        "reported_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "The CLI's own total_cost_usd for the stage, when present"
+        },
+        "computed_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Cost priced from the token counts via _model_cost (model-config.sh)"
+        },
+        "estimated_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Preferred cost: reported_usd when > 0, else computed_usd"
+        }
+      }
     }
   },
   "required": ["status"]


### PR DESCRIPTION
Closes #580

## Summary
Surfaces per-stage token/cost accounting that the Claude CLI already returns on every `--output-format json` call but the orchestrator previously discarded. Each populated `stages[]` entry now carries a `tokens` object + `estimated_cost`, status.json seeds a run-level `cost_summary`, `export_metrics` rolls per-stage spend into `metrics.json`, and `batch-orchestrator.sh` exposes a batch-level `cost_summary` summing each issue's run cost. Pricing is computed from a table in `model-config.sh` (`_model_cost`).

**Implemented outside the pipeline orchestrator** (Edit/Write + bats/git/gh only): this issue edits `implement-issue-orchestrator.sh` and `batch-orchestrator.sh` themselves, and running the pipeline on it triggers a self-modification stall (bash re-reads the very script bodies being rewritten) — which is what killed the prior automated run.

## Task status (11 Implementation Tasks)

Already done on the branch by the prior run (verified against the referenced functions):
- Task 1 — `_model_cost` + per-model price table in `model-config.sh`
- Task 2 — `run_stage` parses `usage`/`total_cost_usd` via `_extract_usage` (`// 0` guards)
- Task 3 — token counts + cost threaded into the `_emit_stage_result` envelope
- Task 4 — `set_stage_completed` persists `.stages[<stage>].tokens` + `.estimated_cost`
- Task 5 — `init_status` seeds a run-level `cost_summary`
- Task 6 — `export_metrics` rolls per-stage tokens/cost into `cost_summary`/`metrics.json`
- Task 10 — batch-level `cost_summary` rollup in `batch-orchestrator.sh` `init_status`/`update_progress`
- Task 11 — `cost-accounting.bats` covering `_model_cost` math, per-stage tokens/cost, and rollups

Completed by me (missing on the branch):
- Task 7 — added optional `tokens`/`cost` properties to `schemas/stage-result.json`
- Task 8 — extended the `stage_end` `oneOf` branch in `schemas/pipeline-event.json` with optional token/cost fields (plus `error_kind`)
- Task 9 — `set_stage_completed` now passes token/cost args to `emit_event "stage_end"` (JSON-typed `:=`, optional so legacy events still validate)

Also fixed: two `cost-accounting.bats` cache-pricing tests (11 & 12) had their `_model_cost` cache-token arguments reversed relative to the documented signature `<model> <input> <output> <cache_creation> <cache_read>` and the real orchestrator caller; corrected the test arg order (implementation + orchestrator were already consistent and correct).

## Verification
- bats: **374 tests, 374 passing, 0 failures** across `cost-accounting.bats`, `test-batch-orchestrator.bats`, `test-model-config.bats`, `test-json-parsing.bats`
- `bash -n` clean on `implement-issue-orchestrator.sh`, `batch-orchestrator.sh`, `model-config.sh`
- `jq empty` valid on both `stage-result.json` and `pipeline-event.json`
- Smoke-tested `event-emit.sh`: a `stage_end` event carrying token/cost validates, and a legacy `stage_end` without them still validates (AC5)
