### PR TITLE
feat(issue-581): enforce /explore task granularity (M/L split)

### DIFF
--- a/.claude/scripts/implement-issue-test/test-issue-body-lib.bats
+++ b/.claude/scripts/implement-issue-test/test-issue-body-lib.bats
@@ -6,7 +6,11 @@
 #   assert_issue_valid(body) — validates a pipeline issue body against the
 #                              six structural criteria (>=1 task, agents
 #                              resolve, path suffixes resolve, AC present,
-#                              Deploy Verification iff DEPLOY_VERIFY_CMD set)
+#                              Deploy Verification iff DEPLOY_VERIFY_CMD set,
+#                              task granularity: no M/L task naming >2 paths),
+#                              plus a non-failing non-S task-mix warning
+#   _issue_body_task_complexity(desc)  — S/M/L hint extraction (default M)
+#   _issue_body_task_path_count(desc)  — distinct path count (:Lnn-tolerant)
 #
 
 bats_require_minimum_version 1.5.0
@@ -740,4 +744,209 @@ Some prose but no task checkboxes.
 	line_count=$(printf '%s\n' "$output" | grep -c $'\t' || true)
 	[ "$line_count" -eq 1 ]
 	[[ "$output" == *"bash-script-craftsman"* ]]
+}
+
+# =============================================================================
+# _issue_body_task_complexity()
+# =============================================================================
+
+@test "_issue_body_task_complexity: extracts (S) hint" {
+	run _issue_body_task_complexity "**(S)** Small task — \`a.sh\`"
+	[ "$status" -eq 0 ]
+	[ "$output" = "S" ]
+}
+
+@test "_issue_body_task_complexity: extracts (M) hint" {
+	run _issue_body_task_complexity "**(M)** Medium task — \`a.sh\`"
+	[ "$status" -eq 0 ]
+	[ "$output" = "M" ]
+}
+
+@test "_issue_body_task_complexity: extracts (L) hint" {
+	run _issue_body_task_complexity "**(L)** Large task — \`a.sh\`"
+	[ "$status" -eq 0 ]
+	[ "$output" = "L" ]
+}
+
+@test "_issue_body_task_complexity: defaults to M when no hint present" {
+	run _issue_body_task_complexity "Do the thing without a size hint"
+	[ "$status" -eq 0 ]
+	[ "$output" = "M" ]
+}
+
+@test "_issue_body_task_complexity: normalizes a lowercase hint to uppercase" {
+	run _issue_body_task_complexity "**(s)** small but lowercase"
+	[ "$status" -eq 0 ]
+	[ "$output" = "S" ]
+}
+
+# =============================================================================
+# _issue_body_task_path_count()
+# =============================================================================
+
+@test "_issue_body_task_path_count: counts three plain backtick paths" {
+	run _issue_body_task_path_count \
+		"Big — \`.claude/scripts/a.sh\`, \`.claude/scripts/b.sh\`, \`.claude/scripts/c.sh\`"
+	[ "$status" -eq 0 ]
+	[ "$output" -eq 3 ]
+}
+
+@test "_issue_body_task_path_count: counts paths carrying a :Lnn line-range suffix" {
+	run _issue_body_task_path_count \
+		"Big — \`src/a.ts:L45-80\`, \`src/b.ts:L5\`, \`src/c.ts:L20-30\`"
+	[ "$status" -eq 0 ]
+	[ "$output" -eq 3 ]
+}
+
+@test "_issue_body_task_path_count: collapses the same file at different lines to one" {
+	run _issue_body_task_path_count \
+		"One file — \`src/a.ts:L1\`, \`src/a.ts:L50\`, \`src/a.ts:L90\`"
+	[ "$status" -eq 0 ]
+	[ "$output" -eq 1 ]
+}
+
+@test "_issue_body_task_path_count: returns 0 when no paths are referenced" {
+	run _issue_body_task_path_count "Refactor the retry logic for reliability"
+	[ "$status" -eq 0 ]
+	[ "$output" -eq 0 ]
+}
+
+# =============================================================================
+# assert_issue_valid() — CRITERION 6: task granularity (M/L + >2 distinct paths)
+# =============================================================================
+
+@test "assert_issue_valid: rejects a decomposable M task naming three distinct paths" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(M)** Big task — \`.claude/scripts/a.sh\`, \`.claude/scripts/b.sh\`, \`.claude/scripts/c.sh\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"granularity"* ]]
+}
+
+@test "assert_issue_valid: rejects a decomposable L task using the :Lnn path format" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(L)** Big task — \`.claude/scripts/a.sh:L1-10\`, \`.claude/scripts/b.sh:L5\`, \`.claude/scripts/c.sh:L9\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"granularity"* ]]
+}
+
+@test "assert_issue_valid: rejects a hint-less (default-M) task naming three distinct paths" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` Big task — \`.claude/scripts/a.sh\`, \`.claude/scripts/b.sh\`, \`.claude/scripts/c.sh\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"granularity"* ]]
+}
+
+@test "assert_issue_valid: allows an atomic M task naming exactly two paths" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(M)** Atomic — \`.claude/scripts/a.sh\`, \`.claude/scripts/b.sh\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"granularity"* ]]
+}
+
+@test "assert_issue_valid: allows an atomic L task referencing one file at multiple line ranges" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(L)** One file — \`.claude/scripts/a.sh:L1-10\`, \`.claude/scripts/a.sh:L90-120\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"granularity"* ]]
+}
+
+@test "assert_issue_valid: exempts an S task even when it names more than two paths" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(S)** Small but wide — \`.claude/scripts/a.sh\`, \`.claude/scripts/b.sh\`, \`.claude/scripts/c.sh\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"granularity"* ]]
+}
+
+# =============================================================================
+# assert_issue_valid() — TASK-MIX ADVISORY WARNING (non-failing)
+# =============================================================================
+
+@test "assert_issue_valid: warns on stderr when the body contains a non-S task" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[default]\` **(M)** Medium task — \`.claude/scripts/a.sh\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	# Warning does not fail the body.
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"WARNING"* ]]
+	[[ "$output" == *"non-S task"* ]]
+}
+
+@test "assert_issue_valid: does not warn when every task is S" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(S)** Small one — \`.claude/scripts/a.sh\`
+- [ ] \`[bash-script-craftsman]\` **(S)** Small two — \`.claude/scripts/b.sh\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"WARNING"* ]]
+}
+
+@test "assert_issue_valid: warning counts M/L against S in a mixed body" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(S)** Small — \`.claude/scripts/a.sh\`
+- [ ] \`[bash-script-craftsman]\` **(M)** Medium — \`.claude/scripts/b.sh\`
+- [ ] \`[bash-script-craftsman]\` **(L)** Large — \`.claude/scripts/c.sh\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"2 non-S task(s)"* ]]
+	[[ "$output" == *"1 S task(s)"* ]]
 }

--- a/.claude/scripts/issue-body-lib.sh
+++ b/.claude/scripts/issue-body-lib.sh
@@ -9,7 +9,7 @@
 #       unique — derived from the .claude/agents/*.md definitions.
 #
 #   assert_issue_valid <body>
-#       Validates an issue body string against five structural criteria:
+#       Validates an issue body string against six structural criteria:
 #         1. at least one parseable (open) task line
 #         2. every task agent resolves to a known agent (or "default")
 #         3. every file path referenced in a task resolves (file exists or
@@ -17,6 +17,10 @@
 #         4. an "Acceptance Criteria" section is present (any heading depth)
 #         5. a "Deploy Verification" section exists if and only if (any heading depth)
 #            DEPLOY_VERIFY_CMD is set
+#         6. task granularity — no M/L task references more than two distinct
+#            file paths (decomposable tasks must be split into S sub-tasks)
+#       Additionally emits a non-failing stderr WARNING reporting the
+#       M/L-vs-S task count whenever the body has any non-S task.
 #       Returns 0 when valid; prints one diagnostic per failure to stderr
 #       and returns 1 otherwise.
 #
@@ -184,6 +188,55 @@ _issue_body_extract_paths() {
 }
 
 #
+# Extracts the S/M/L complexity hint from a task description.  The hint is the
+# first `**(S)**` / `**(M)**` / `**(L)**` marker (case-insensitive) in the
+# description.  A description with no marker defaults to "M" — mirroring the
+# orchestrator's hint-less default (implement-issue-orchestrator.sh:3645),
+# which treats an unsized task as medium.
+#
+# Arguments:
+#   $1 - task description string
+# Outputs:
+#   One of "S", "M", or "L" on stdout
+#
+_issue_body_task_complexity() {
+	local desc="$1"
+	local hint="M"
+	if [[ "$desc" =~ \*\*\(([SsMmLl])\)\*\* ]]; then
+		hint="${BASH_REMATCH[1]}"
+	fi
+	# Normalize to uppercase without relying on bash-4 case conversion.
+	case "$hint" in
+		s) hint="S" ;;
+		m) hint="M" ;;
+		l) hint="L" ;;
+	esac
+	printf '%s' "$hint"
+}
+
+#
+# Counts the distinct file paths referenced in a task description for the
+# granularity criterion.  The canonical Task Format appends an optional
+# ":Lnn"/":nn-mm" line-range suffix to each backtick-quoted path
+# (e.g. `src/app.ts:L45-80`).  `_issue_body_extract_paths` cannot match those
+# tokens because its path char-class excludes ':', so the suffix is stripped
+# here first — this also collapses `file.ts:L10` and `file.ts:L90` to a single
+# distinct path, matching the "distinct file paths" intent.
+#
+# Arguments:
+#   $1 - task description string
+# Outputs:
+#   Distinct path count (integer) on stdout
+#
+_issue_body_task_path_count() {
+	local desc="$1"
+	local stripped
+	stripped=$(printf '%s' "$desc" \
+		| sed -E 's/(`[A-Za-z0-9_./-]+):[A-Za-z0-9_.,-]*(`)/\1\2/g')
+	_issue_body_extract_paths "$stripped" | grep -c '.' || true
+}
+
+#
 # Parses open task lines from an issue body, emitting one
 # "agent<TAB>description" record per task (mirrors the canonical and
 # fallback patterns of the orchestrator's _parse_task_lines).  Checked [x]
@@ -287,12 +340,26 @@ _issue_body_parse_tasks() {
 }
 
 #
-# Validates an issue body against the five structural criteria.
+# Validates an issue body against the structural criteria.
+#
+# Hard criteria (any failure → stderr diagnostic + return 1):
+#   1. at least one parseable open task line
+#   2. every task agent resolves to a known agent (or "default")
+#   3. every referenced file path resolves (file exists or parent dir exists)
+#   4. an "Acceptance Criteria" section is present
+#   5. a "Deploy Verification" section iff DEPLOY_VERIFY_CMD is set
+#   6. task granularity — no M/L task references more than two distinct file
+#      paths (a decomposable task that should be split into S sub-tasks)
+#
+# Soft advisory (never fails the body):
+#   * emits a stderr WARNING reporting the M/L-vs-S task count whenever the
+#     body contains at least one non-S task
 #
 # Arguments:
 #   $1 - issue body text
 # Outputs:
-#   One diagnostic per failure on stderr
+#   One diagnostic per hard failure, plus the optional task-mix warning, on
+#   stderr
 # Returns:
 #   0 when valid, 1 otherwise
 #
@@ -312,8 +379,9 @@ assert_issue_valid() {
 		errors+=("no parseable task lines found")
 	fi
 
-	# Criteria 2 & 3: agents resolve and path suffixes resolve.
-	local agent desc remapped path parent
+	# Criteria 2, 3 & 6: agents resolve, path suffixes resolve, granularity.
+	local agent desc remapped path parent complexity path_count
+	local -i s_count=0 nons_count=0
 	while IFS=$'\t' read -r agent desc; do
 		[[ -z "$agent" ]] && continue
 
@@ -337,7 +405,29 @@ assert_issue_valid() {
 				errors+=("unresolved path: $path")
 			fi
 		done < <(_issue_body_extract_paths "$desc")
+
+		# Criterion 6: task granularity.  Tally the S/non-S mix for the
+		# advisory warning, and hard-fail any M/L task that names more than
+		# two distinct file paths — a decomposable task the explore step
+		# should have split into S sub-tasks.
+		complexity=$(_issue_body_task_complexity "$desc")
+		if [[ "$complexity" == "S" ]]; then
+			s_count=$((s_count + 1))
+		else
+			nons_count=$((nons_count + 1))
+			path_count=$(_issue_body_task_path_count "$desc")
+			if (( path_count > 2 )); then
+				errors+=("task granularity: (${complexity}) task references ${path_count} distinct file paths (>2); split into S sub-tasks — ${desc}")
+			fi
+		fi
 	done <<< "$tasks"
+
+	# Advisory (never fails the body): report the non-S task mix so operators
+	# see the M/L-vs-S balance and are nudged toward S-only decomposition.
+	if (( nons_count > 0 )); then
+		printf 'assert_issue_valid: WARNING: %d non-S task(s) (M/L) vs %d S task(s); prefer splitting M/L into S sub-tasks\n' \
+			"$nons_count" "$s_count" >&2
+	fi
 
 	# Criterion 4: Acceptance Criteria section present.
 	if ! grep -qE '^##+ Acceptance Criteria' <<< "$body"; then

--- a/.claude/scripts/issue-body-lib.sh
+++ b/.claude/scripts/issue-body-lib.sh
@@ -191,7 +191,7 @@ _issue_body_extract_paths() {
 # Extracts the S/M/L complexity hint from a task description.  The hint is the
 # first `**(S)**` / `**(M)**` / `**(L)**` marker (case-insensitive) in the
 # description.  A description with no marker defaults to "M" — mirroring the
-# orchestrator's hint-less default (implement-issue-orchestrator.sh:3645),
+# orchestrator's hint-less default (implement-issue-orchestrator.sh:3834),
 # which treats an unsized task as medium.
 #
 # Arguments:

--- a/plugins/pipeline-core/skills/explore/SKILL.md
+++ b/plugins/pipeline-core/skills/explore/SKILL.md
@@ -82,8 +82,20 @@ Break the chosen approach into implementable tasks:
 - Tasks are ordered by dependency (data layer first, then presentation)
 - Each task is a single logical unit of work
 - Each task should target 5-30 minutes of subagent execution time
-- If a task requires reading more than 3 files or modifying more than 2 files, split it
 - Add a complexity hint: `- [ ] \`[agent]\` **(S)** Description` where S=small (~5 min), M=medium (~15 min), L=large (~30 min)
+
+**Split M/L into ordered S sub-tasks — this is enforced, not advice.** Task granularity is the dominant quality lever: completion rate falls sharply with size (S ~90%, M ~67%, L ~63%), and `assert_issue_valid` now **hard-rejects** any `**(M)**`/`**(L)**` task that names more than two distinct file paths (see Task Format Specification). So do the decomposition *before* writing the task list, not after the gate bounces it:
+
+1. **Draft the task, then test it against the S bar:** an S task touches ≤2 files and has a single, verifiable done-criterion. If a task you were about to mark `**(M)**` or `**(L)**` names >2 files, or bundles two independent done-criteria, it is decomposable — split it.
+2. **Split by file scope and dependency order**, not by convenience. Each resulting S sub-task gets: (a) its own agent, (b) an explicit per-task done-criterion, (c) a file scope of ≤2 paths. Order them so each depends only on earlier sub-tasks (data/lib layer → callers → presentation → tests).
+3. **Only keep a task at `**(M)**`/`**(L)**` when it is genuinely atomic** — the work cannot be divided into independently-verifiable steps *and* it touches ≤2 files (e.g. one dense algorithm in a single file). An atomic M/L naming ≤2 paths passes the gate; a decomposable one naming >2 paths does not.
+
+Example — a single "**(L)** Add auth middleware, wire routes, add tests" naming 3+ files must become ordered S sub-tasks:
+```
+- [ ] `[fastify-backend-developer]` **(S)** Add token-verify middleware — `src/middleware/auth.ts:L1-40`
+- [ ] `[fastify-backend-developer]` **(S)** Apply middleware to protected routes — `src/routes/index.ts:L20-55`
+- [ ] `[default]` **(S)** Add middleware unit tests — `tests/unit/auth.test.ts:L1-60`
+```
 - **Parseable format required:** Every task line in `## Implementation Tasks` MUST begin with `- [ ] \`[agent-name]\``. Prose lines such as "Task 1: Do something" are **silently skipped** by the orchestrator — no error is raised and no warning is emitted; the task simply never executes.
 - Frontend and backend changes in the same task should be split — backend first (data layer), then frontend (presentation)
 - **E2E tests (REQUIRED for UI changes):** If `TEST_E2E_CMD` is configured in `.claude/config/platform.sh`, include an E2E task for ANY issue touching user-visible UI — CSS, components, layouts, forms, navigation, visual regressions. This is NOT optional for UI work.
@@ -238,6 +250,10 @@ The `## Implementation Tasks` section must use this parseable convention:
 - **Paths must be real repo paths** — verify each path exists in the repository before writing it. Never invent or guess file paths.
 - **Task descriptions must stay under ~200 characters** — keep the description concise; put details in the Research Findings section of the issue body instead.
 
+**Granularity is enforced by `assert_issue_valid` (not advisory):** the shared validator every created issue passes through (`.claude/scripts/issue-body-lib.sh`) now applies a hard granularity criterion in addition to the structural checks:
+- **HARD error — issue is rejected:** any `**(M)**` or `**(L)**` task whose files-suffix names **more than two distinct file paths** (line-range suffixes like `:L10-40` are ignored, so `file.ts:L10` and `file.ts:L90` count as one path). A hint-less task is treated as `**(M)**`. Split such a task into ordered S sub-tasks (see Step 4) before creating the issue.
+- **WARNING — non-failing:** whenever the body contains any non-S task, the validator prints the M/L-vs-S count to stderr. This is a nudge to keep decomposing toward S; it does not block issue creation, but treat a large M/L count as a sign the plan is under-decomposed.
+
 **Agent values** — use agents defined in `.claude/agents/`:
 
 | Agent | Use for |
@@ -274,7 +290,7 @@ The `## Implementation Tasks` section must use this parseable convention:
 Task sizing directly controls model cost via `model-config.sh`:
 
 - **Prefer S-complexity tasks** — S and M tasks use sonnet; only L tasks use opus. Prefer S over M/L for smaller scope, not model savings.
-- **Split M/L tasks into multiple S tasks** when the work is decomposable into independent steps.
+- **Split M/L tasks into multiple S tasks** when the work is decomposable into independent steps. **This is now enforced:** `assert_issue_valid` hard-rejects a decomposable M/L task (M/L hint AND >2 distinct file paths) and warns on the overall non-S mix — see the Task Format Specification. Decompose at explore time; do not rely on the gate to catch it.
 - **Every task MUST include at least one file path. Tasks without file paths will cause subagents to scan broadly — this is the #1 token waste in the pipeline.**
 - **Each task's affected file list reduces subagent exploration cost** — include file paths in the task description.
 


### PR DESCRIPTION
Closes #581. Stacked on #586 (feature/issue-580).

## What

Converts the advisory "prefer S / split M/L" granularity guidance into an enforced gate at the single choke point every created issue passes through — `assert_issue_valid()` in `.claude/scripts/issue-body-lib.sh` — and rewrites the `/explore` skill to split M/L into ordered S sub-tasks up front.

## Tasks implemented (6/6)

1. `[bash-script-craftsman]` Added `_issue_body_task_complexity` — extracts the `**(S)/(M)/(L)**` hint (default M, case-insensitive) from a task desc.
2. `[bash-script-craftsman]` Added a HARD granularity criterion to `assert_issue_valid`: an M/L task naming >2 distinct file paths is rejected with a stderr `task granularity:` diagnostic. New private helper `_issue_body_task_path_count` strips the canonical `:Lnn` line-range suffix before counting (so `file.ts:L10` and `file.ts:L90` collapse to one path) — without it the check would never fire on real explore output, whose file suffixes always carry line ranges.
3. `[bash-script-craftsman]` Emit a non-failing stderr WARNING reporting the M/L-vs-S task count whenever the body has ≥1 non-S task (does not fail closed).
4. `[cc-orchestration-writer]` Rewrote explore Step 4 to actively split M/L into ordered S sub-tasks with per-task done-criteria + ≤2-file scope, with a worked example.
5. `[cc-orchestration-writer]` Updated Task Format Specification + Token Efficiency to state granularity is now enforced by `assert_issue_valid` (hard error + warning), not advisory.
6. `[default]` Added BATS coverage: reject decomposable M/L (plain paths, `:Lnn` paths, and hint-less default-M), allow atomic M/L (≤2 paths, same-file multi-range), exempt S even when >2 paths, warn-on-mix, no-warn on all-S, plus unit tests for both new helpers.

## Safety / no over-tightening

The hard error is gated on the decomposability signal (M/L hint AND >2 *distinct* paths), never on the hint alone. An M/L task naming ≤2 paths still passes, so pre-existing valid issues (including #581's own all-S body) validate unchanged.

## Tests

- `test-issue-body-lib.bats`: **70/70 pass** (was 52; +18 new).
- Regression suites that consume `assert_issue_valid`: `test-create-issue-parent` 28/28, `test-create-followup-issue` 36/36, `test-adj-body-validation` 30/30, `test-enrich-issue` 26/26 — all pass.
- Heavy orchestrator suites `test-stage-runner` + `test-batch-orchestrator`: 240/240 pass.
- `bash -n .claude/scripts/issue-body-lib.sh`: clean.

Implemented subagent-driven (no live orchestrator) to avoid the self-modification hazard of editing `issue-body-lib.sh` while an orchestrator sources it.