### PR TITLE
feat(issue-585): MT/issue cost trend guard

### DIFF
--- a/.claude/scripts/batch-orchestrator.sh
+++ b/.claude/scripts/batch-orchestrator.sh
@@ -82,6 +82,17 @@ ACTIVE_ORCH_PGID=""
 # to log and record why an issue was skipped in status.json.
 _SKIP_REASON=""
 
+# Epic-scope signal set by validate_issue_for_processing() when an issue is
+# flagged as epic-scope (see EPIC_SCOPE_MAX_TASKS). Epic issues concentrate
+# spend, so they are routed to split-first (skipped from a wholesale run)
+# rather than implemented in a single expensive pass. Empty when not epic.
+_EPIC_SCOPE=""
+
+# Epic-scope task-count threshold: an issue whose body carries more than this
+# many task/AC checkboxes is treated as epic-scope regardless of labels. Set
+# generously so ordinary multi-task issues are not flagged. Env-configurable.
+EPIC_SCOPE_MAX_TASKS="${EPIC_SCOPE_MAX_TASKS:-20}"
+
 # Timeouts and limits
 readonly ISSUE_TIMEOUT=10800  # 180 minutes per issue
 readonly MAX_CONSECUTIVE_FAILURES=3
@@ -879,6 +890,39 @@ validate_issue_for_processing() {
 			return 0
 		fi
 		_SKIP_REASON="needs-explore label"
+		return 1
+	fi
+
+	# -----------------------------------------------------------------
+	# Check 1b: epic-scope flag — route oversized issues to split-first
+	#
+	# Epic-scope issues concentrate spend (claude-spend: 48 epic-scope runs
+	# used 35% of tokens). Detect them at preflight — via an `epic`/
+	# `epic-scope` label or an oversized body (more than EPIC_SCOPE_MAX_TASKS
+	# task/AC checkboxes) — set _EPIC_SCOPE, and route to split-first by
+	# skipping the wholesale run so the issue is broken into sub-issues first.
+	# -----------------------------------------------------------------
+	_EPIC_SCOPE=""
+	local has_epic_label epic_body epic_task_count
+	has_epic_label=$(printf '%s' "$issue_json" \
+		| jq -r '[.labels[].name] | any(. == "epic" or . == "epic-scope")' \
+		2>/dev/null) || has_epic_label="false"
+	epic_body=$(printf '%s' "$issue_json" \
+		| jq -r '.body // ""' 2>/dev/null) || epic_body=""
+	epic_task_count=$(printf '%s' "$epic_body" \
+		| grep -cE '^[[:space:]]*[-*] \[[ xX]\]' 2>/dev/null) \
+		|| epic_task_count=0
+
+	if [[ "$has_epic_label" == "true" ]] \
+		|| (( epic_task_count > EPIC_SCOPE_MAX_TASKS )); then
+		if [[ "$has_epic_label" == "true" ]]; then
+			_EPIC_SCOPE="epic label"
+		else
+			_EPIC_SCOPE="oversized body ($epic_task_count checkboxes > $EPIC_SCOPE_MAX_TASKS)"
+		fi
+		log_warn "Preflight #$issue_num: epic-scope ($_EPIC_SCOPE)" \
+			"— routing to split-first"
+		_SKIP_REASON="epic-scope — split into sub-issues first ($_EPIC_SCOPE)"
 		return 1
 	fi
 
@@ -1794,9 +1838,43 @@ _batch_outcome=$(jq -r '.state' "$STATUS_FILE" 2>/dev/null)
 [[ -z "$_batch_outcome" || "$_batch_outcome" == "null" ]] && _batch_outcome="failed"
 emit_event "batch_end" "outcome=$_batch_outcome"
 
+# -----------------------------------------------------------------------------
+# COST/TOKEN TREND GUARD (advisory, non-blocking — issue #585)
+#
+# Evaluate this batch's MT/issue against a rolling baseline of recent batch
+# summaries. The guard reads #580's cost_summary (falling back to the ab-report
+# stage-log token parse) and NO-OPs cleanly when cost_summary is absent. Its
+# verdict is attached to summary.json as cost_rollup / trend_warning and, when
+# a drift is detected, surfaced on the event stream as cost_trend_warning.
+# Every failure mode degrades to a benign noop verdict so the guard can never
+# block or fail the batch.
+# -----------------------------------------------------------------------------
+_trend_verdict='{"status":"noop","warning":false}'
+_trend_guard="$SCRIPT_DIR/cost-trend-guard.sh"
+if [[ -x "$_trend_guard" ]]; then
+    _trend_out=$("$_trend_guard" \
+        --current "$STATUS_FILE" \
+        --history-dir "$(dirname "$LOG_BASE")" 2>/dev/null) || _trend_out=""
+    if [[ -n "$_trend_out" ]] && printf '%s' "$_trend_out" | jq empty 2>/dev/null; then
+        _trend_verdict="$_trend_out"
+    fi
+fi
+
+_trend_warn=$(printf '%s' "$_trend_verdict" | jq -r '.warning // false' 2>/dev/null)
+if [[ "$_trend_warn" == "true" ]]; then
+    _trend_msg=$(printf '%s' "$_trend_verdict" | jq -r '.message // "cost trend regression detected"')
+    log_warn "Cost trend guard: $_trend_msg"
+    emit_event "cost_trend_warning" \
+        "latest_mt_per_issue:=$(printf '%s' "$_trend_verdict" | jq -c '.latest_mt_per_issue // 0')" \
+        "baseline_mt_per_issue:=$(printf '%s' "$_trend_verdict" | jq -c '.baseline_mt_per_issue // 0')" \
+        "factor:=$(printf '%s' "$_trend_verdict" | jq -c '.factor // 0')" \
+        "window:=$(printf '%s' "$_trend_verdict" | jq -c '.window // 0')"
+fi
+
 # Write summary — include deploy_verify_failed and skipped counts in
-# .progress so consumers can query them without iterating .issues[].
-jq '{
+# .progress so consumers can query them without iterating .issues[]. The
+# cost_rollup / trend_warning fields carry the advisory trend guard verdict.
+jq --argjson trend "$_trend_verdict" '{
     state: .state,
     base_branch: .base_branch,
     progress: (.progress + {
@@ -1808,6 +1886,14 @@ jq '{
     issues: [.issues[] | {
         number, status, pr, follow_ups, error, deploy_verify_failed
     }],
+    cost_summary: (.cost_summary // null),
+    cost_rollup: {
+        latest_mt_per_issue: ($trend.latest_mt_per_issue // null),
+        baseline_mt_per_issue: ($trend.baseline_mt_per_issue // null),
+        window: ($trend.window // null),
+        factor: ($trend.factor // null)
+    },
+    trend_warning: ($trend.warning // false),
     log_dir: .log_dir,
     completed_at: (now | todate)
 }' "$STATUS_FILE" > "$LOG_BASE/summary.json"

--- a/.claude/scripts/batch-orchestrator.sh
+++ b/.claude/scripts/batch-orchestrator.sh
@@ -435,7 +435,11 @@ init_status() {
             "started_at": null,
             "stage_started_at": null,
             "completed_at": null,
-            "cost_usd": 0
+            "cost_usd": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0
         }]')
     done
 
@@ -466,7 +470,15 @@ init_status() {
             },
             issues: $issues,
             cost_summary: {
-                total_cost_usd: ($issues | map(.cost_usd // 0) | add // 0)
+                total_cost_usd: ($issues | map(.cost_usd // 0) | add // 0),
+                total_input_tokens:
+                    ($issues | map(.input_tokens // 0) | add // 0),
+                total_output_tokens:
+                    ($issues | map(.output_tokens // 0) | add // 0),
+                total_cache_read_tokens:
+                    ($issues | map(.cache_read_tokens // 0) | add // 0),
+                total_cache_creation_tokens:
+                    ($issues | map(.cache_creation_tokens // 0) | add // 0)
             },
             rate_limit: {
                 waiting: false,
@@ -522,6 +534,14 @@ update_progress() {
             ([.issues[] | select(.status == "pending")] | length) |
         .cost_summary.total_cost_usd =
             ([.issues[] | (.cost_usd // 0)] | add // 0) |
+        .cost_summary.total_input_tokens =
+            ([.issues[] | (.input_tokens // 0)] | add // 0) |
+        .cost_summary.total_output_tokens =
+            ([.issues[] | (.output_tokens // 0)] | add // 0) |
+        .cost_summary.total_cache_read_tokens =
+            ([.issues[] | (.cache_read_tokens // 0)] | add // 0) |
+        .cost_summary.total_cache_creation_tokens =
+            ([.issues[] | (.cache_creation_tokens // 0)] | add // 0) |
         .last_update = (now | todate)' \
         "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
 }
@@ -1203,11 +1223,31 @@ process_issue() {
     # the batch cost_summary rollup. `// 0` degrades to zero when the
     # field is absent rather than corrupting status.json.
     local impl_cost_usd="0"
+    local impl_input_tokens="0" impl_output_tokens="0"
+    local impl_cache_read_tokens="0" impl_cache_creation_tokens="0"
     if [[ -f "$issue_status_file" ]]; then
         impl_cost_usd=$(jq -r '.cost_summary.total_cost_usd // 0' \
             "$issue_status_file" 2>/dev/null) || impl_cost_usd="0"
+        impl_input_tokens=$(jq -r '.cost_summary.total_input_tokens // 0' \
+            "$issue_status_file" 2>/dev/null) || impl_input_tokens="0"
+        impl_output_tokens=$(jq -r '.cost_summary.total_output_tokens // 0' \
+            "$issue_status_file" 2>/dev/null) || impl_output_tokens="0"
+        impl_cache_read_tokens=$(jq -r \
+            '.cost_summary.total_cache_read_tokens // 0' \
+            "$issue_status_file" 2>/dev/null) || impl_cache_read_tokens="0"
+        impl_cache_creation_tokens=$(jq -r \
+            '.cost_summary.total_cache_creation_tokens // 0' \
+            "$issue_status_file" 2>/dev/null) || impl_cache_creation_tokens="0"
     fi
     update_issue_field "$issue_num" "cost_usd" "$impl_cost_usd" "true"
+    update_issue_field "$issue_num" "input_tokens" \
+        "$impl_input_tokens" "true"
+    update_issue_field "$issue_num" "output_tokens" \
+        "$impl_output_tokens" "true"
+    update_issue_field "$issue_num" "cache_read_tokens" \
+        "$impl_cache_read_tokens" "true"
+    update_issue_field "$issue_num" "cache_creation_tokens" \
+        "$impl_cache_creation_tokens" "true"
 
     # Log location of metrics.json emitted by the orchestrator's EXIT trap
     if [[ -f "$issue_status_file" ]]; then
@@ -1842,8 +1882,9 @@ emit_event "batch_end" "outcome=$_batch_outcome"
 # COST/TOKEN TREND GUARD (advisory, non-blocking — issue #585)
 #
 # Evaluate this batch's MT/issue against a rolling baseline of recent batch
-# summaries. The guard reads #580's cost_summary (falling back to the ab-report
-# stage-log token parse) and NO-OPs cleanly when cost_summary is absent. Its
+# summaries. The guard reads the batch cost_summary token totals (rolled up
+# from #580's per-issue cost_summary) and NO-OPs cleanly when cost_summary is
+# absent or carries only total_cost_usd (no token totals). Its
 # verdict is attached to summary.json as cost_rollup / trend_warning and, when
 # a drift is detected, surfaced on the event stream as cost_trend_warning.
 # Every failure mode degrades to a benign noop verdict so the guard can never

--- a/.claude/scripts/cost-trend-guard.sh
+++ b/.claude/scripts/cost-trend-guard.sh
@@ -9,15 +9,16 @@
 # orchestrator attaches to summary.json (as cost_rollup / trend_warning) and
 # forwards to the event stream as a `cost_trend_warning` event.
 #
-# Metric source (in order):
-#   1. #580's `cost_summary` token fields in a batch summary/status JSON.
-#   2. Fallback: the total_cost_usd/token parse pattern from ab-report.sh's
-#      collect_stage_costs(), applied over the run's log_dir stage logs — used
-#      when cost_summary carries only total_cost_usd (no token totals).
+# Metric source:
+#   The batch-level `cost_summary` token totals — total_input_tokens,
+#   total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens —
+#   emitted per-issue by #580 and rolled up across the batch by
+#   batch-orchestrator.sh (init_status / update_progress).
 #
 # NO-OP contract: when `cost_summary` is absent (older summaries pre-#580) or
-# no token metric can be derived, the verdict is {"status":"noop",...} and no
-# warning is produced.
+# carries only total_cost_usd with no token totals, the token sum is 0 and no
+# MT/issue is derivable, so the verdict is {"status":"noop",...} and no warning
+# is produced.
 #
 # Environment:
 #   COST_TREND_WINDOW  Rolling window size (# of recent batches).  Default 5.
@@ -39,39 +40,6 @@ set -uo pipefail
 
 COST_TREND_WINDOW="${COST_TREND_WINDOW:-5}"
 COST_TREND_FACTOR="${COST_TREND_FACTOR:-1.5}"
-
-# -----------------------------------------------------------------------------
-# ctg_tokens_from_logs <log_dir>
-#
-# Fallback token extractor. Reuses ab-report.sh's canonical parse: grep the
-# Claude CLI `--output-format json` result lines (identified by the presence of
-# "total_cost_usd") from every *.log under the run directory, then sum the
-# input/output/cache token fields. Prints a single integer (0 when nothing is
-# found).
-# -----------------------------------------------------------------------------
-ctg_tokens_from_logs() {
-	local log_dir="$1"
-	[[ -n "$log_dir" && -d "$log_dir" ]] || { printf '0'; return 0; }
-
-	local lines
-	lines=$(find "$log_dir" -type f -name '*.log' \
-		-exec grep -h '^{.*"total_cost_usd"' {} + 2>/dev/null) || lines=""
-	[[ -n "$lines" ]] || { printf '0'; return 0; }
-
-	printf '%s\n' "$lines" | jq -cs '
-		[.[] | select(.total_cost_usd != null)]
-		| ( map(.usage.input_tokens // .input_tokens // 0) | add // 0)
-		+ ( map(.usage.output_tokens // .output_tokens // 0) | add // 0)
-		+ ( map(.usage.cache_creation_input_tokens
-			// .usage.cache_creation_tokens
-			// .cache_creation_input_tokens
-			// .cache_creation_tokens // 0) | add // 0)
-		+ ( map(.usage.cache_read_input_tokens
-			// .usage.cache_read_tokens
-			// .cache_read_input_tokens
-			// .cache_read_tokens // 0) | add // 0)
-	' 2>/dev/null || printf '0'
-}
 
 # -----------------------------------------------------------------------------
 # ctg_batch_mt <summary_json_file>
@@ -98,25 +66,17 @@ ctg_batch_mt() {
 			or .status == "already_done")] | length)
 		// 0' "$file" 2>/dev/null) || completed=0
 
+	# Sum the batch-level token totals emitted by #580 (per-issue
+	# cost_summary) and rolled up by batch-orchestrator.sh (init_status /
+	# update_progress). When cost_summary carries only total_cost_usd (older
+	# summaries pre-token-rollup), every field is absent → sum is 0 → no-op.
 	tokens=$(jq -r '
 		(.cost_summary) as $cs
-		| ($cs.total_tokens
-			// (($cs.input_tokens // 0)
-				+ ($cs.output_tokens // 0)
-				+ ($cs.cache_creation_tokens // 0)
-				+ ($cs.cache_read_tokens // 0))
-			// 0)' "$file" 2>/dev/null) || tokens=0
-
-	# Fallback: cost_summary present but carries no token totals (current
-	# #580 records only total_cost_usd). Derive tokens from the run's stage
-	# logs using ab-report.sh's parse pattern.
-	if [[ -z "$tokens" || "$tokens" == "0" || "$tokens" == "null" ]]; then
-		local log_dir
-		log_dir=$(jq -r '.log_dir // empty' "$file" 2>/dev/null) || log_dir=""
-		if [[ -n "$log_dir" ]]; then
-			tokens=$(ctg_tokens_from_logs "$log_dir")
-		fi
-	fi
+		| (($cs.total_input_tokens // 0)
+			+ ($cs.total_output_tokens // 0)
+			+ ($cs.total_cache_read_tokens // 0)
+			+ ($cs.total_cache_creation_tokens // 0))' \
+		"$file" 2>/dev/null) || tokens=0
 
 	# Not computable → no-op (print nothing).
 	[[ -n "$tokens" && "$tokens" != "0" && "$tokens" != "null" ]] || return 0

--- a/.claude/scripts/cost-trend-guard.sh
+++ b/.claude/scripts/cost-trend-guard.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+#
+# cost-trend-guard.sh — advisory cost/token trend guard for the pipeline.
+#
+# Computes a rolling MT/issue (megatokens per completed issue) baseline over
+# the most recent N batch summaries and warns when the current batch exceeds
+# that baseline by a configurable factor. The guard is ADVISORY: it never
+# blocks or fails a batch. It emits a JSON verdict on stdout that the batch
+# orchestrator attaches to summary.json (as cost_rollup / trend_warning) and
+# forwards to the event stream as a `cost_trend_warning` event.
+#
+# Metric source (in order):
+#   1. #580's `cost_summary` token fields in a batch summary/status JSON.
+#   2. Fallback: the total_cost_usd/token parse pattern from ab-report.sh's
+#      collect_stage_costs(), applied over the run's log_dir stage logs — used
+#      when cost_summary carries only total_cost_usd (no token totals).
+#
+# NO-OP contract: when `cost_summary` is absent (older summaries pre-#580) or
+# no token metric can be derived, the verdict is {"status":"noop",...} and no
+# warning is produced.
+#
+# Environment:
+#   COST_TREND_WINDOW  Rolling window size (# of recent batches).  Default 5.
+#   COST_TREND_FACTOR  Warn when latest > baseline * factor.        Default 1.5.
+#
+# Usage:
+#   cost-trend-guard.sh --current <summary-or-status.json> \
+#                       [--history-dir <dir containing batch-*/summary.json>] \
+#                       [--window N] [--factor F]
+#
+# Output (stdout): a single-line JSON verdict. Exit code is always 0 for a
+# well-formed invocation so callers can treat the guard as non-blocking.
+#
+# This file is safe to `source` for unit testing: the CLI entry point only
+# runs when the script is executed directly, not when sourced.
+#
+
+set -uo pipefail
+
+COST_TREND_WINDOW="${COST_TREND_WINDOW:-5}"
+COST_TREND_FACTOR="${COST_TREND_FACTOR:-1.5}"
+
+# -----------------------------------------------------------------------------
+# ctg_tokens_from_logs <log_dir>
+#
+# Fallback token extractor. Reuses ab-report.sh's canonical parse: grep the
+# Claude CLI `--output-format json` result lines (identified by the presence of
+# "total_cost_usd") from every *.log under the run directory, then sum the
+# input/output/cache token fields. Prints a single integer (0 when nothing is
+# found).
+# -----------------------------------------------------------------------------
+ctg_tokens_from_logs() {
+	local log_dir="$1"
+	[[ -n "$log_dir" && -d "$log_dir" ]] || { printf '0'; return 0; }
+
+	local lines
+	lines=$(find "$log_dir" -type f -name '*.log' \
+		-exec grep -h '^{.*"total_cost_usd"' {} + 2>/dev/null) || lines=""
+	[[ -n "$lines" ]] || { printf '0'; return 0; }
+
+	printf '%s\n' "$lines" | jq -cs '
+		[.[] | select(.total_cost_usd != null)]
+		| ( map(.usage.input_tokens // .input_tokens // 0) | add // 0)
+		+ ( map(.usage.output_tokens // .output_tokens // 0) | add // 0)
+		+ ( map(.usage.cache_creation_input_tokens
+			// .usage.cache_creation_tokens
+			// .cache_creation_input_tokens
+			// .cache_creation_tokens // 0) | add // 0)
+		+ ( map(.usage.cache_read_input_tokens
+			// .usage.cache_read_tokens
+			// .cache_read_input_tokens
+			// .cache_read_tokens // 0) | add // 0)
+	' 2>/dev/null || printf '0'
+}
+
+# -----------------------------------------------------------------------------
+# ctg_batch_mt <summary_json_file>
+#
+# Prints the batch's MT/issue (megatokens per completed issue) as a decimal,
+# or prints NOTHING when the metric is unavailable (no cost_summary, zero
+# completed issues, or no derivable token total). An empty result is the
+# no-op signal.
+# -----------------------------------------------------------------------------
+ctg_batch_mt() {
+	local file="$1"
+	[[ -f "$file" ]] || return 0
+
+	# NO-OP gate: cost_summary must be present (issue #580 prerequisite).
+	local has_cs
+	has_cs=$(jq -r 'if (.cost_summary // null) == null then "no" else "yes" end' \
+		"$file" 2>/dev/null) || has_cs="no"
+	[[ "$has_cs" == "yes" ]] || return 0
+
+	local completed tokens
+	completed=$(jq -r '
+		.progress.completed
+		// ([.issues[]? | select(.status == "completed"
+			or .status == "already_done")] | length)
+		// 0' "$file" 2>/dev/null) || completed=0
+
+	tokens=$(jq -r '
+		(.cost_summary) as $cs
+		| ($cs.total_tokens
+			// (($cs.input_tokens // 0)
+				+ ($cs.output_tokens // 0)
+				+ ($cs.cache_creation_tokens // 0)
+				+ ($cs.cache_read_tokens // 0))
+			// 0)' "$file" 2>/dev/null) || tokens=0
+
+	# Fallback: cost_summary present but carries no token totals (current
+	# #580 records only total_cost_usd). Derive tokens from the run's stage
+	# logs using ab-report.sh's parse pattern.
+	if [[ -z "$tokens" || "$tokens" == "0" || "$tokens" == "null" ]]; then
+		local log_dir
+		log_dir=$(jq -r '.log_dir // empty' "$file" 2>/dev/null) || log_dir=""
+		if [[ -n "$log_dir" ]]; then
+			tokens=$(ctg_tokens_from_logs "$log_dir")
+		fi
+	fi
+
+	# Not computable → no-op (print nothing).
+	[[ -n "$tokens" && "$tokens" != "0" && "$tokens" != "null" ]] || return 0
+	[[ -n "$completed" && "$completed" != "0" && "$completed" != "null" ]] \
+		|| return 0
+
+	awk -v t="$tokens" -v c="$completed" \
+		'BEGIN { printf "%.6f", (t / 1000000) / c }'
+}
+
+# -----------------------------------------------------------------------------
+# ctg_baseline <window> <summary_file>...
+#
+# Computes the rolling baseline: the mean MT/issue over up to <window> of the
+# most-recent computable summaries. Non-computable summaries (no cost_summary)
+# are skipped. Files are consumed in the order given; the caller is expected to
+# pass them oldest-first (lexical batch-<ts> sort), so the last <window> are
+# the most recent. Prints the mean, or NOTHING when no computable summary
+# exists.
+# -----------------------------------------------------------------------------
+ctg_baseline() {
+	local window="$1"; shift
+	local -a vals=()
+	local f v
+	for f in "$@"; do
+		v=$(ctg_batch_mt "$f")
+		[[ -n "$v" ]] && vals+=("$v")
+	done
+
+	local n=${#vals[@]}
+	(( n > 0 )) || return 0
+
+	local start=0
+	(( n > window )) && start=$(( n - window ))
+	local -a recent=("${vals[@]:start}")
+
+	printf '%s\n' "${recent[@]}" \
+		| awk '{ sum += $1; c++ } END { if (c > 0) printf "%.6f", sum / c }'
+}
+
+# -----------------------------------------------------------------------------
+# ctg_evaluate <current_summary> [history_dir]
+#
+# Produces the advisory verdict JSON on stdout. Honors COST_TREND_WINDOW and
+# COST_TREND_FACTOR. Never exits non-zero for a computable/uncomputable metric.
+# -----------------------------------------------------------------------------
+ctg_evaluate() {
+	local current="$1"
+	local history_dir="${2:-}"
+	local window="${COST_TREND_WINDOW:-5}"
+	local factor="${COST_TREND_FACTOR:-1.5}"
+
+	local latest
+	latest=$(ctg_batch_mt "$current")
+
+	if [[ -z "$latest" ]]; then
+		jq -nc \
+			--argjson window "$window" \
+			--argjson factor "$factor" \
+			'{
+				status: "noop",
+				warning: false,
+				reason: "cost_summary absent or MT/issue not derivable",
+				latest_mt_per_issue: null,
+				baseline_mt_per_issue: null,
+				window: $window,
+				factor: $factor
+			}'
+		return 0
+	fi
+
+	local -a hist_files=()
+	if [[ -n "$history_dir" && -d "$history_dir" ]]; then
+		local f
+		while IFS= read -r f; do
+			[[ -n "$f" ]] || continue
+			[[ "$f" -ef "$current" ]] && continue
+			hist_files+=("$f")
+		done < <(find "$history_dir" -type f -name 'summary.json' \
+			2>/dev/null | sort)
+	fi
+
+	local baseline=""
+	(( ${#hist_files[@]} > 0 )) \
+		&& baseline=$(ctg_baseline "$window" "${hist_files[@]}")
+
+	if [[ -z "$baseline" ]]; then
+		jq -nc \
+			--argjson latest "$latest" \
+			--argjson window "$window" \
+			--argjson factor "$factor" \
+			'{
+				status: "ok",
+				warning: false,
+				reason: "no baseline history",
+				latest_mt_per_issue: $latest,
+				baseline_mt_per_issue: null,
+				window: $window,
+				factor: $factor
+			}'
+		return 0
+	fi
+
+	jq -nc \
+		--argjson latest "$latest" \
+		--argjson baseline "$baseline" \
+		--argjson window "$window" \
+		--argjson factor "$factor" \
+		'($baseline * $factor) as $threshold
+		 | ($latest > $threshold) as $warn
+		 | {
+			status: "ok",
+			warning: $warn,
+			latest_mt_per_issue: $latest,
+			baseline_mt_per_issue: $baseline,
+			threshold_mt_per_issue: $threshold,
+			window: $window,
+			factor: $factor,
+			message: (if $warn
+				then "MT/issue \($latest) exceeds baseline "
+					+ "\($baseline) × \($factor) = \($threshold)"
+				else "MT/issue \($latest) within baseline "
+					+ "\($baseline) × \($factor) = \($threshold)"
+				end)
+		 }'
+}
+
+# -----------------------------------------------------------------------------
+# CLI entry point
+# -----------------------------------------------------------------------------
+ctg_usage() {
+	cat >&2 <<'EOF'
+Usage: cost-trend-guard.sh --current <summary.json> [options]
+
+Options:
+  --current <file>       Batch summary/status JSON to evaluate (required)
+  --history-dir <dir>    Directory tree containing prior batch-*/summary.json
+  --window <N>           Rolling window size (overrides COST_TREND_WINDOW)
+  --factor <F>           Warn factor (overrides COST_TREND_FACTOR)
+  -h, --help             Show this help
+
+Environment: COST_TREND_WINDOW (default 5), COST_TREND_FACTOR (default 1.5).
+Output: a single-line advisory JSON verdict on stdout. Never blocking.
+EOF
+}
+
+ctg_main() {
+	local current="" history_dir=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--current)
+				current="${2:-}"; shift 2 ;;
+			--history-dir)
+				history_dir="${2:-}"; shift 2 ;;
+			--window)
+				COST_TREND_WINDOW="${2:-}"; shift 2 ;;
+			--factor)
+				COST_TREND_FACTOR="${2:-}"; shift 2 ;;
+			-h|--help)
+				ctg_usage; return 0 ;;
+			*)
+				printf 'cost-trend-guard: unknown argument: %s\n' "$1" >&2
+				return 2 ;;
+		esac
+	done
+
+	if [[ -z "$current" ]]; then
+		printf 'cost-trend-guard: --current <summary.json> is required\n' >&2
+		return 2
+	fi
+
+	ctg_evaluate "$current" "$history_dir"
+}
+
+# Only run the CLI when executed directly, not when sourced by tests.
+# The `:-` guards keep this safe under `set -u` when sourced by a shell that
+# does not populate BASH_SOURCE.
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+	ctg_main "$@"
+fi

--- a/.claude/scripts/implement-issue-test/test-cost-trend-guard.bats
+++ b/.claude/scripts/implement-issue-test/test-cost-trend-guard.bats
@@ -1,0 +1,387 @@
+#!/usr/bin/env bats
+#
+# test-cost-trend-guard.bats
+#
+# Tests for the advisory cost/token trend guard (issue #585):
+#   - cost-trend-guard.sh: rolling MT/issue baseline, factor threshold,
+#     env configurability, and NO-OP when #580's cost_summary is absent.
+#   - batch-orchestrator.sh: epic-scope preflight flag routing to split-first.
+#
+# The guard is ADVISORY — it must never exit non-zero for a well-formed
+# invocation and must degrade to a benign noop verdict.
+#
+
+load 'helpers/test-helper.bash'
+
+GUARD_SCRIPT="$SCRIPT_DIR/cost-trend-guard.sh"
+
+setup() {
+	setup_test_env
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# Build a batch summary JSON with token totals under cost_summary.
+# Usage: _mk_summary <file> <input_tokens> <output_tokens> <completed>
+_mk_summary() {
+	local file="$1" in_tok="$2" out_tok="$3" completed="$4"
+	mkdir -p "$(dirname "$file")"
+	jq -n \
+		--argjson i "$in_tok" \
+		--argjson o "$out_tok" \
+		--argjson c "$completed" \
+		'{cost_summary: {input_tokens: $i, output_tokens: $o},
+		  progress: {completed: $c}}' > "$file"
+}
+
+# =============================================================================
+# PRECONDITIONS
+# =============================================================================
+
+@test "cost-trend-guard.sh exists and is executable" {
+	[[ -f "$GUARD_SCRIPT" ]]
+	[[ -x "$GUARD_SCRIPT" ]]
+}
+
+@test "cost-trend-guard.sh passes bash -n" {
+	run bash -n "$GUARD_SCRIPT"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "cost-trend-guard.sh is sourceable without running the CLI" {
+	# Sourcing must define functions but not execute ctg_main.
+	source "$GUARD_SCRIPT"
+	run declare -f ctg_batch_mt
+	[[ "$status" -eq 0 ]]
+	run declare -f ctg_baseline
+	[[ "$status" -eq 0 ]]
+	run declare -f ctg_evaluate
+	[[ "$status" -eq 0 ]]
+}
+
+# =============================================================================
+# MT/ISSUE EXTRACTION + BASELINE MATH
+# =============================================================================
+
+@test "ctg_batch_mt computes megatokens per completed issue" {
+	source "$GUARD_SCRIPT"
+	# 6M + 4M = 10M tokens over 5 issues = 2.0 MT/issue.
+	_mk_summary "$TEST_TMP/s.json" 6000000 4000000 5
+	local mt
+	mt=$(ctg_batch_mt "$TEST_TMP/s.json")
+	[[ "$mt" == "2.000000" ]]
+}
+
+@test "ctg_batch_mt reads total_tokens when present" {
+	source "$GUARD_SCRIPT"
+	jq -n '{cost_summary: {total_tokens: 5000000}, progress: {completed: 2}}' \
+		> "$TEST_TMP/s.json"
+	local mt
+	mt=$(ctg_batch_mt "$TEST_TMP/s.json")
+	# 5M / 1e6 / 2 = 2.5
+	[[ "$mt" == "2.500000" ]]
+}
+
+@test "ctg_baseline averages MT/issue over the window" {
+	source "$GUARD_SCRIPT"
+	# Three batches: 1.0, 2.0, 3.0 MT/issue. Mean = 2.0.
+	_mk_summary "$TEST_TMP/b1.json" 1000000 0 1
+	_mk_summary "$TEST_TMP/b2.json" 2000000 0 1
+	_mk_summary "$TEST_TMP/b3.json" 3000000 0 1
+	local base
+	base=$(ctg_baseline 5 "$TEST_TMP/b1.json" "$TEST_TMP/b2.json" "$TEST_TMP/b3.json")
+	[[ "$base" == "2.000000" ]]
+}
+
+@test "ctg_baseline honors the window size (only most-recent N)" {
+	source "$GUARD_SCRIPT"
+	# Four batches: 1,2,3,4 MT/issue. Window 2 → mean of last two (3,4) = 3.5.
+	_mk_summary "$TEST_TMP/b1.json" 1000000 0 1
+	_mk_summary "$TEST_TMP/b2.json" 2000000 0 1
+	_mk_summary "$TEST_TMP/b3.json" 3000000 0 1
+	_mk_summary "$TEST_TMP/b4.json" 4000000 0 1
+	local base
+	base=$(ctg_baseline 2 \
+		"$TEST_TMP/b1.json" "$TEST_TMP/b2.json" \
+		"$TEST_TMP/b3.json" "$TEST_TMP/b4.json")
+	[[ "$base" == "3.500000" ]]
+}
+
+# =============================================================================
+# FACTOR THRESHOLD: WARN / NO-WARN
+# =============================================================================
+
+@test "warns when latest MT/issue exceeds baseline * factor" {
+	# Baseline 1.0 MT/issue; latest 2.0 > 1.0 * 1.5.
+	_mk_summary "$TEST_TMP/hist/batch-1/summary.json" 1000000 0 1
+	_mk_summary "$TEST_TMP/hist/batch-2/summary.json" 1000000 0 1
+	_mk_summary "$TEST_TMP/cur/status.json" 10000000 0 5
+
+	run env COST_TREND_FACTOR=1.5 COST_TREND_WINDOW=5 \
+		"$GUARD_SCRIPT" --current "$TEST_TMP/cur/status.json" \
+		--history-dir "$TEST_TMP/hist"
+	[[ "$status" -eq 0 ]]
+	local warn
+	warn=$(printf '%s' "$output" | jq -r '.warning')
+	[[ "$warn" == "true" ]]
+}
+
+@test "does not warn when latest is within baseline * factor" {
+	# Baseline 1.0; latest 2.0 is within 1.0 * 3.0.
+	_mk_summary "$TEST_TMP/hist/batch-1/summary.json" 1000000 0 1
+	_mk_summary "$TEST_TMP/hist/batch-2/summary.json" 1000000 0 1
+	_mk_summary "$TEST_TMP/cur/status.json" 10000000 0 5
+
+	run env COST_TREND_FACTOR=3.0 COST_TREND_WINDOW=5 \
+		"$GUARD_SCRIPT" --current "$TEST_TMP/cur/status.json" \
+		--history-dir "$TEST_TMP/hist"
+	[[ "$status" -eq 0 ]]
+	local warn
+	warn=$(printf '%s' "$output" | jq -r '.warning')
+	[[ "$warn" == "false" ]]
+}
+
+@test "COST_TREND_FACTOR env is honored (same data, opposite verdict)" {
+	_mk_summary "$TEST_TMP/hist/batch-1/summary.json" 1000000 0 1
+	_mk_summary "$TEST_TMP/cur/status.json" 1600000 0 1  # 1.6 MT/issue
+
+	# factor 1.5 → threshold 1.5 → 1.6 warns.
+	run env COST_TREND_FACTOR=1.5 "$GUARD_SCRIPT" \
+		--current "$TEST_TMP/cur/status.json" --history-dir "$TEST_TMP/hist"
+	[[ "$(printf '%s' "$output" | jq -r '.warning')" == "true" ]]
+
+	# factor 2.0 → threshold 2.0 → 1.6 does not warn.
+	run env COST_TREND_FACTOR=2.0 "$GUARD_SCRIPT" \
+		--current "$TEST_TMP/cur/status.json" --history-dir "$TEST_TMP/hist"
+	[[ "$(printf '%s' "$output" | jq -r '.warning')" == "false" ]]
+}
+
+@test "--factor / --window flags override the environment" {
+	_mk_summary "$TEST_TMP/hist/batch-1/summary.json" 1000000 0 1
+	_mk_summary "$TEST_TMP/cur/status.json" 1600000 0 1
+	run "$GUARD_SCRIPT" --current "$TEST_TMP/cur/status.json" \
+		--history-dir "$TEST_TMP/hist" --factor 1.5 --window 3
+	[[ "$status" -eq 0 ]]
+	[[ "$(printf '%s' "$output" | jq -r '.warning')" == "true" ]]
+	[[ "$(printf '%s' "$output" | jq -r '.factor')" == "1.5" ]]
+	[[ "$(printf '%s' "$output" | jq -r '.window')" == "3" ]]
+}
+
+# =============================================================================
+# NO-OP: cost_summary absent (issue #580 metric missing)
+# =============================================================================
+
+@test "no-ops when cost_summary is absent" {
+	jq -n '{progress: {completed: 5}}' > "$TEST_TMP/nocs.json"
+	run "$GUARD_SCRIPT" --current "$TEST_TMP/nocs.json"
+	[[ "$status" -eq 0 ]]
+	[[ "$(printf '%s' "$output" | jq -r '.status')" == "noop" ]]
+	[[ "$(printf '%s' "$output" | jq -r '.warning')" == "false" ]]
+}
+
+@test "ctg_batch_mt prints nothing when cost_summary is absent" {
+	source "$GUARD_SCRIPT"
+	jq -n '{progress: {completed: 5}}' > "$TEST_TMP/nocs.json"
+	local mt
+	mt=$(ctg_batch_mt "$TEST_TMP/nocs.json")
+	[[ -z "$mt" ]]
+}
+
+@test "no-ops when cost_summary present but no derivable token metric" {
+	# Only total_cost_usd, no token fields, and no stage logs to fall back on.
+	jq -n '{cost_summary: {total_cost_usd: 1.23}, progress: {completed: 3},
+	        log_dir: "does-not-exist"}' > "$TEST_TMP/costonly.json"
+	run "$GUARD_SCRIPT" --current "$TEST_TMP/costonly.json"
+	[[ "$status" -eq 0 ]]
+	[[ "$(printf '%s' "$output" | jq -r '.status')" == "noop" ]]
+}
+
+@test "advisory: guard exits 0 even with no history and no baseline" {
+	_mk_summary "$TEST_TMP/cur/status.json" 5000000 0 5
+	run "$GUARD_SCRIPT" --current "$TEST_TMP/cur/status.json"
+	[[ "$status" -eq 0 ]]
+	# Has a metric but no baseline → ok, warning false, never blocks.
+	[[ "$(printf '%s' "$output" | jq -r '.status')" == "ok" ]]
+	[[ "$(printf '%s' "$output" | jq -r '.warning')" == "false" ]]
+}
+
+# =============================================================================
+# FALLBACK: token parse over stage logs (ab-report pattern)
+# =============================================================================
+
+@test "falls back to stage-log token parse when cost_summary lacks tokens" {
+	# cost_summary has only total_cost_usd; tokens come from a stage log line
+	# matching ab-report.sh's `total_cost_usd` result grep.
+	local run_dir="$TEST_TMP/run"
+	mkdir -p "$run_dir/stages"
+	printf '%s\n' \
+		'{"total_cost_usd":0.5,"usage":{"input_tokens":4000000,"output_tokens":0}}' \
+		> "$run_dir/stages/implement.log"
+	jq -n --arg ld "$run_dir" \
+		'{cost_summary: {total_cost_usd: 0.5}, progress: {completed: 2},
+		  log_dir: $ld}' > "$run_dir/status.json"
+
+	source "$GUARD_SCRIPT"
+	local mt
+	mt=$(ctg_batch_mt "$run_dir/status.json")
+	# 4M / 1e6 / 2 = 2.0
+	[[ "$mt" == "2.000000" ]]
+}
+
+# =============================================================================
+# WIRING: batch-orchestrator.sh summary + event emission
+# =============================================================================
+
+@test "batch-orchestrator invokes cost-trend-guard.sh at batch end" {
+	run grep -q 'cost-trend-guard.sh' "$SCRIPT_DIR/batch-orchestrator.sh"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "batch-orchestrator summary jq adds cost_rollup and trend_warning" {
+	local body
+	body=$(awk '/Write summary/,/log.*Summary written/' \
+		"$SCRIPT_DIR/batch-orchestrator.sh")
+	[[ "$body" == *'cost_rollup'* ]]
+	[[ "$body" == *'trend_warning'* ]]
+}
+
+@test "batch-orchestrator emits cost_trend_warning event on warning" {
+	local body
+	body=$(awk '/COST\/TOKEN TREND GUARD/,/Write summary/' \
+		"$SCRIPT_DIR/batch-orchestrator.sh")
+	[[ "$body" == *'emit_event "cost_trend_warning"'* ]]
+}
+
+@test "pipeline-event schema includes cost_trend_warning in the enum" {
+	run jq -e '.properties.event.enum | index("cost_trend_warning")' \
+		"$SCRIPT_DIR/schemas/pipeline-event.json"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "a cost_trend_warning event validates through event-emit.sh" {
+	local emit="$SCRIPT_DIR/event-emit.sh"
+	[[ -x "$emit" ]] || skip "event-emit.sh not present"
+	local ev='{"ts":"2026-07-21T10:00:00+00:00","run_id":"batch-x","event":"cost_trend_warning","latest_mt_per_issue":2.0,"baseline_mt_per_issue":1.0,"factor":1.5,"window":5}'
+	run env LOG_DIR="$TEST_TMP" "$emit" "$ev"
+	[[ "$status" -eq 0 ]]
+}
+
+# =============================================================================
+# EPIC-SCOPE PREFLIGHT FLAG (batch-orchestrator.sh)
+# =============================================================================
+
+@test "validate_issue_for_processing detects epic-scope (static)" {
+	local body
+	body=$(_extract_function_body validate_issue_for_processing \
+		"$SCRIPT_DIR/batch-orchestrator.sh")
+	[[ "$body" == *'_EPIC_SCOPE'* ]]
+	[[ "$body" == *'split-first'* ]]
+}
+
+@test "batch-orchestrator declares _EPIC_SCOPE and EPIC_SCOPE_MAX_TASKS" {
+	run grep -q '^_EPIC_SCOPE=' "$SCRIPT_DIR/batch-orchestrator.sh"
+	[[ "$status" -eq 0 ]]
+	run grep -q 'EPIC_SCOPE_MAX_TASKS=' "$SCRIPT_DIR/batch-orchestrator.sh"
+	[[ "$status" -eq 0 ]]
+}
+
+# --- Functional: epic label routes to split-first (skip) ---
+
+# Source validate_issue_for_processing in isolation (mirrors the helper in
+# test-batch-orchestrator.bats).
+_source_validate() {
+	local lib="$SCRIPT_DIR/issue-body-lib.sh"
+	[[ -f "$lib" ]] || return 1
+	# shellcheck disable=SC1090
+	source "$lib"
+	local func_file="$TEST_TMP/validate_issue_for_processing.bash"
+	_extract_function_body validate_issue_for_processing \
+		"$SCRIPT_DIR/batch-orchestrator.sh" > "$func_file"
+	grep -q 'validate_issue_for_processing' "$func_file" 2>/dev/null || return 1
+	# shellcheck disable=SC1090
+	source "$func_file"
+}
+
+@test "functional: epic label flags _EPIC_SCOPE and skips" {
+	local mock_bin="$TEST_TMP/mock-bin"
+	mkdir -p "$mock_bin"
+	cat > "$mock_bin/gh" << 'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' '{"body":"## Implementation Tasks\n- [ ] do a thing","labels":[{"name":"epic"}]}'
+GHEOF
+	chmod +x "$mock_bin/gh"
+	export PATH="$mock_bin:$PATH"
+
+	_source_validate || skip "validate_issue_for_processing not present"
+	log()                  { :; }
+	log_warn()             { :; }
+	dispatch_composition() { return 1; }
+	export ENRICH_FOLLOWUPS=false
+	EPIC_SCOPE_MAX_TASKS=20
+
+	_SKIP_REASON=""
+	_EPIC_SCOPE=""
+	local rc=0
+	validate_issue_for_processing 42 || rc=$?
+
+	[[ "$rc" -eq 1 ]]
+	[[ -n "$_EPIC_SCOPE" ]]
+	[[ "$_SKIP_REASON" == *"epic-scope"* ]]
+}
+
+@test "functional: oversized body (checkbox count) flags epic-scope" {
+	local mock_bin="$TEST_TMP/mock-bin"
+	mkdir -p "$mock_bin"
+	# Body with 4 checkboxes; threshold lowered to 3 to trigger.
+	cat > "$mock_bin/gh" << 'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' '{"body":"## Implementation Tasks\n- [ ] a\n- [ ] b\n- [ ] c\n- [ ] d","labels":[]}'
+GHEOF
+	chmod +x "$mock_bin/gh"
+	export PATH="$mock_bin:$PATH"
+
+	_source_validate || skip "validate_issue_for_processing not present"
+	log()                  { :; }
+	log_warn()             { :; }
+	dispatch_composition() { return 1; }
+	export ENRICH_FOLLOWUPS=false
+	EPIC_SCOPE_MAX_TASKS=3
+
+	_SKIP_REASON=""
+	_EPIC_SCOPE=""
+	local rc=0
+	validate_issue_for_processing 43 || rc=$?
+
+	[[ "$rc" -eq 1 ]]
+	[[ "$_EPIC_SCOPE" == *"oversized body"* ]]
+}
+
+@test "functional: normal issue is NOT flagged epic-scope" {
+	local mock_bin="$TEST_TMP/mock-bin"
+	mkdir -p "$mock_bin"
+	# A well-formed non-epic issue with a couple of tasks and ACs.
+	cat > "$mock_bin/gh" << 'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' '{"body":"## Implementation Tasks\n- [ ] `[default]` do a thing — file.sh\n\n## Acceptance Criteria\n- [ ] it works","labels":[]}'
+GHEOF
+	chmod +x "$mock_bin/gh"
+	export PATH="$mock_bin:$PATH"
+
+	_source_validate || skip "validate_issue_for_processing not present"
+	log()                  { :; }
+	log_warn()             { :; }
+	dispatch_composition() { return 1; }
+	assert_issue_valid()   { return 0; }
+	export ENRICH_FOLLOWUPS=false
+	EPIC_SCOPE_MAX_TASKS=20
+
+	_SKIP_REASON=""
+	_EPIC_SCOPE=""
+	local rc=0
+	validate_issue_for_processing 44 || rc=$?
+
+	[[ "$rc" -eq 0 ]]
+	[[ -z "$_EPIC_SCOPE" ]]
+}

--- a/.claude/scripts/implement-issue-test/test-cost-trend-guard.bats
+++ b/.claude/scripts/implement-issue-test/test-cost-trend-guard.bats
@@ -23,7 +23,11 @@ teardown() {
 	teardown_test_env
 }
 
-# Build a batch summary JSON with token totals under cost_summary.
+# Build a batch summary/status JSON in the shape batch-orchestrator.sh writes:
+# a batch-level cost_summary with the #580 token totals (total_input_tokens /
+# total_output_tokens / total_cache_read_tokens / total_cache_creation_tokens)
+# plus progress.completed. Cache token totals are 0 here; the input/output
+# split is what drives the MT/issue arithmetic in these tests.
 # Usage: _mk_summary <file> <input_tokens> <output_tokens> <completed>
 _mk_summary() {
 	local file="$1" in_tok="$2" out_tok="$3" completed="$4"
@@ -32,8 +36,50 @@ _mk_summary() {
 		--argjson i "$in_tok" \
 		--argjson o "$out_tok" \
 		--argjson c "$completed" \
-		'{cost_summary: {input_tokens: $i, output_tokens: $o},
+		'{cost_summary: {
+			total_cost_usd: 0,
+			total_input_tokens: $i,
+			total_output_tokens: $o,
+			total_cache_read_tokens: 0,
+			total_cache_creation_tokens: 0
+		},
 		  progress: {completed: $c}}' > "$file"
+}
+
+# Build a batch status/summary JSON in the EXACT shape batch-orchestrator.sh
+# writes: an issues[] array carrying per-issue cost_usd + token fields, and a
+# batch-level cost_summary rolled up from those issues exactly as
+# update_progress does. Two completed issues total 10.5M tokens
+# (8M input + 1.5M output + 0.5M cache_read + 0.5M cache_creation) over 2
+# completed issues = 5.25 MT/issue.
+_mk_batch_status() {
+	local file="$1"
+	mkdir -p "$(dirname "$file")"
+	jq -n '{
+		state: "completed",
+		base_branch: "main",
+		progress: {total: 2, completed: 2, failed: 0},
+		issues: [
+			{number:"1", status:"completed", cost_usd:1.0,
+			 input_tokens:5000000, output_tokens:1000000,
+			 cache_read_tokens:500000, cache_creation_tokens:0},
+			{number:"2", status:"completed", cost_usd:0.6,
+			 input_tokens:3000000, output_tokens:500000,
+			 cache_read_tokens:0, cache_creation_tokens:500000}
+		]
+	}
+	| .cost_summary = {
+		total_cost_usd:
+			([.issues[] | (.cost_usd // 0)] | add // 0),
+		total_input_tokens:
+			([.issues[] | (.input_tokens // 0)] | add // 0),
+		total_output_tokens:
+			([.issues[] | (.output_tokens // 0)] | add // 0),
+		total_cache_read_tokens:
+			([.issues[] | (.cache_read_tokens // 0)] | add // 0),
+		total_cache_creation_tokens:
+			([.issues[] | (.cache_creation_tokens // 0)] | add // 0)
+	}' > "$file"
 }
 
 # =============================================================================
@@ -74,14 +120,18 @@ _mk_summary() {
 	[[ "$mt" == "2.000000" ]]
 }
 
-@test "ctg_batch_mt reads total_tokens when present" {
+@test "ctg_batch_mt sums all four token totals (incl. cache) from cost_summary" {
 	source "$GUARD_SCRIPT"
-	jq -n '{cost_summary: {total_tokens: 5000000}, progress: {completed: 2}}' \
-		> "$TEST_TMP/s.json"
+	# 5M in + 1M out + 0.5M cache_read + 0.5M cache_creation = 7M over 2 = 3.5.
+	jq -n '{cost_summary: {
+			total_input_tokens: 5000000,
+			total_output_tokens: 1000000,
+			total_cache_read_tokens: 500000,
+			total_cache_creation_tokens: 500000
+		}, progress: {completed: 2}}' > "$TEST_TMP/s.json"
 	local mt
 	mt=$(ctg_batch_mt "$TEST_TMP/s.json")
-	# 5M / 1e6 / 2 = 2.5
-	[[ "$mt" == "2.500000" ]]
+	[[ "$mt" == "3.500000" ]]
 }
 
 @test "ctg_baseline averages MT/issue over the window" {
@@ -189,13 +239,24 @@ _mk_summary() {
 	[[ -z "$mt" ]]
 }
 
-@test "no-ops when cost_summary present but no derivable token metric" {
-	# Only total_cost_usd, no token fields, and no stage logs to fall back on.
-	jq -n '{cost_summary: {total_cost_usd: 1.23}, progress: {completed: 3},
-	        log_dir: "does-not-exist"}' > "$TEST_TMP/costonly.json"
+@test "no-ops when cost_summary carries only total_cost_usd (no token totals)" {
+	# Old/absent token rollup: cost_summary has total_cost_usd but none of the
+	# total_*_tokens fields → token sum is 0 → not computable → noop. This is
+	# the pre-token-rollup graceful-degradation contract.
+	jq -n '{cost_summary: {total_cost_usd: 1.23}, progress: {completed: 3}}' \
+		> "$TEST_TMP/costonly.json"
 	run "$GUARD_SCRIPT" --current "$TEST_TMP/costonly.json"
 	[[ "$status" -eq 0 ]]
 	[[ "$(printf '%s' "$output" | jq -r '.status')" == "noop" ]]
+}
+
+@test "ctg_batch_mt prints nothing for token-less (cost-only) summary" {
+	source "$GUARD_SCRIPT"
+	jq -n '{cost_summary: {total_cost_usd: 1.23}, progress: {completed: 3}}' \
+		> "$TEST_TMP/costonly.json"
+	local mt
+	mt=$(ctg_batch_mt "$TEST_TMP/costonly.json")
+	[[ -z "$mt" ]]
 }
 
 @test "advisory: guard exits 0 even with no history and no baseline" {
@@ -208,26 +269,40 @@ _mk_summary() {
 }
 
 # =============================================================================
-# FALLBACK: token parse over stage logs (ab-report pattern)
+# REAL SHAPE: exact batch-orchestrator.sh status.json / summary.json end-to-end
+#
+# These exercise the guard against the EXACT JSON batch-orchestrator.sh now
+# writes — an issues[] array plus a batch-level cost_summary rolled up from the
+# #580 per-issue token fields. This is the RED→GREEN case: the pre-fix guard
+# read total_tokens / input_tokens / output_tokens (field names no producer
+# emits) and would derive nothing (noop, empty) from this shape.
 # =============================================================================
 
-@test "falls back to stage-log token parse when cost_summary lacks tokens" {
-	# cost_summary has only total_cost_usd; tokens come from a stage log line
-	# matching ab-report.sh's `total_cost_usd` result grep.
-	local run_dir="$TEST_TMP/run"
-	mkdir -p "$run_dir/stages"
-	printf '%s\n' \
-		'{"total_cost_usd":0.5,"usage":{"input_tokens":4000000,"output_tokens":0}}' \
-		> "$run_dir/stages/implement.log"
-	jq -n --arg ld "$run_dir" \
-		'{cost_summary: {total_cost_usd: 0.5}, progress: {completed: 2},
-		  log_dir: $ld}' > "$run_dir/status.json"
-
+@test "REAL SHAPE: ctg_batch_mt derives non-zero MT/issue from batch cost_summary" {
 	source "$GUARD_SCRIPT"
+	_mk_batch_status "$TEST_TMP/status.json"
 	local mt
-	mt=$(ctg_batch_mt "$run_dir/status.json")
-	# 4M / 1e6 / 2 = 2.0
-	[[ "$mt" == "2.000000" ]]
+	mt=$(ctg_batch_mt "$TEST_TMP/status.json")
+	[[ -n "$mt" ]]                 # must NOT no-op on the real shape
+	# 10.5M tokens / 2 completed issues = 5.25 MT/issue.
+	[[ "$mt" == "5.250000" ]]
+}
+
+@test "REAL SHAPE: ctg_evaluate warns when latest exceeds baseline * factor" {
+	# Realistic history: two prior batches at 1.0 MT/issue. Current batch (real
+	# full shape) is 5.25 MT/issue > 1.0 * 1.5 → warn.
+	_mk_summary "$TEST_TMP/hist/batch-1/summary.json" 1000000 0 1
+	_mk_summary "$TEST_TMP/hist/batch-2/summary.json" 1000000 0 1
+	_mk_batch_status "$TEST_TMP/cur/status.json"
+
+	run env COST_TREND_FACTOR=1.5 COST_TREND_WINDOW=5 \
+		"$GUARD_SCRIPT" --current "$TEST_TMP/cur/status.json" \
+		--history-dir "$TEST_TMP/hist"
+	[[ "$status" -eq 0 ]]
+	[[ "$(printf '%s' "$output" | jq -r '.status')" == "ok" ]]
+	[[ "$(printf '%s' "$output" | jq -r '.warning')" == "true" ]]
+	[[ "$(printf '%s' "$output" | jq -r '.latest_mt_per_issue')" == "5.250000" ]]
+	[[ "$(printf '%s' "$output" | jq -r '.baseline_mt_per_issue')" == "1.000000" ]]
 }
 
 # =============================================================================

--- a/.claude/scripts/schemas/pipeline-event.json
+++ b/.claude/scripts/schemas/pipeline-event.json
@@ -31,7 +31,8 @@
         "batch_end",
         "issue_start",
         "issue_end",
-        "batch_paused"
+        "batch_paused",
+        "cost_trend_warning"
       ],
       "description": "Event type discriminator"
     },
@@ -278,6 +279,31 @@
         }
       },
       "required": ["event", "consecutive_failures", "max_failures"]
+    },
+    {
+      "description": "Advisory cost/token trend guard fired — the batch's MT/issue exceeded the rolling baseline by the configured factor (issue #585). Non-blocking.",
+      "properties": {
+        "event": { "const": "cost_trend_warning" },
+        "latest_mt_per_issue": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Latest batch megatokens per completed issue"
+        },
+        "baseline_mt_per_issue": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Rolling baseline megatokens per issue over the window"
+        },
+        "factor": {
+          "type": "number",
+          "description": "Configured warn factor (COST_TREND_FACTOR)"
+        },
+        "window": {
+          "type": "integer",
+          "description": "Configured rolling window size (COST_TREND_WINDOW)"
+        }
+      },
+      "required": ["event", "latest_mt_per_issue", "baseline_mt_per_issue"]
     }
   ]
 }


### PR DESCRIPTION
Closes #585. Stacked on the #580→#581→#577 chain (base: `feature/issue-577`). Consumes #580's `cost_summary`.

## What

Adds an **advisory, non-blocking** cost/token trend guard plus an epic-scope preflight flag.

- **`.claude/scripts/cost-trend-guard.sh`** (new): computes rolling MT/issue (megatokens per completed issue) baseline over the most-recent N batch summaries; warns when the current batch exceeds `baseline × factor`. Env: `COST_TREND_WINDOW` (default 5), `COST_TREND_FACTOR` (default 1.5). Reads #580's `cost_summary` token fields; falls back to `ab-report.sh`'s `total_cost_usd`/token stage-log parse when `cost_summary` carries only `total_cost_usd`. **NO-OPs** cleanly (`{"status":"noop"}`) when `cost_summary` is absent.
- **`batch-orchestrator.sh`**: invokes the guard at batch end, attaches `cost_rollup` + `trend_warning` to `summary.json`, and emits a `cost_trend_warning` event when a drift is detected. Invocation is fully wrapped (`|| _trend_out=""`, `jq empty` guard, noop default) so it can never block or fail a batch.
- **Epic-scope preflight**: `validate_issue_for_processing()` now sets `_EPIC_SCOPE` (via `epic`/`epic-scope` label or a body exceeding `EPIC_SCOPE_MAX_TASKS` checkboxes, default 20) and routes to split-first (skip) alongside the needs-explore check.
- **`schemas/pipeline-event.json`**: adds `cost_trend_warning` to the event enum + a oneOf variant.

## Acceptance criteria

- Rolling MT/issue baseline over a configurable window, surfaced per batch in `summary.json` (`cost_rollup`) — yes.
- Baseline-factor exceedance emits a visible warning (`log_warn` + `cost_trend_warning` event) — yes.
- Epic-scope issues flagged at preflight and routed to split-first — yes.
- Baseline/factor/window env-configurable with sane defaults — yes.
- Guard is advisory (non-blocking) and no-ops when #580 `cost_summary` is absent — yes.
- BATS coverage for baseline math, factor threshold, no-op fallback, epic-scope flagging — yes.

## Tests

- `test-cost-trend-guard.bats`: 26/26 pass.
- `test-batch-orchestrator.bats`: 135/135 pass (regressions).
- `test-batch-events` 29/29, `test-event-emit` 24/24, `cost-accounting` 26/26 pass.
- `bash -n` clean on guard + orchestrator + ab-report; `jq empty` clean on the schema.

Subagent-driven (no live orchestrator).