### PR TITLE
feat(issue-577): stop false-success on partial failure / rejected review

### DIFF
--- a/.claude/scripts/batch-orchestrator.sh
+++ b/.claude/scripts/batch-orchestrator.sh
@@ -1102,6 +1102,16 @@ process_issue() {
                 pr_number=$(jq -r '.stages.pr.pr_number // empty' "$issue_status_file" 2>/dev/null)
                 log "PR #${pr_number:-?} left open — merge blocked by quality gate"
                 ;;
+            completed_partial)
+                # Issue #577: partial delivery (not all tasks completed, or the
+                # PR review never approved).  Handle it like merge_blocked —
+                # leave the PR open and record it — rather than letting it fall
+                # to the *) error arm, where the PR-recovery logic below would
+                # wrongly flip it to success because a PR number exists.
+                impl_status="merge_blocked"
+                pr_number=$(jq -r '.stages.pr.pr_number // empty' "$issue_status_file" 2>/dev/null)
+                log "PR #${pr_number:-?} left open — partial delivery (not all tasks completed / review unresolved)"
+                ;;
             error|max_iterations_quality|max_iterations_pr_review)
                 impl_status="error"
                 impl_error="Script exited with state: $state"

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -8483,6 +8483,12 @@ $complete_summary
         local merge_blocked_reason=""
         local merge_block_kind=""   # "convergence" | "partial"
 
+        # Read the persisted merge_blocked_reason once; nothing mutates
+        # status.json between the two gates, so both share this value.
+        local _persisted
+        _persisted=$(jq -r '.merge_blocked_reason // empty' \
+            "$STATUS_FILE" 2>/dev/null || printf '')
+
         # Gate A — quality-loop convergence failure.  Override:
         # BLOCK_MERGE_ON_CONVERGENCE_FAILURE=0.  A convergence reason may be
         # persisted in status.json (so a standalone process-pr honours it) or
@@ -8492,9 +8498,6 @@ $complete_summary
         if [[ "${BLOCK_MERGE_ON_CONVERGENCE_FAILURE:-1}" == "0" ]]; then
             log "BLOCK_MERGE_ON_CONVERGENCE_FAILURE=0 — skipping merge-block check"
         else
-            local _persisted
-            _persisted=$(jq -r '.merge_blocked_reason // empty' \
-                "$STATUS_FILE" 2>/dev/null || printf '')
             if [[ -n "$_persisted" && "$_persisted" != "Partial implementation:"* ]]; then
                 merge_blocked_reason="$_persisted"
                 merge_block_kind="convergence"
@@ -8519,11 +8522,8 @@ $complete_summary
             if [[ "${BLOCK_MERGE_ON_PARTIAL:-1}" == "0" ]]; then
                 log "BLOCK_MERGE_ON_PARTIAL=0 — skipping partial/pr-review merge-block check"
             else
-                local _persisted_p
-                _persisted_p=$(jq -r '.merge_blocked_reason // empty' \
-                    "$STATUS_FILE" 2>/dev/null || printf '')
-                if [[ "$_persisted_p" == "Partial implementation:"* ]]; then
-                    merge_blocked_reason="$_persisted_p"
+                if [[ "$_persisted" == "Partial implementation:"* ]]; then
+                    merge_blocked_reason="$_persisted"
                     merge_block_kind="partial"
                 else
                     local _dsp

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -906,6 +906,35 @@ compute_task_summary() {
     ' "$STATUS_FILE"
 }
 
+# _format_task_summary_line() — emit a single human-readable task-summary line
+# for inclusion in terminal issue/PR comments (issue #577).  Reads the task
+# roster from status.json and reports "<completed>/<total> tasks completed",
+# appending "(<n> failed)" when any task failed.  Prints nothing when there is
+# no task roster (e.g. surgical fast-path runs) so callers can splice the
+# result unconditionally.  Data-returning function: no log() to stdout.
+_format_task_summary_line() {
+    [[ -f "$STATUS_FILE" ]] || { printf ''; return 0; }
+
+    local total done_count failed_count
+    total=$(jq -r '(.tasks // []) | length' "$STATUS_FILE" 2>/dev/null || printf '0')
+    [[ "$total" =~ ^[0-9]+$ ]] || total=0
+    (( total > 0 )) || { printf ''; return 0; }
+
+    done_count=$(jq -r '[(.tasks // [])[] | select(.status == "completed")] | length' \
+        "$STATUS_FILE" 2>/dev/null || printf '0')
+    failed_count=$(jq -r '[(.tasks // [])[] | select(.status == "failed")] | length' \
+        "$STATUS_FILE" 2>/dev/null || printf '0')
+    [[ "$done_count" =~ ^[0-9]+$ ]] || done_count=0
+    [[ "$failed_count" =~ ^[0-9]+$ ]] || failed_count=0
+
+    if (( failed_count > 0 )); then
+        printf '**Task summary:** %s/%s tasks completed (%s failed).' \
+            "$done_count" "$total" "$failed_count"
+    else
+        printf '**Task summary:** %s/%s tasks completed.' "$done_count" "$total"
+    fi
+}
+
 # _rewrite_running_to_interrupted() — called from the EXIT trap to surface
 # interrupted runs as a distinct state rather than leaving state="running".
 # When state is "running" at exit time, rewrites it to
@@ -7591,6 +7620,50 @@ $impl_summary" "$tagent"
                 exit 1
             fi
         fi
+
+        # -----------------------------------------------------------------
+        # PARTIAL-COMPLETION GATE (issue #577)
+        # When fewer tasks completed this run than were planned, this is a
+        # partial delivery: record an implement:partial:<n>/<m> marker in
+        # DEGRADED_STAGES (consulted by the merge gate below to block
+        # auto-merge) and post an issue comment naming each failed task.
+        # DEGRADED_STAGES is guarded against set -u unbound expansion at every
+        # read site, so appending here is safe.
+        # -----------------------------------------------------------------
+        if (( completed_tasks < task_count )); then
+            DEGRADED_STAGES+=("implement:partial:${completed_tasks}/${task_count}")
+            log_warn "Partial implementation: ${completed_tasks}/${task_count} tasks completed —" \
+                "recording implement:partial and reporting failed tasks."
+
+            # Persist a merge-block reason so a standalone process-pr or a
+            # resumed run honours the gate from status.json too.  Use // to
+            # avoid clobbering a reason a prior gate (e.g. convergence) set.
+            if [[ -f "$STATUS_FILE" ]]; then
+                jq --arg reason "Partial implementation: ${completed_tasks}/${task_count} tasks completed (implement:partial:${completed_tasks}/${task_count})." \
+                   '.merge_blocked_reason = (.merge_blocked_reason // $reason) | .last_update = (now | todate)' \
+                   "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+                sync_status_to_log
+            fi
+
+            # Build a bullet list of the failed tasks from status.json.
+            local _failed_list=""
+            if [[ -f "$STATUS_FILE" ]]; then
+                _failed_list=$(jq -r '
+                    [.tasks[]? | select(.status == "failed")
+                        | "- Task \(.id // "?"): \(.description // "(no description)")"]
+                    | join("\n")' "$STATUS_FILE" 2>/dev/null || printf '')
+            fi
+            [[ -n "$_failed_list" ]] \
+                || _failed_list="- (failed tasks not individually recorded in status.json)"
+
+            comment_issue "Implementation: Partial" \
+                "⚠️ Only **${completed_tasks}/${task_count}** implementation task(s) completed. The following task(s) failed:
+
+$_failed_list
+
+Auto-merge will be blocked and the PR left open for review. To merge anyway, re-run with \`BLOCK_MERGE_ON_PARTIAL=0\`." \
+                "default"
+        fi
     fi
 
     # -------------------------------------------------------------------------
@@ -8408,24 +8481,109 @@ $complete_summary
         # DEGRADED_STAGES array.  Override with BLOCK_MERGE_ON_CONVERGENCE_FAILURE=0.
         # ---------------------------------------------------------------------
         local merge_blocked_reason=""
+        local merge_block_kind=""   # "convergence" | "partial"
+
+        # Gate A — quality-loop convergence failure.  Override:
+        # BLOCK_MERGE_ON_CONVERGENCE_FAILURE=0.  A convergence reason may be
+        # persisted in status.json (so a standalone process-pr honours it) or
+        # live in the in-memory DEGRADED_STAGES array.  A persisted *partial*
+        # reason is deliberately left for Gate B so it gets the
+        # completed_partial state rather than merge_blocked.
         if [[ "${BLOCK_MERGE_ON_CONVERGENCE_FAILURE:-1}" == "0" ]]; then
             log "BLOCK_MERGE_ON_CONVERGENCE_FAILURE=0 — skipping merge-block check"
         else
-            merge_blocked_reason=$(jq -r '.merge_blocked_reason // empty' \
+            local _persisted
+            _persisted=$(jq -r '.merge_blocked_reason // empty' \
                 "$STATUS_FILE" 2>/dev/null || printf '')
-            if [[ -z "$merge_blocked_reason" ]]; then
+            if [[ -n "$_persisted" && "$_persisted" != "Partial implementation:"* ]]; then
+                merge_blocked_reason="$_persisted"
+                merge_block_kind="convergence"
+            else
                 local _ds
                 for _ds in "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}"; do
                     if [[ "$_ds" == quality:convergence_failure:* ]]; then
                         merge_blocked_reason="Quality loop convergence failure recorded in degraded_stages: $_ds"
+                        merge_block_kind="convergence"
                         break
                     fi
                 done
             fi
         fi
-        log "merge_pr: merge_blocked_reason check done — blocked='${merge_blocked_reason:-<none>}'"
+
+        # Gate B — partial task completion or an unresolved PR-review verdict
+        # (issue #577).  Override: BLOCK_MERGE_ON_PARTIAL=0.  Reason source is a
+        # persisted "Partial implementation:" line (process-pr / resumed runs)
+        # or the in-memory DEGRADED_STAGES array (implement:partial:*,
+        # pr_review:max_iterations:*, pr_review:wall_timeout).
+        if [[ -z "$merge_blocked_reason" ]]; then
+            if [[ "${BLOCK_MERGE_ON_PARTIAL:-1}" == "0" ]]; then
+                log "BLOCK_MERGE_ON_PARTIAL=0 — skipping partial/pr-review merge-block check"
+            else
+                local _persisted_p
+                _persisted_p=$(jq -r '.merge_blocked_reason // empty' \
+                    "$STATUS_FILE" 2>/dev/null || printf '')
+                if [[ "$_persisted_p" == "Partial implementation:"* ]]; then
+                    merge_blocked_reason="$_persisted_p"
+                    merge_block_kind="partial"
+                else
+                    local _dsp
+                    for _dsp in "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}"; do
+                        if [[ "$_dsp" == implement:partial:* ]]; then
+                            merge_blocked_reason="Partial implementation — not all tasks completed (degraded_stages: $_dsp)."
+                            merge_block_kind="partial"
+                            break
+                        fi
+                        if [[ "$_dsp" == pr_review:max_iterations:* || "$_dsp" == pr_review:wall_timeout ]]; then
+                            merge_blocked_reason="PR review loop ended without an approved verdict (degraded_stages: $_dsp)."
+                            merge_block_kind="partial"
+                            break
+                        fi
+                    done
+                fi
+            fi
+        fi
+        log "merge_pr: merge_blocked_reason check done — blocked='${merge_blocked_reason:-<none>}' kind='${merge_block_kind:-none}'"
 
         if [[ -n "$merge_blocked_reason" ]]; then
+            local _task_summary_line
+            _task_summary_line=$(_format_task_summary_line)
+
+            # Partial-delivery / unresolved-review block (issue #577): distinct
+            # completed_partial state and a non-zero exit (2) so batch metrics
+            # and operators can tell a partial delivery from an error or a full
+            # success.
+            if [[ "$merge_block_kind" == "partial" ]]; then
+                log_warn "Merge blocked for PR #$pr_number: partial delivery / unresolved review"
+                comment_pr "$pr_number" "Merge Blocked — Partial Delivery" \
+                    "🚫 Auto-merge was blocked because not all implementation tasks completed or the PR review never reached an approved verdict. This PR has been left **open** for a human to review and merge (or push further fixes).
+
+$merge_blocked_reason${_task_summary_line:+
+
+$_task_summary_line}
+
+To override this gate and merge anyway, re-run with \`BLOCK_MERGE_ON_PARTIAL=0\`." \
+                    "default"
+                comment_issue "Merge: Blocked (Partial Delivery)" \
+                    "🚫 Merge of PR #$pr_number blocked — partial delivery. PR left open for human review.
+
+$merge_blocked_reason${_task_summary_line:+
+
+$_task_summary_line}" \
+                    "default"
+                set_final_state "completed_partial"
+                cp "$STATUS_FILE" "$LOG_BASE/status.json"
+
+                log "=========================================="
+                log "Implement Issue Complete (partial delivery — merge blocked)"
+                log "=========================================="
+                log "Issue: #$ISSUE_NUMBER"
+                log "PR: #$pr_number"
+                log "Branch: $branch"
+                log "Status: completed_partial"
+                exit 2
+            fi
+
+            # Gate A (convergence) — unchanged behaviour: merge_blocked, exit 0.
             log_warn "Merge blocked for PR #$pr_number: unresolved quality feedback"
             comment_pr "$pr_number" "Merge Blocked — Unresolved Quality Feedback" \
                 "🚫 Auto-merge was blocked because the internal quality loop could not resolve recurring review feedback. This PR has been left **open** for a human to review and merge (or push further fixes).
@@ -8437,7 +8595,9 @@ To override this gate and merge anyway, re-run with \`BLOCK_MERGE_ON_CONVERGENCE
             comment_issue "Merge: Blocked" \
                 "🚫 Merge of PR #$pr_number blocked — unresolved quality feedback. PR left open for human review.${merge_blocked_reason:+
 
-$merge_blocked_reason}" \
+$merge_blocked_reason}${_task_summary_line:+
+
+$_task_summary_line}" \
                 "default"
             set_final_state "merge_blocked"
             cp "$STATUS_FILE" "$LOG_BASE/status.json"
@@ -8528,12 +8688,18 @@ $merge_blocked_reason}" \
 
         if [[ "${QUIET:-false}" != "true" ]]; then
             log "merge_pr: posting merge-complete comment on issue"
+            # Include the task summary on this terminal exit path too (issue
+            # #577) so a full-success merge still reports what was delivered.
+            local _merge_summary_line
+            _merge_summary_line=$(_format_task_summary_line)
             local _merge_comment
             _merge_comment=$(cat <<EOF
 ## Merge: Complete
 ###### *Posted by \`implement-issue-orchestrator\`*
 
-✅ PR #$pr_number merged into \`$BASE_BRANCH\` successfully.
+✅ PR #$pr_number merged into \`$BASE_BRANCH\` successfully.${_merge_summary_line:+
+
+$_merge_summary_line}
 EOF
 )
             timeout "$MERGE_COMMENT_TIMEOUT" "$PLATFORM_DIR/comment-issue.sh" \

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -966,6 +966,23 @@ set_final_state() {
         "to_state=$state"
 }
 
+# ---------------------------------------------------------------------------
+# persist_merge_blocked_reason <reason>
+# Persist a merge-block reason into status.json so the merge gate honours it
+# on a resumed run — after a crash+resume the in-memory DEGRADED_STAGES array
+# is empty, so soft-fail sites (implement:partial, pr_review:*) must durably
+# record WHY the merge is blocked. Uses `// $reason` so a reason a prior gate
+# already set (e.g. quality convergence) is not clobbered.
+# ---------------------------------------------------------------------------
+persist_merge_blocked_reason() {
+    local reason="$1"
+    [[ -f "$STATUS_FILE" ]] || return 0
+    jq --arg reason "$reason" \
+       '.merge_blocked_reason = (.merge_blocked_reason // $reason) | .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+}
+
 increment_quality_iteration() {
     jq '.quality_iterations += 1 |
         .stages.quality_loop.iteration = .quality_iterations |
@@ -8226,6 +8243,8 @@ $pr_creation_skill}"
             log_warn "Wall-clock timeout in PR review loop at iteration $pr_iteration"
             set_final_state "wall_timeout_pr_review"
             DEGRADED_STAGES+=("pr_review:wall_timeout")
+            persist_merge_blocked_reason \
+                "PR review loop hit wall-clock timeout without an approved verdict (pr_review:wall_timeout)."
             pr_approved=true
             break
         fi
@@ -8235,6 +8254,8 @@ $pr_creation_skill}"
             log_warn "PR-review budget timeout at iteration $pr_iteration"
             set_final_state "wall_timeout_pr_review"
             DEGRADED_STAGES+=("pr_review:wall_timeout")
+            persist_merge_blocked_reason \
+                "PR review loop hit its wall-clock budget without an approved verdict (pr_review:wall_timeout)."
             pr_approved=true
             break
         fi
@@ -8243,6 +8264,8 @@ $pr_creation_skill}"
             log_warn "PR review loop exceeded max iterations ($pr_review_max_iter). Soft-failing and continuing."
             set_final_state "max_iterations_pr_review"
             DEGRADED_STAGES+=("pr_review:max_iterations:iter=$pr_iteration")
+            persist_merge_blocked_reason \
+                "PR review loop ended without an approved verdict after max iterations (pr_review:max_iterations:iter=$pr_iteration)."
             pr_approved=true
             break
         fi

--- a/.claude/scripts/implement-issue-test/test-merge-block-partial.bats
+++ b/.claude/scripts/implement-issue-test/test-merge-block-partial.bats
@@ -316,3 +316,93 @@ teardown() {
 	# generic error path (which would flip to success via the PR-recovery logic).
 	[[ "$batch_content" == *'completed_partial)'* ]]
 }
+
+# =============================================================================
+# RESUME DURABILITY: pr_review soft-fail persists a merge_blocked_reason
+# (issue #577). Regression: the three pr_review degradation sites used to only
+# append to the in-memory DEGRADED_STAGES array. set_stage_completed "pr_review"
+# runs unconditionally after the loop, so a crash+resume skipped the loop with
+# an empty DEGRADED_STAGES and NO persisted reason → the merge gate saw nothing
+# and merged an UNAPPROVED PR. The reason must survive into status.json.
+# =============================================================================
+
+@test "persist_merge_blocked_reason writes the reason into status.json" {
+	# Fresh status.json from init_status has .merge_blocked_reason == null.
+	run jq -r '.merge_blocked_reason' "$STATUS_FILE"
+	[[ "$output" == "null" || -z "$output" ]]
+
+	# Drive the real persist function the soft-fail sites call.
+	persist_merge_blocked_reason \
+		"PR review loop ended without an approved verdict after max iterations (pr_review:max_iterations:iter=3)."
+
+	local persisted
+	persisted=$(jq -r '.merge_blocked_reason // empty' "$STATUS_FILE")
+	[[ -n "$persisted" ]]
+	[[ "$persisted" == *"pr_review"* ]]
+}
+
+@test "pr_review max_iterations soft-fail survives into status.json for a resumed run" {
+	# Simulate the exact max_iterations soft-fail sequence the loop runs.
+	set_final_state "max_iterations_pr_review"
+	DEGRADED_STAGES+=("pr_review:max_iterations:iter=3")
+	persist_merge_blocked_reason \
+		"PR review loop ended without an approved verdict after max iterations (pr_review:max_iterations:iter=3)."
+
+	# Simulate crash+resume: the in-memory array is lost on a fresh process.
+	DEGRADED_STAGES=()
+
+	# The merge gate's first move is to read the persisted reason from
+	# status.json — that is the ONLY signal available after a resume.
+	local persisted
+	persisted=$(jq -r '.merge_blocked_reason // empty' "$STATUS_FILE")
+	[[ -n "$persisted" ]]
+	[[ "$persisted" == *"pr_review"* ]]
+}
+
+@test "pr_review wall_timeout soft-fail survives into status.json for a resumed run" {
+	set_final_state "wall_timeout_pr_review"
+	DEGRADED_STAGES+=("pr_review:wall_timeout")
+	persist_merge_blocked_reason \
+		"PR review loop hit wall-clock timeout without an approved verdict (pr_review:wall_timeout)."
+
+	DEGRADED_STAGES=()
+
+	local persisted
+	persisted=$(jq -r '.merge_blocked_reason // empty' "$STATUS_FILE")
+	[[ -n "$persisted" ]]
+	[[ "$persisted" == *"pr_review"* ]]
+}
+
+@test "persist_merge_blocked_reason does not clobber a pre-existing reason" {
+	# A prior gate (e.g. quality convergence) may already have set a reason.
+	jq --arg r "Quality loop convergence failure" \
+		'.merge_blocked_reason = $r' \
+		"$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+
+	persist_merge_blocked_reason \
+		"PR review loop ended without an approved verdict (pr_review:max_iterations:iter=3)."
+
+	# The // guard keeps the first-set reason.
+	local persisted
+	persisted=$(jq -r '.merge_blocked_reason' "$STATUS_FILE")
+	[[ "$persisted" == "Quality loop convergence failure" ]]
+}
+
+@test "all three pr_review degradation sites also persist a merge_blocked_reason" {
+	# Static wiring guard: each DEGRADED_STAGES+=("pr_review:...") append in the
+	# PR review loop must be paired with a persist_merge_blocked_reason call so
+	# the block is durable across a resume. Extract the three-guard region and
+	# assert one persist call per pr_review append.
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	local pr_appends persist_calls
+	pr_appends=$(grep -c 'DEGRADED_STAGES+=("pr_review:' <<< "$script_content")
+	# Persist calls that name a pr_review cause.
+	persist_calls=$(grep -c 'persist_merge_blocked_reason' <<< "$script_content")
+
+	# Three pr_review appends (2× wall_timeout, 1× max_iterations).
+	[[ "$pr_appends" -eq 3 ]]
+	# At least three persist calls exist (the three pr_review sites).
+	[[ "$persist_calls" -ge 3 ]]
+}

--- a/.claude/scripts/implement-issue-test/test-merge-block-partial.bats
+++ b/.claude/scripts/implement-issue-test/test-merge-block-partial.bats
@@ -1,0 +1,318 @@
+#!/usr/bin/env bats
+#
+# test-merge-block-partial.bats
+# Tests for issue #577: block merge + report on partial task failure /
+# rejected PR review.  Mirrors test-merge-block-convergence.bats idioms:
+# static analysis of the orchestrator source plus functional simulation of
+# the gate logic.
+#
+
+load 'helpers/test-helper.bash'
+
+setup() {
+	setup_test_env
+
+	export ISSUE_NUMBER=123
+	export BASE_BRANCH=test
+	export STATUS_FILE="$TEST_TMP/status.json"
+	export LOG_BASE="$TEST_TMP/logs/test"
+	export LOG_FILE="$LOG_BASE/orchestrator.log"
+	export STAGE_COUNTER=0
+
+	mkdir -p "$LOG_BASE/stages" "$LOG_BASE/context"
+
+	ORCHESTRATOR_START_EPOCH=$(date +%s)
+	DEGRADED_STAGES=()
+
+	source_orchestrator_functions
+	init_status
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# =============================================================================
+# STATIC ANALYSIS: partial-completion detection after the implement stage
+# =============================================================================
+
+@test "implement stage records implement:partial when completed_tasks < task_count" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	# The exact DEGRADED_STAGES entry appended on partial completion.
+	[[ "$script_content" == *'DEGRADED_STAGES+=("implement:partial:${completed_tasks}/${task_count}")'* ]]
+}
+
+@test "partial detection gate compares completed_tasks against task_count" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	[[ "$script_content" == *'(( completed_tasks < task_count ))'* ]]
+}
+
+@test "partial detection posts an issue comment listing failed tasks" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	[[ "$script_content" == *'Implementation: Partial'* ]]
+	# The failed-task list is derived from status.json tasks with status failed
+	[[ "$script_content" == *'select(.status == "failed")'* ]]
+}
+
+@test "partial detection persists a merge_blocked_reason to status.json" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	# A persisted reason lets a standalone process-pr / resumed run honour the gate
+	[[ "$script_content" == *'Partial implementation'* ]]
+}
+
+# =============================================================================
+# STATIC ANALYSIS: BLOCK_MERGE_ON_PARTIAL gate in the merge stage
+# =============================================================================
+
+@test "merge stage checks BLOCK_MERGE_ON_PARTIAL env var" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	[[ "$script_content" == *'BLOCK_MERGE_ON_PARTIAL:-1'* ]]
+}
+
+@test "BLOCK_MERGE_ON_PARTIAL defaults to 1 (blocking enabled)" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	[[ "$script_content" == *'BLOCK_MERGE_ON_PARTIAL:-1'* ]]
+	[[ "$script_content" != *'BLOCK_MERGE_ON_PARTIAL:-0'* ]]
+}
+
+@test "merge stage blocks on implement:partial degraded entry" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	[[ "$script_content" == *'implement:partial:*'* ]]
+}
+
+@test "merge stage blocks on pr_review max_iterations and wall_timeout" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	[[ "$script_content" == *'pr_review:max_iterations:*'* ]]
+	[[ "$script_content" == *'pr_review:wall_timeout'* ]]
+}
+
+@test "merge stage logs bypass message when BLOCK_MERGE_ON_PARTIAL=0" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	[[ "$script_content" == *'BLOCK_MERGE_ON_PARTIAL=0 — skipping partial/pr-review merge-block check'* ]]
+}
+
+@test "partial block check precedes merge-mr.sh call" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	local block_pos merge_pos
+	block_pos=$(grep -n 'BLOCK_MERGE_ON_PARTIAL' <<< "$script_content" \
+		| tail -1 | cut -d: -f1)
+	merge_pos=$(grep -n 'merge-mr.sh' <<< "$script_content" \
+		| tail -1 | cut -d: -f1)
+
+	(( block_pos < merge_pos ))
+}
+
+# =============================================================================
+# STATIC ANALYSIS: completed_partial final state + distinct exit code
+# =============================================================================
+
+@test "merge stage sets final state completed_partial when partial-blocked" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	[[ "$script_content" == *'set_final_state "completed_partial"'* ]]
+}
+
+@test "partial-blocked path exits non-zero and distinct from error (exit 2)" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	# The exit statement following set_final_state "completed_partial" must be
+	# exit 2 — non-zero (unlike merge_blocked's exit 0) and distinct from the
+	# error path's exit 1.
+	local block_pos next_exit
+	block_pos=$(grep -n 'set_final_state "completed_partial"' <<< "$script_content" \
+		| tail -1 | cut -d: -f1)
+	next_exit=$(awk "NR>$block_pos && /exit [0-9]/{ print; exit }" <<< "$script_content")
+	[[ "$next_exit" == *'exit 2'* ]]
+}
+
+@test "convergence merge_blocked path still exits 0 (regression guard)" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	# Issue #577 must not change the convergence gate: the exit after the last
+	# set_final_state "merge_blocked" stays exit 0.
+	local block_pos next_exit
+	block_pos=$(grep -n 'set_final_state "merge_blocked"' <<< "$script_content" \
+		| tail -1 | cut -d: -f1)
+	next_exit=$(awk "NR>$block_pos && /exit [0-9]/{ print; exit }" <<< "$script_content")
+	[[ "$next_exit" == *'exit 0'* ]]
+}
+
+@test "final comment path includes a task summary helper" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	[[ "$script_content" == *'_format_task_summary_line'* ]]
+}
+
+# =============================================================================
+# FUNCTIONAL: _format_task_summary_line reflects failed tasks
+# =============================================================================
+
+@test "_format_task_summary_line reports completed/total with failure count" {
+	# Seed status.json with 1 completed + 2 failed tasks
+	jq '.tasks = [
+		{"id":1,"description":"A","status":"completed"},
+		{"id":2,"description":"B","status":"failed"},
+		{"id":3,"description":"C","status":"failed"}
+	]' "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+
+	local line
+	line=$(_format_task_summary_line)
+
+	[[ "$line" == *'1/3'* ]]
+	[[ "$line" == *'2 failed'* ]]
+}
+
+@test "_format_task_summary_line is empty when there are no tasks" {
+	# init_status leaves .tasks absent/empty
+	local line
+	line=$(_format_task_summary_line)
+
+	[[ -z "$line" ]]
+}
+
+# =============================================================================
+# FUNCTIONAL: partial gate logic (mirrors the in-script scan)
+# =============================================================================
+
+@test "partial gate detects implement:partial entry and blocks" {
+	declare -a deg=("implement:partial:1/3")
+
+	local blocked_reason=""
+	if [[ "${BLOCK_MERGE_ON_PARTIAL:-1}" != "0" ]]; then
+		local _ds
+		for _ds in "${deg[@]}"; do
+			if [[ "$_ds" == implement:partial:* ]]; then
+				blocked_reason="Partial implementation — not all tasks completed (degraded_stages: $_ds)"
+				break
+			fi
+		done
+	fi
+
+	[[ -n "$blocked_reason" ]]
+	[[ "$blocked_reason" == *"1/3"* ]]
+}
+
+@test "partial gate detects pr_review:max_iterations entry and blocks" {
+	declare -a deg=("pr_review:max_iterations:iter=4")
+
+	local blocked_reason=""
+	local _ds
+	for _ds in "${deg[@]}"; do
+		if [[ "$_ds" == pr_review:max_iterations:* || "$_ds" == pr_review:wall_timeout ]]; then
+			blocked_reason="PR review loop ended without an approved verdict (degraded_stages: $_ds)"
+			break
+		fi
+	done
+
+	[[ -n "$blocked_reason" ]]
+	[[ "$blocked_reason" == *"max_iterations"* ]]
+}
+
+@test "partial gate detects pr_review:wall_timeout entry and blocks" {
+	declare -a deg=("pr_review:wall_timeout")
+
+	local blocked_reason=""
+	local _ds
+	for _ds in "${deg[@]}"; do
+		if [[ "$_ds" == pr_review:max_iterations:* || "$_ds" == pr_review:wall_timeout ]]; then
+			blocked_reason="PR review loop ended without an approved verdict (degraded_stages: $_ds)"
+			break
+		fi
+	done
+
+	[[ -n "$blocked_reason" ]]
+}
+
+@test "BLOCK_MERGE_ON_PARTIAL=0 restores merge-anyway behaviour" {
+	export BLOCK_MERGE_ON_PARTIAL=0
+	declare -a deg=("implement:partial:1/3")
+
+	local blocked_reason=""
+	if [[ "${BLOCK_MERGE_ON_PARTIAL:-1}" != "0" ]]; then
+		local _ds
+		for _ds in "${deg[@]}"; do
+			if [[ "$_ds" == implement:partial:* ]]; then
+				blocked_reason="blocked"
+				break
+			fi
+		done
+	fi
+
+	# Gate bypassed — merge-mr.sh would be reached
+	[[ -z "$blocked_reason" ]]
+}
+
+@test "partial gate ignores non-blocking degradations" {
+	declare -a deg=("test:max_iterations:iter=7" "deploy_verify:deploy_failed:exit=1")
+
+	local blocked_reason=""
+	local _ds
+	for _ds in "${deg[@]}"; do
+		if [[ "$_ds" == implement:partial:* \
+			|| "$_ds" == pr_review:max_iterations:* \
+			|| "$_ds" == pr_review:wall_timeout ]]; then
+			blocked_reason="blocked"
+			break
+		fi
+	done
+
+	[[ -z "$blocked_reason" ]]
+}
+
+# =============================================================================
+# FUNCTIONAL: failed-task list derivation from status.json
+# =============================================================================
+
+@test "failed-task list names each failed task from status.json" {
+	jq '.tasks = [
+		{"id":1,"description":"Add regression test","status":"completed"},
+		{"id":2,"description":"Fix the secret handling","status":"failed"},
+		{"id":3,"description":"Update the workflow file","status":"failed"}
+	]' "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+
+	local failed_list
+	failed_list=$(jq -r '
+		[.tasks[]? | select(.status == "failed")
+			| "- Task \(.id): \(.description)"] | join("\n")' "$STATUS_FILE")
+
+	[[ "$failed_list" == *"Fix the secret handling"* ]]
+	[[ "$failed_list" == *"Update the workflow file"* ]]
+	[[ "$failed_list" != *"Add regression test"* ]]
+}
+
+# =============================================================================
+# STATIC ANALYSIS: batch-orchestrator handles completed_partial without crash
+# =============================================================================
+
+@test "batch-orchestrator maps completed_partial state explicitly" {
+	local batch_content
+	batch_content=$(< "$BATCH_ORCHESTRATOR_SCRIPT_PATH")
+
+	# Must have an explicit case arm so completed_partial is NOT swept into the
+	# generic error path (which would flip to success via the PR-recovery logic).
+	[[ "$batch_content" == *'completed_partial)'* ]]
+}

--- a/.claude/scripts/implement-issue-test/test-soft-fail-convergence.bats
+++ b/.claude/scripts/implement-issue-test/test-soft-fail-convergence.bats
@@ -217,25 +217,50 @@ teardown() {
 }
 
 # =============================================================================
-# NO EXIT 2 IN SCRIPT (soft-fail replaces hard exit)
+# NO MID-LOOP HARD EXIT (soft-fail replaces hard exit)
+#
+# Historically the quality/test/pr loops hard-failed with `exit 2` when they
+# exceeded their iteration budget; that was replaced with the soft-fail pattern
+# (break + DEGRADED_STAGES) so the pipeline continues to PR/merge reporting.
+# Issue #577 reintroduces a SINGLE, TERMINAL `exit 2` at the merge gate for the
+# completed_partial state (after the PR exists) — a distinct non-zero exit so
+# batch metrics and operators can tell a partial delivery from an error or a
+# full success.  These tests guard the original invariant (loops soft-fail)
+# while permitting that one terminal exit.
 # =============================================================================
 
-@test "no exit 2 calls remain in orchestrator" {
-	local script_path
-	script_path="$ORCHESTRATOR_SCRIPT"
-	local exit2_count
-	exit2_count=$(grep -c 'exit 2' "$script_path" || true)
-	[ "$exit2_count" -eq 0 ]
-}
-
-@test "orchestrator uses soft-fail pattern instead of exit 2" {
+@test "the only exit 2 is the terminal completed_partial merge-gate path" {
 	local script_content
 	script_content=$(< "$ORCHESTRATOR_SCRIPT")
 
-	# Soft-fail means loops break and add to DEGRADED_STAGES
-	# rather than calling exit 2
+	# Exactly one `exit 2` (line-terminal) may remain.
+	local exit2_count
+	exit2_count=$(grep -c 'exit 2$' "$ORCHESTRATOR_SCRIPT" || true)
+	[ "$exit2_count" -eq 1 ]
+
+	# ...and it must follow set_final_state "completed_partial" (issue #577),
+	# i.e. it is the terminal partial-delivery exit, not a mid-loop hard-fail.
+	local block_pos next_exit
+	block_pos=$(grep -n 'set_final_state "completed_partial"' <<< "$script_content" \
+		| tail -1 | cut -d: -f1)
+	next_exit=$(awk "NR>$block_pos && /exit [0-9]/{ print; exit }" <<< "$script_content")
+	[[ "$next_exit" == *'exit 2'* ]]
+}
+
+@test "orchestrator uses soft-fail pattern in loops (not a mid-loop exit 2)" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	# Soft-fail means the quality/test/pr loops break and add to DEGRADED_STAGES
+	# rather than hard-exiting.
 	[[ "$script_content" == *"DEGRADED_STAGES"* ]]
-	[[ "$script_content" != *"exit 2"* ]]
+	[[ "$script_content" == *'DEGRADED_STAGES+=("quality:max_iterations:'* ]]
+	[[ "$script_content" == *'DEGRADED_STAGES+=("quality:convergence_failure:'* ]]
+
+	# No more than the single terminal completed_partial exit 2 may exist.
+	local exit2_count
+	exit2_count=$(grep -c 'exit 2$' "$ORCHESTRATOR_SCRIPT" || true)
+	[ "$exit2_count" -le 1 ]
 }
 
 # =============================================================================


### PR DESCRIPTION
Closes #577. Stacked on #581 (which stacks on #580).

## Problem
The orchestrator auto-merged and reported `Status: completed` even when only a subset of implementation tasks succeeded AND/OR the PR review loop bailed via max-iterations/timeout without an approved verdict. Nothing in the issue comments, exit code, or final state flagged the partial delivery.

## Changes (`.claude/scripts/implement-issue-orchestrator.sh`)
1. **Partial detection** — after the implement stage, when `completed_tasks < task_count`, append `implement:partial:<n>/<m>` to `DEGRADED_STAGES`, persist a `merge_blocked_reason`, and post an "Implementation: Partial" issue comment listing each failed task.
2. **Extended merge gate** — new Gate B blocks auto-merge on `implement:partial:*`, `pr_review:max_iterations:*`, and `pr_review:wall_timeout`, overridable via `BLOCK_MERGE_ON_PARTIAL=0`. The existing convergence gate (Gate A) is unchanged. When blocked, the PR is left open with an explanatory comment.
3. **`completed_partial` final state** — distinct from `error`, exits `2` (vs merge_blocked's `exit 0` and error's `exit 1`). A `_format_task_summary_line` helper injects the task summary into terminal comments (partial-block, convergence-block, and the merge-complete success path).

## Batch (`.claude/scripts/batch-orchestrator.sh`)
Explicit `completed_partial)` case arm maps it like `merge_blocked` (leave PR open) so it is NOT swept into the generic error path — where the PR-recovery logic would otherwise wrongly flip a partial to success.

## Tests (`.claude/scripts/implement-issue-test/`)
- New `test-merge-block-partial.bats` (23 tests): partial detection records `implement:partial`; merge gate blocks on partial + pr_review degradation; `BLOCK_MERGE_ON_PARTIAL=0` restores merge-anyway; `completed_partial`/exit 2 distinct from convergence's exit 0; task-summary helper; failed-task list derivation; batch maps `completed_partial`.
- Updated `test-soft-fail-convergence.bats`: the two "no exit 2" CODECHECK tests now permit the single terminal `completed_partial` exit while still guarding loops against mid-loop hard-fail.

## Verification
- `bash -n` clean on both orchestrators.
- Full suite green except one PRE-EXISTING unrelated failure (`test-skill-validate.bats` "issue-204 writing-agents SKILL.md exits 0" — fails identically with all changes stashed; touches no file in this PR).

Implemented subagent-driven to avoid the self-modification hazard (the orchestrator was edited with Edit, never run).