### PR TITLE
feat(issue-583): token/cost budget ceiling + circuit breaker

### DIFF
--- a/.claude/scripts/batch-orchestrator.sh
+++ b/.claude/scripts/batch-orchestrator.sh
@@ -19,7 +19,11 @@
 # Exit codes:
 #   0  - All issues processed successfully
 #   1  - Some issues failed (check status.json)
-#   2  - Circuit breaker triggered
+#   2  - Circuit breaker triggered.  Two independent breakers share this code
+#        and set a distinct batch state before exiting:
+#          * consecutive failures    -> state "circuit_breaker"
+#          * per-batch token/cost cap -> state "budget_exceeded" (issue #583,
+#            terminal: the batch is never resumed or retried on a budget halt)
 #   3  - Configuration/argument error
 #
 
@@ -92,6 +96,25 @@ _EPIC_SCOPE=""
 # many task/AC checkboxes is treated as epic-scope regardless of labels. Set
 # generously so ordinary multi-task issues are not flagged. Env-configurable.
 EPIC_SCOPE_MAX_TASKS="${EPIC_SCOPE_MAX_TASKS:-20}"
+
+# Per-batch cumulative token/cost budget ceiling (issue #583).  A second
+# circuit breaker alongside MAX_CONSECUTIVE_FAILURES: after every processed
+# issue the running batch tally is compared against these ceilings, and a hard
+# breach halts the loop with batch state `budget_exceeded` (exit code 2),
+# mirroring the consecutive-failure breaker.  Defaults are NON-BREAKING: 0 (or
+# empty) = disabled, so existing batches are unaffected until an operator opts
+# in.  A soft breach at BATCH_BUDGET_SOFT_PCT% of a ceiling warns once first.
+# Env-overridable for tuning and tests.
+MAX_BATCH_TOKENS="${MAX_BATCH_TOKENS:-0}"
+MAX_BATCH_COST_USD="${MAX_BATCH_COST_USD:-0}"
+BATCH_BUDGET_SOFT_PCT="${BATCH_BUDGET_SOFT_PCT:-80}"
+
+# Cumulative batch spend tally.  Summed after each process_issue from the same
+# per-issue cost_summary the batch already records (see process_issue).  Read
+# by check_batch_budget().  _BATCH_BUDGET_SOFT_WARNED latches the one-shot warn.
+_BATCH_TOKENS_USED=0
+_BATCH_COST_USED=0
+_BATCH_BUDGET_SOFT_WARNED=0
 
 # Timeouts and limits
 readonly ISSUE_TIMEOUT=10800  # 180 minutes per issue
@@ -561,6 +584,71 @@ set_state() {
     local state="$1"
     jq --arg state "$state" '.state = $state | .last_update = (now | todate)' \
         "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+}
+
+# Check the cumulative per-batch token/cost budget ceiling (issue #583).
+#
+# Uses the running tally accumulated in _BATCH_TOKENS_USED / _BATCH_COST_USED
+# after each process_issue (summed from every issue's cost_summary — the same
+# per-issue accounting the batch already records).  Returns:
+#   0 — within budget, OR only a soft breach (one-shot warning emitted, batch
+#       continues)
+#   1 — HARD breach: the caller halts the loop with state budget_exceeded
+#
+# Disabled (always returns 0) when both ceilings are unset/0, so existing
+# batches are unaffected.  Mirrors the consecutive-failure circuit breaker.
+check_batch_budget() {
+    local max_tokens="${MAX_BATCH_TOKENS:-0}"
+    local max_cost="${MAX_BATCH_COST_USD:-0}"
+    local soft_pct="${BATCH_BUDGET_SOFT_PCT:-80}"
+    local used_tokens="${_BATCH_TOKENS_USED:-0}"
+    local used_cost="${_BATCH_COST_USED:-0}"
+
+    # Disabled unless at least one ceiling is a positive value.
+    if awk -v t="$max_tokens" -v c="$max_cost" \
+        'BEGIN { exit !((t+0) <= 0 && (c+0) <= 0) }'; then
+        return 0
+    fi
+
+    local verdict
+    verdict=$(awk -v ut="$used_tokens" -v uc="$used_cost" \
+        -v mt="$max_tokens" -v mc="$max_cost" -v sp="$soft_pct" '
+        BEGIN {
+            hard = 0; soft = 0;
+            if (mt + 0 > 0) {
+                if (ut + 0 >= mt + 0) hard = 1;
+                else if (ut + 0 >= (mt + 0) * (sp + 0) / 100) soft = 1;
+            }
+            if (mc + 0 > 0) {
+                if (uc + 0 >= mc + 0) hard = 1;
+                else if (uc + 0 >= (mc + 0) * (sp + 0) / 100) soft = 1;
+            }
+            if (hard) print "hard";
+            else if (soft) print "soft";
+            else print "ok";
+        }')
+
+    case "$verdict" in
+        hard)
+            log_error "BATCH BUDGET CEILING:" \
+                "tokens=${used_tokens}/${max_tokens}" \
+                "cost=\$${used_cost}/\$${max_cost} —" \
+                "stopping batch (budget_exceeded)."
+            return 1
+            ;;
+        soft)
+            if (( ${_BATCH_BUDGET_SOFT_WARNED:-0} == 0 )); then
+                _BATCH_BUDGET_SOFT_WARNED=1
+                log_warn "Batch budget soft threshold reached (${soft_pct}%):" \
+                    "tokens=${used_tokens}/${max_tokens}" \
+                    "cost=\$${used_cost}/\$${max_cost}."
+            fi
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
 }
 
 # =============================================================================
@@ -1156,6 +1244,16 @@ process_issue() {
                 pr_number=$(jq -r '.stages.pr.pr_number // empty' "$issue_status_file" 2>/dev/null)
                 log "PR #${pr_number:-?} left open — partial delivery (not all tasks completed / review unresolved)"
                 ;;
+            budget_exceeded)
+                # Issue #583: the per-run token/cost ceiling halted the
+                # orchestrator cleanly before completion.  Treat it as terminal
+                # like merge_blocked — leave any PR open, record it, and do NOT
+                # let the recovery arm below flip it to success on a stray PR
+                # number.  This is a spend-halt, never an escalate/retry.
+                impl_status="budget_exceeded"
+                pr_number=$(jq -r '.stages.pr.pr_number // empty' "$issue_status_file" 2>/dev/null)
+                log "Issue #$issue_num halted — per-run budget ceiling exceeded (budget_exceeded)"
+                ;;
             error|max_iterations_quality|max_iterations_pr_review)
                 impl_status="error"
                 impl_error="Script exited with state: $state"
@@ -1209,6 +1307,21 @@ process_issue() {
     fi
     update_issue_field "$issue_num" "cost_usd" "$impl_cost_usd" "true"
 
+    # Feed the cumulative per-batch spend tally (issue #583) from the same
+    # per-issue cost_summary read above.  Runs before every early return so
+    # partial/failed/skipped issues still count toward the batch ceiling. The
+    # tally is checked by check_batch_budget() in the main loop after this
+    # function returns.  Tokens are integer; cost is a float summed via awk.
+    local impl_tokens="0"
+    if [[ -f "$issue_status_file" ]]; then
+        impl_tokens=$(jq -r '(.cost_summary.total_input_tokens // 0) + (.cost_summary.total_output_tokens // 0) + (.cost_summary.total_cache_read_tokens // 0) + (.cost_summary.total_cache_creation_tokens // 0)' \
+            "$issue_status_file" 2>/dev/null) || impl_tokens="0"
+    fi
+    [[ -n "$impl_tokens" ]] || impl_tokens=0
+    _BATCH_TOKENS_USED=$(( ${_BATCH_TOKENS_USED:-0} + impl_tokens ))
+    _BATCH_COST_USED=$(awk -v a="${_BATCH_COST_USED:-0}" -v b="${impl_cost_usd:-0}" \
+        'BEGIN { printf "%.6f", (a + 0) + (b + 0) }')
+
     # Log location of metrics.json emitted by the orchestrator's EXIT trap
     if [[ -f "$issue_status_file" ]]; then
         local issue_log_dir
@@ -1251,6 +1364,23 @@ process_issue() {
     if [[ "$impl_status" == "merge_blocked" ]]; then
         log "Issue #$issue_num PR #${pr_number:-?} left open — merge blocked by quality gate."
         update_issue_field "$issue_num" "status" "merge_blocked"
+        if [[ -n "$pr_number" ]]; then
+            update_issue_field "$issue_num" "pr" "$pr_number" "true"
+        fi
+        update_progress
+        git checkout "$BRANCH" 2>/dev/null || true
+        return 0
+    fi
+
+    if [[ "$impl_status" == "budget_exceeded" ]]; then
+        # Issue #583: per-run budget ceiling halted this issue.  Record it as a
+        # terminal spend-halt (not a failure) and leave any PR open, mirroring
+        # merge_blocked.  Returning 0 keeps it out of consecutive_failures — the
+        # per-BATCH ceiling (check_batch_budget) is what stops the whole batch;
+        # a single over-budget issue does not, since the next issue starts fresh
+        # against its own per-run ceiling.
+        log "Issue #$issue_num PR #${pr_number:-?} left open — per-run budget ceiling exceeded."
+        update_issue_field "$issue_num" "status" "budget_exceeded"
         if [[ -n "$pr_number" ]]; then
             update_issue_field "$issue_num" "pr" "$pr_number" "true"
         fi
@@ -1754,6 +1884,25 @@ for issue in "${ISSUE_ARRAY[@]}"; do
             exit_code=2
             break
         fi
+    fi
+
+    # Per-batch token/cost budget breaker (issue #583).  Checked after every
+    # processed issue — success or failure — mirroring the consecutive-failure
+    # circuit breaker above.  A HARD breach halts the batch with the terminal
+    # budget_exceeded state (exit code 2); the batch is never resumed on a
+    # budget halt.  Disabled by default, so no behaviour change until an
+    # operator sets MAX_BATCH_TOKENS / MAX_BATCH_COST_USD.
+    if ! check_batch_budget; then
+        log_error "BATCH BUDGET BREAKER: cumulative token/cost ceiling exceeded. Stopping batch."
+        set_state "budget_exceeded"
+        emit_event "budget_exceeded" \
+            "scope=batch" \
+            "used_tokens:=${_BATCH_TOKENS_USED:-0}" \
+            "max_tokens:=${MAX_BATCH_TOKENS:-0}" \
+            "used_cost_usd:=${_BATCH_COST_USED:-0}" \
+            "max_cost_usd:=${MAX_BATCH_COST_USD:-0}"
+        exit_code=2
+        break
     fi
 done
 

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -163,9 +163,11 @@ TEST_LOOP_GIT_TIMEOUT="${TEST_LOOP_GIT_TIMEOUT:-30}"
 ESCALATION_POLICY_BACKEND="${ESCALATION_POLICY_BACKEND:-}"
 ORCHESTRATOR_START_EPOCH=$(date +%s)
 declare -a DEGRADED_STAGES=()
-# One-shot latch so the run-budget soft-threshold warning is emitted at most
-# once per run (issue #583).  Reset only at process start.
-_RUN_BUDGET_SOFT_WARNED=0
+# The run-budget soft-threshold warning is emitted at most once per run
+# (issue #583).  The latch lives in status.json (.run_budget_soft_warned), NOT a
+# shell global: check_run_budget() runs inside the run_stage command-substitution
+# subshell, so a global would reset every stage and re-fire the "one-shot"
+# warning on every stage.  Durable state survives the subshell.
 readonly RATE_LIMIT_BUFFER=60
 readonly RATE_LIMIT_DEFAULT_WAIT=3600
 # Waits longer than this imply a weekly-cap exhaustion (rather than a transient
@@ -369,7 +371,8 @@ calc_orchestrator_wall_time() {
 #
 # Returns:
 #   0 — within budget, OR only a soft breach (a one-shot warning is emitted
-#       via _RUN_BUDGET_SOFT_WARNED and the run continues)
+#       once, latched durably in status.json .run_budget_soft_warned, and the
+#       run continues)
 #   1 — HARD breach: the caller must halt the run with budget_exceeded and
 #       must NOT escalate or retry
 #
@@ -424,8 +427,20 @@ check_run_budget() {
             return 1
             ;;
         soft)
-            if (( ${_RUN_BUDGET_SOFT_WARNED:-0} == 0 )); then
-                _RUN_BUDGET_SOFT_WARNED=1
+            # One-shot warning, latched in status.json so it survives the
+            # run_stage subshell (a shell global would reset every stage and
+            # re-warn each time).  Read the durable latch; warn + set it once.
+            local _soft_warned="false"
+            if [[ -f "$STATUS_FILE" ]]; then
+                _soft_warned=$(jq -r '.run_budget_soft_warned // false' \
+                    "$STATUS_FILE" 2>/dev/null) || _soft_warned="false"
+            fi
+            if [[ "$_soft_warned" != "true" ]]; then
+                if [[ -f "$STATUS_FILE" ]]; then
+                    jq '.run_budget_soft_warned = true | .last_update = (now | todate)' \
+                        "$STATUS_FILE" > "${STATUS_FILE}.tmp" \
+                        && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+                fi
                 log_warn "Run budget soft threshold reached (${soft_pct}%):" \
                     "tokens=${used_tokens}/${max_tokens}" \
                     "cost=\$${used_cost}/\$${max_cost}." \
@@ -1017,6 +1032,37 @@ set_run_budget_exceeded() {
         "scope=run" \
         "max_tokens:=${MAX_RUN_TOKENS:-0}" \
         "max_cost_usd:=${MAX_RUN_COST_USD:-0}"
+}
+
+# Parent-shell halt guard for the run-level budget ceiling (issue #583).
+#
+# check_run_budget()/set_run_budget_exceeded() run INSIDE the run_stage
+# command-substitution subshell (`result=$(run_stage ...)`), so a `return 1`
+# there cannot stop the parent — the caller inspects the stage_result JSON, not
+# $?, and would otherwise call set_stage_completed and advance to the next
+# (spending) stage.  The one signal that DOES survive the subshell is the
+# durable state written to status.json: `.state == "budget_exceeded"`.
+#
+# This guard is invoked in the PARENT shell immediately after every run_stage
+# capture that can spend.  It reads that durable state and, on a breach,
+# finalizes the run and exits 2 (the issue's chosen budget-halt exit code) so
+# NO subsequent stage's CLI call can run.  It is a cheap no-op otherwise, so
+# sprinkling it after each spending stage is safe.
+_halt_if_budget_exceeded() {
+    [[ -f "$STATUS_FILE" ]] || return 0
+    local _state
+    _state=$(jq -r '.state // empty' "$STATUS_FILE" 2>/dev/null) || return 0
+    [[ "$_state" == "budget_exceeded" ]] || return 0
+
+    # set_final_state is a no-op when already budget_exceeded (it refuses to
+    # overwrite the terminal spend-halt), but call it so the EXIT trap / metrics
+    # observe a consistent terminal state regardless of entry path.
+    set_final_state "budget_exceeded"
+    local _reason
+    _reason=$(jq -r '.budget_exceeded_reason // "run token/cost ceiling exceeded"' \
+        "$STATUS_FILE" 2>/dev/null) || _reason="run token/cost ceiling exceeded"
+    log_error "Run halted (budget ceiling): $_reason — no further stages will run."
+    exit 2
 }
 
 record_escalation() {
@@ -2706,6 +2752,22 @@ for m in re.finditer(r'\[\s*\{', t):
             return $?
             ;;
         escalate)
+            # Issue #583: check the run budget BEFORE spending on the pricier
+            # escalated model.  The post-dispatch check in _apply_stage_action
+            # runs only AFTER the extra CLI call, so without this pre-check the
+            # escalation would already have spent by the time the ceiling fires.
+            # On a HARD breach, halt cleanly WITHOUT making the escalated call:
+            # record the terminal budget_exceeded state and emit the interim
+            # result unchanged (the parent-shell _halt_if_budget_exceeded guard
+            # finalizes + exits).  This satisfies "must NOT trigger escalation".
+            if ! check_run_budget; then
+                set_run_budget_exceeded \
+                    "$stage_name" \
+                    "run token/cost ceiling exceeded (escalation suppressed)"
+                printf '%s\n' "$_sr_interim"
+                return 1
+            fi
+
             # Re-run with the model decide-action.sh selected
             local _esc_model="${_da_target_model:-$(effective_fallback "$model")}"
             local _esc_fallback
@@ -2813,6 +2875,20 @@ for m in re.finditer(r'\[\s*\{', t):
             return $?
             ;;
         retry_same)
+            # Issue #583: check the run budget BEFORE spending on the retry.
+            # Same rationale as the escalate branch — the post-dispatch check in
+            # _apply_stage_action runs only AFTER the retry CLI call.  On a HARD
+            # breach, halt WITHOUT retrying: record budget_exceeded and emit the
+            # interim result (the parent-shell guard finalizes + exits).  This
+            # satisfies "must NOT trigger retry".
+            if ! check_run_budget; then
+                set_run_budget_exceeded \
+                    "$stage_name" \
+                    "run token/cost ceiling exceeded (retry suppressed)"
+                printf '%s\n' "$_sr_interim"
+                return 1
+            fi
+
             # handle_rate_limit() was already called during error_kind
             # classification above; emit the retry/model_call events now.
             emit_event "retry" \
@@ -3139,6 +3215,7 @@ Output a summary of changes made."
             simplify_head_before=$(git -C "$loop_dir" rev-parse HEAD \
                 2>/dev/null || true)
             simplify_result=$(run_stage "$simplify_stage_name" "$simplify_prompt" "implement-issue-simplify.json" "" "$loop_complexity")
+            _halt_if_budget_exceeded
             local simplify_status
             simplify_status=$(printf '%s' "$simplify_result" | jq -r '.status // "success"')
             if [[ "$simplify_status" != "error" ]]; then
@@ -3225,6 +3302,7 @@ Simply output 'approved' if code quality is acceptable, or 'changes_requested' w
         set_stage_started "$review_stage_name"
         local review_result
         review_result=$(run_stage "$review_stage_name" "$review_prompt" "implement-issue-review.json" "code-reviewer" "$loop_complexity")
+        _halt_if_budget_exceeded
         local review_run_status
         review_run_status=$(printf '%s' "$review_result" | jq -r '.status // "success"')
         if [[ "$review_run_status" != "error" ]]; then
@@ -3443,6 +3521,7 @@ Fix only the blocking issues and commit. Output a summary of fixes applied."
             set_stage_started "$fix_stage_name"
             local fix_result
             fix_result=$(run_stage "$fix_stage_name" "$fix_prompt" "implement-issue-fix.json" "$loop_agent" "$loop_complexity" "" "${loop_model_override:-}")
+            _halt_if_budget_exceeded
             local fix_status
             fix_status=$(printf '%s' "$fix_result" | jq -r '.status // "success"')
             if [[ "$fix_status" != "error" ]]; then
@@ -4755,6 +4834,7 @@ Commit your changes with a descriptive message."
 				"implement-issue-implement.json" \
 				"$task_agent" "$task_size")
 		fi
+		_halt_if_budget_exceeded
 
 		local impl_status
 		impl_status=$(printf '%s' "$impl_result" \
@@ -5443,6 +5523,7 @@ Commit your changes with a descriptive message."
 						"implement-issue-implement.json" \
 						"$_next_tagent" "$_next_tsize" \
 						"$_pw_timeout" "$_pw_model")
+					_halt_if_budget_exceeded
 
 					local _pw_status
 					_pw_status=$(printf '%s' "$_pw_result" \
@@ -5599,6 +5680,7 @@ Commit your changes with a descriptive message."
 					"implement-issue-implement.json" \
 					"$tagent" "$tsize")
 			fi
+			_halt_if_budget_exceeded
 
 			local impl_status
 			impl_status=$(printf '%s' "$impl_result" \
@@ -6361,6 +6443,7 @@ Output both test results and validation findings in one structured response.
 
         local test_result
         test_result=$(run_stage "test-iter-$test_iteration" "$test_prompt" "implement-issue-test-validate.json" "default" "$loop_complexity")
+        _halt_if_budget_exceeded
 
         # Handle timeout: skip result inspection and retry on next iteration
         if is_stage_timeout "$test_result"; then
@@ -6500,6 +6583,7 @@ Fix the issues and commit. Output a summary of fixes applied."
 
             local fix_result
             fix_result=$(run_stage "fix-tests-iter-$test_iteration" "$fix_prompt" "implement-issue-fix.json" "$loop_agent" "$loop_complexity")
+            _halt_if_budget_exceeded
 
             local fix_summary
             fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
@@ -6563,6 +6647,7 @@ Output a summary of fixes applied."
             # task size: S→haiku, M→sonnet, L→opus (via resolve_model).
             local fix_result
             fix_result=$(run_stage "fix-test-quality-iter-$test_iteration" "$fix_prompt" "implement-issue-fix.json" "$loop_agent" "$loop_complexity")
+            _halt_if_budget_exceeded
 
             local fix_summary
             fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
@@ -6791,6 +6876,7 @@ Report result as 'passed' or 'failed' with a detailed summary."
 				"$e2e_verify_prompt" \
 				"implement-issue-e2e-validate.json" \
 				"playwright-test-developer")
+			_halt_if_budget_exceeded
 
 			local e2e_verify_status e2e_verify_summary
 			e2e_verify_status=$(printf '%s' "$e2e_verify_result" \
@@ -6879,6 +6965,7 @@ Output result as 'passed' or 'failed' with a detailed summary."
 					"$acceptance_prompt" \
 					"implement-issue-test.json" \
 					"default")
+				_halt_if_budget_exceeded
 
 				local acceptance_status acceptance_summary
 				acceptance_status=$(printf '%s' "$acceptance_result" \
@@ -6939,6 +7026,11 @@ $acceptance_summary" "default"
 		fi
 	fi
 
+	# Issue #583: a parallel stage (e2e/acceptance) may have tripped the run
+	# budget inside its background subshell.  Halt in the PARENT shell BEFORE
+	# dispatching any sequential fix stage, so no fix CLI call runs post-breach.
+	_halt_if_budget_exceeded
+
 	# ------------------------------------------------------------------
 	# Sequential fix dispatch: if a stage failed, dispatch fix agents
 	# one at a time to avoid concurrent commits to $branch.
@@ -6980,6 +7072,7 @@ Commit your changes."
 				"implement-issue-fix.json" \
 				"$AGENT" \
 				"$max_task_size")
+			_halt_if_budget_exceeded
 
 			local e2e_fix_summary
 			e2e_fix_summary=$(printf '%s' "$e2e_fix_result" \
@@ -7022,6 +7115,7 @@ Report result as 'passed' or 'failed' with a detailed summary."
 				"$rerun_prompt" \
 				"implement-issue-e2e-validate.json" \
 				"playwright-test-developer")
+			_halt_if_budget_exceeded
 
 			local rerun_status rerun_summary
 			rerun_status=$(printf '%s' "$rerun_result" \
@@ -7089,6 +7183,7 @@ Investigate the root cause and fix the issue. Commit your changes."
 			"$acceptance_fix_prompt" \
 			"implement-issue-fix.json" \
 			"$AGENT")
+		_halt_if_budget_exceeded
 
 		local acceptance_fix_summary
 		acceptance_fix_summary=$(printf '%s' \
@@ -7670,6 +7765,13 @@ $task_list_md
         _process_batch_results() {
             local result_json="$1"
             local src_label="$2"
+
+            # Issue #583: the batch executors (execute_batch_serial/parallel) run
+            # in command-substitution subshells, so a budget halt inside them
+            # exits only that subshell.  This funnel runs in the PARENT shell
+            # after every batch dispatch, so re-assert the durable budget halt
+            # here — otherwise the run would keep spending on later stages.
+            _halt_if_budget_exceeded
 
             # Process completed tasks
             local comp_count
@@ -8300,6 +8402,7 @@ $pr_creation_skill}"
 
         local pr_result
         pr_result=$(run_stage "pr" "$pr_prompt" "implement-issue-pr.json" "" "" "" "opus")
+        _halt_if_budget_exceeded
 
         local pr_status
         pr_status=$(printf '%s' "$pr_result" | jq -r '.output.status')
@@ -8518,6 +8621,7 @@ Approve or request changes. Output a summary suitable for an issue comment."
 
         local review_result
         review_result=$(run_stage "pr-review-iter-$pr_iteration" "$review_prompt" "implement-issue-review.json" "code-reviewer" "" "$pr_review_timeout" "$pr_review_model")
+        _halt_if_budget_exceeded
 
         # Handle timeout: skip result inspection and retry on next iteration
         if is_stage_timeout "$review_result"; then
@@ -8695,6 +8799,7 @@ Fix the issues and commit. Output a summary of fixes applied."
 
             local fix_result
             fix_result=$(run_stage "fix-pr-review-iter-$pr_iteration" "$fix_prompt" "implement-issue-fix.json" "$AGENT")
+            _halt_if_budget_exceeded
 
             local fix_summary
             fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
@@ -8734,6 +8839,7 @@ $complete_skill
 
         local complete_result
         complete_result=$(run_stage "complete" "$complete_prompt" "implement-issue-complete.json")
+        _halt_if_budget_exceeded
 
         local complete_summary
         complete_summary=$(printf '%s' "$complete_result" | jq -r '.output.summary // "Implementation completed successfully"')
@@ -9160,6 +9266,7 @@ STEPS:
                         "$deploy_verify_prompt" \
                         "implement-issue-deploy-verify.json" \
                         "default")
+                    _halt_if_budget_exceeded
 
                     local dv_status dv_health dv_summary
                     dv_status=$(printf '%s' "$deploy_verify_result" \

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -116,6 +116,20 @@ TEST_ITER_WALL_TIME_SLACK="${TEST_ITER_WALL_TIME_SLACK:-120}"
 # replaces test-iter-timeout×planned_iter+slack entirely.
 TEST_LOOP_WALL_BUDGET="${TEST_LOOP_WALL_BUDGET:-}"
 
+# Per-run token/cost budget ceiling (issue #583).  Mirrors the wall-clock
+# budget idiom above but bounds spend instead of wall time.  Defaults are
+# NON-BREAKING: 0 (or empty) means "disabled", so existing runs are entirely
+# unaffected until an operator opts in.  When set, check_run_budget() compares
+# the run's accumulated token/cost total (rolled up from issue #580's per-stage
+# .stages[].tokens / .stages[].estimated_cost accounting in status.json) against
+# these ceilings BETWEEN stages via _apply_stage_action.  A hard breach halts
+# the run with terminal state budget_exceeded — never escalating or retrying —
+# and a soft breach (>= RUN_BUDGET_SOFT_PCT% of a ceiling) emits a one-shot
+# warning first.  Env-overridable for tuning and tests.
+MAX_RUN_TOKENS="${MAX_RUN_TOKENS:-0}"
+MAX_RUN_COST_USD="${MAX_RUN_COST_USD:-0}"
+RUN_BUDGET_SOFT_PCT="${RUN_BUDGET_SOFT_PCT:-80}"
+
 # Per-command timeouts (seconds) for the merge_pr stage.  Each long-running
 # sub-step is wrapped in `timeout` so a hung network/git/CLI call cannot stall
 # the orchestrator indefinitely.  On timeout the stage transitions to
@@ -149,6 +163,9 @@ TEST_LOOP_GIT_TIMEOUT="${TEST_LOOP_GIT_TIMEOUT:-30}"
 ESCALATION_POLICY_BACKEND="${ESCALATION_POLICY_BACKEND:-}"
 ORCHESTRATOR_START_EPOCH=$(date +%s)
 declare -a DEGRADED_STAGES=()
+# One-shot latch so the run-budget soft-threshold warning is emitted at most
+# once per run (issue #583).  Reset only at process start.
+_RUN_BUDGET_SOFT_WARNED=0
 readonly RATE_LIMIT_BUFFER=60
 readonly RATE_LIMIT_DEFAULT_WAIT=3600
 # Waits longer than this imply a weekly-cap exhaustion (rather than a transient
@@ -336,6 +353,90 @@ calc_orchestrator_wall_time() {
 		pr_budget=$(( 1200 * pr_iter + PR_REVIEW_WALL_TIME_SLACK ))
 	fi
 	printf '%s' "$(( test_budget + pr_budget + 5700 ))"
+}
+
+# =============================================================================
+# RUN-LEVEL TOKEN/COST BUDGET CEILING (issue #583)
+# =============================================================================
+
+# Check the run-level token/cost budget ceiling.
+#
+# Reuses issue #580's accounting rather than re-parsing the CLI JSON: every
+# stage already persists its tokens (.stages[].tokens) and estimated cost
+# (.stages[].estimated_cost) into status.json via set_stage_completed.  This
+# helper sums those into a run-level running total and compares it to the
+# configured ceilings.  No second parse of the --output-format json capture.
+#
+# Returns:
+#   0 — within budget, OR only a soft breach (a one-shot warning is emitted
+#       via _RUN_BUDGET_SOFT_WARNED and the run continues)
+#   1 — HARD breach: the caller must halt the run with budget_exceeded and
+#       must NOT escalate or retry
+#
+# Disabled (always returns 0) when both ceilings are unset/0, so existing runs
+# are unaffected.  Mirrors the check_*_wall_timeout idiom above.
+check_run_budget() {
+    local max_tokens="${MAX_RUN_TOKENS:-0}"
+    local max_cost="${MAX_RUN_COST_USD:-0}"
+    local soft_pct="${RUN_BUDGET_SOFT_PCT:-80}"
+
+    # Disabled unless at least one ceiling is a positive value.
+    if awk -v t="$max_tokens" -v c="$max_cost" \
+        'BEGIN { exit !((t+0) <= 0 && (c+0) <= 0) }'; then
+        return 0
+    fi
+    [[ -f "$STATUS_FILE" ]] || return 0
+
+    # Run-level running total from #580's per-stage accounting.  Each jq filter
+    # is kept on a single line so the BATS function extractor -- which counts
+    # braces to find a function end -- is never tripped by a multi-line filter.
+    local used_tokens used_cost
+    used_tokens=$(jq -r '[.stages[]?.tokens.input_tokens // 0, .stages[]?.tokens.output_tokens // 0, .stages[]?.tokens.cache_creation_input_tokens // 0, .stages[]?.tokens.cache_read_input_tokens // 0] | add // 0' "$STATUS_FILE" 2>/dev/null) || used_tokens=0
+    used_cost=$(jq -r '[.stages[]?.estimated_cost // 0] | add // 0' "$STATUS_FILE" 2>/dev/null) || used_cost=0
+    [[ -n "$used_tokens" ]] || used_tokens=0
+    [[ -n "$used_cost" ]] || used_cost=0
+
+    # Classify in awk so the float cost comparison is safe.
+    local verdict
+    verdict=$(awk -v ut="$used_tokens" -v uc="$used_cost" \
+        -v mt="$max_tokens" -v mc="$max_cost" -v sp="$soft_pct" '
+        BEGIN {
+            hard = 0; soft = 0;
+            if (mt + 0 > 0) {
+                if (ut + 0 >= mt + 0) hard = 1;
+                else if (ut + 0 >= (mt + 0) * (sp + 0) / 100) soft = 1;
+            }
+            if (mc + 0 > 0) {
+                if (uc + 0 >= mc + 0) hard = 1;
+                else if (uc + 0 >= (mc + 0) * (sp + 0) / 100) soft = 1;
+            }
+            if (hard) print "hard";
+            else if (soft) print "soft";
+            else print "ok";
+        }')
+
+    case "$verdict" in
+        hard)
+            log_warn "Run budget ceiling exceeded:" \
+                "tokens=${used_tokens}/${max_tokens}" \
+                "cost=\$${used_cost}/\$${max_cost}." \
+                "Halting run with budget_exceeded (no escalate/retry)."
+            return 1
+            ;;
+        soft)
+            if (( ${_RUN_BUDGET_SOFT_WARNED:-0} == 0 )); then
+                _RUN_BUDGET_SOFT_WARNED=1
+                log_warn "Run budget soft threshold reached (${soft_pct}%):" \
+                    "tokens=${used_tokens}/${max_tokens}" \
+                    "cost=\$${used_cost}/\$${max_cost}." \
+                    "Approaching hard ceiling — one more breach will halt."
+            fi
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
 }
 
 # =============================================================================
@@ -766,6 +867,33 @@ set_stage_failed() {
     emit_event "stage_end" "stage=$stage" "status=error" "error_kind=$error_kind"
 }
 
+# Terminal-state writer for a run-level token/cost budget ceiling breach
+# (issue #583).  Sibling of set_stage_failed, but records the dedicated
+# budget_exceeded state so downstream consumers (and the batch orchestrator)
+# treat the run as a clean spend-halt — never as a failure to escalate/retry.
+# The state is written to status.json (a real file that survives the run_stage
+# subshell) and set_final_state() refuses to overwrite it, so the halt is
+# preserved even as the bail path unwinds the stack.
+set_run_budget_exceeded() {
+    local stage="$1"
+    local detail="${2:-run token/cost ceiling exceeded}"
+    jq --arg stage "$stage" \
+       --arg detail "$detail" \
+       '.stages[$stage].completed_at = (now | todate) |
+        .stages[$stage].status = "budget_exceeded" |
+        .state = "budget_exceeded" |
+        .budget_exceeded_reason = $detail |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+    log_warn "Run halted: $detail (stage=$stage) — state set to budget_exceeded"
+    emit_event "budget_exceeded" \
+        "stage=$stage" \
+        "scope=run" \
+        "max_tokens:=${MAX_RUN_TOKENS:-0}" \
+        "max_cost_usd:=${MAX_RUN_COST_USD:-0}"
+}
+
 record_escalation() {
     local stage="$1"
     local from_model="$2"
@@ -830,6 +958,16 @@ set_final_state() {
         || prev_state="running"
     stage=$(jq -r '.current_stage // "unknown"' "$STATUS_FILE" 2>/dev/null) \
         || stage="unknown"
+
+    # Issue #583: budget_exceeded is a terminal spend-halt.  Once the run-budget
+    # ceiling fires (set_run_budget_exceeded), the bail path unwinds the stack
+    # and a caller may try to stamp a downstream error/failed state.  Refuse it
+    # here so the clean budget_exceeded halt is preserved end-to-end.
+    if [[ "$prev_state" == "budget_exceeded" && "$state" != "budget_exceeded" ]]; then
+        log_warn "set_final_state: run already halted (budget_exceeded);" \
+            "ignoring transition to '$state'"
+        return 0
+    fi
 
     jq --arg state "$state" \
        '.state = $state | .last_update = (now | todate)' \
@@ -1766,6 +1904,22 @@ _apply_stage_action() {
 	local stage_result="$1"
 	local action="$2"
 	local reason="${3:-}"
+
+	# Between-stages token/cost budget ceiling check (issue #583).  This is the
+	# single post-stage dispatch point, so it is the only place a budget check
+	# runs — never mid-stage.  A HARD breach overrides the requested action
+	# (accept/escalate/retry_same all included): the run halts cleanly with the
+	# terminal budget_exceeded state and is NEVER escalated or retried.  Soft
+	# breaches emit a one-shot warning inside check_run_budget and fall through
+	# to normal routing.  Disabled by default (ceilings 0), so no behaviour
+	# change for existing runs.
+	if ! check_run_budget; then
+		set_run_budget_exceeded \
+			"${_RUN_STAGE_NAME:-unknown}" \
+			"run token/cost ceiling exceeded (requested action=$action)"
+		printf '%s\n' "$stage_result"
+		return 1
+	fi
 
 	case "$action" in
 		accept)

--- a/.claude/scripts/implement-issue-test/test-run-budget-ceiling.bats
+++ b/.claude/scripts/implement-issue-test/test-run-budget-ceiling.bats
@@ -1,0 +1,322 @@
+#!/usr/bin/env bats
+#
+# test-run-budget-ceiling.bats
+# Tests for the per-run and per-batch token/cost budget ceiling + circuit
+# breaker (issue #583).
+#
+# Covers:
+#   - check_run_budget(): disabled by default, hard breach (token & cost),
+#     soft-threshold one-shot warning — implement-issue-orchestrator.sh
+#   - set_run_budget_exceeded(): writes the terminal budget_exceeded state
+#   - set_final_state(): refuses to overwrite a budget_exceeded halt
+#   - _apply_stage_action(): a hard breach halts the run with budget_exceeded
+#     and OVERRIDES escalate/retry (never escalates or retries)
+#   - check_batch_budget(): disabled by default, hard breach, soft warning —
+#     batch-orchestrator.sh
+#   - batch header/config documents the budget_exceeded state + exit code
+#
+# The budget check reuses issue #580's per-stage accounting: it sums the
+# .stages[].tokens / .stages[].estimated_cost already persisted in status.json
+# rather than re-parsing the CLI JSON, so the fixtures below seed those fields.
+#
+
+load 'helpers/test-helper.bash'
+
+setup() {
+	setup_test_env
+	WARN_LOG="$TEST_TMP/warn.log"
+	: > "$WARN_LOG"
+	STATUS_FILE="$TEST_TMP/status.json"
+
+	# Leaf collaborators the extracted functions call. log_warn/log_error
+	# append their (space-joined) message as one line so "warned once" is a
+	# simple line count.
+	log()                { :; }
+	log_warn()           { printf '%s\n' "$*" >> "$WARN_LOG"; }
+	log_error()          { printf '%s\n' "$*" >> "$WARN_LOG"; }
+	emit_event()         { :; }
+	sync_status_to_log() { :; }
+	set_stage_failed()   { :; }
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# Extract the named orchestrator budget functions (plus their collaborators
+# under test) into one file and source them in the current shell.
+_source_orch_budget_fns() {
+	local out="$TEST_TMP/orch_budget_fns.bash"
+	: > "$out"
+	local fn
+	for fn in check_run_budget set_run_budget_exceeded set_final_state _apply_stage_action; do
+		_extract_function_body "$fn" "$ORCHESTRATOR_SCRIPT" >> "$out"
+		printf '\n' >> "$out"
+	done
+	# shellcheck disable=SC1090
+	source "$out"
+}
+
+_source_batch_budget_fn() {
+	local out="$TEST_TMP/batch_budget_fn.bash"
+	_extract_function_body check_batch_budget \
+		"$BATCH_ORCHESTRATOR_SCRIPT_PATH" > "$out"
+	grep -q 'check_batch_budget' "$out" || return 1
+	# shellcheck disable=SC1090
+	source "$out"
+}
+
+# Seed a status.json whose per-stage tokens/estimated_cost sum to the given
+# totals. $1 = total tokens (split into input/output), $2 = total cost.
+_seed_status() {
+	local total_tokens="$1" total_cost="$2"
+	local half=$(( total_tokens / 2 ))
+	local rest=$(( total_tokens - half ))
+	jq -n --argjson inp "$half" --argjson out "$rest" \
+		--argjson cost "$total_cost" \
+		'{
+			state: "running",
+			stages: {
+				implement: {
+					tokens: {
+						input_tokens: $inp,
+						output_tokens: $out,
+						cache_creation_input_tokens: 0,
+						cache_read_input_tokens: 0
+					},
+					estimated_cost: $cost
+				}
+			}
+		}' > "$STATUS_FILE"
+}
+
+# =============================================================================
+# check_run_budget — DISABLED BY DEFAULT
+# =============================================================================
+
+@test "check_run_budget: disabled (ceilings 0) returns 0 regardless of spend" {
+	_source_orch_budget_fns
+	MAX_RUN_TOKENS=0
+	MAX_RUN_COST_USD=0
+	_seed_status 999999 999
+	run check_run_budget
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# check_run_budget — HARD BREACH (halt signal)
+# =============================================================================
+
+@test "check_run_budget: hard token breach returns 1" {
+	_source_orch_budget_fns
+	MAX_RUN_TOKENS=1000
+	MAX_RUN_COST_USD=0
+	_seed_status 1200 0     # 1200 > 1000
+	run check_run_budget
+	[ "$status" -eq 1 ]
+}
+
+@test "check_run_budget: hard cost breach returns 1" {
+	_source_orch_budget_fns
+	MAX_RUN_TOKENS=0
+	MAX_RUN_COST_USD=1.00
+	_seed_status 0 1.5      # $1.50 > $1.00
+	run check_run_budget
+	[ "$status" -eq 1 ]
+}
+
+@test "check_run_budget: within budget returns 0" {
+	_source_orch_budget_fns
+	MAX_RUN_TOKENS=1000
+	MAX_RUN_COST_USD=0
+	_seed_status 100 0      # well under 80% of 1000
+	run check_run_budget
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# check_run_budget — SOFT THRESHOLD (one-shot warning)
+# =============================================================================
+
+@test "check_run_budget: soft threshold warns exactly once across calls" {
+	_source_orch_budget_fns
+	MAX_RUN_TOKENS=1000
+	MAX_RUN_COST_USD=0
+	RUN_BUDGET_SOFT_PCT=80
+	_RUN_BUDGET_SOFT_WARNED=0
+	_seed_status 850 0      # 850 >= 800 (soft) and < 1000 (not hard)
+
+	check_run_budget
+	[ "$?" -eq 0 ]
+	check_run_budget
+	[ "$?" -eq 0 ]
+
+	local warns
+	warns=$(grep -c 'soft threshold' "$WARN_LOG")
+	[ "$warns" -eq 1 ]
+}
+
+# =============================================================================
+# set_run_budget_exceeded — TERMINAL STATE WRITER
+# =============================================================================
+
+@test "set_run_budget_exceeded: writes budget_exceeded state and stage status" {
+	_source_orch_budget_fns
+	_seed_status 0 0
+	set_run_budget_exceeded "implement" "ceiling hit"
+	assert_json_field "$STATUS_FILE" '.state' 'budget_exceeded'
+	assert_json_field "$STATUS_FILE" '.stages.implement.status' 'budget_exceeded'
+	assert_json_field "$STATUS_FILE" '.budget_exceeded_reason' 'ceiling hit'
+}
+
+# =============================================================================
+# set_final_state — GUARD: never overwrite a budget_exceeded halt
+# =============================================================================
+
+@test "set_final_state: refuses to overwrite budget_exceeded with error" {
+	_source_orch_budget_fns
+	jq -n '{state:"budget_exceeded", current_stage:"implement"}' > "$STATUS_FILE"
+	set_final_state "error"
+	assert_json_field "$STATUS_FILE" '.state' 'budget_exceeded'
+}
+
+@test "set_final_state: still transitions normal (non-budget) states" {
+	_source_orch_budget_fns
+	jq -n '{state:"running", current_stage:"implement"}' > "$STATUS_FILE"
+	set_final_state "completed"
+	assert_json_field "$STATUS_FILE" '.state' 'completed'
+}
+
+# =============================================================================
+# _apply_stage_action — HARD BREACH OVERRIDES ESCALATE/RETRY
+# =============================================================================
+
+@test "_apply_stage_action: hard breach halts with budget_exceeded, overrides escalate" {
+	_source_orch_budget_fns
+	MAX_RUN_TOKENS=1000
+	MAX_RUN_COST_USD=0
+	_RUN_STAGE_NAME="implement"
+	_seed_status 1200 0     # over ceiling
+
+	local sr='{"status":"error","action":"escalate"}'
+	run _apply_stage_action "$sr" "escalate"
+	# Non-zero return = halt (not the 0 escalate would normally return).
+	[ "$status" -eq 1 ]
+	# State proves the run was halted, NOT escalated/retried.
+	assert_json_field "$STATUS_FILE" '.state' 'budget_exceeded'
+}
+
+@test "_apply_stage_action: hard breach also overrides retry_same" {
+	_source_orch_budget_fns
+	MAX_RUN_TOKENS=1000
+	MAX_RUN_COST_USD=0
+	_RUN_STAGE_NAME="test"
+	_seed_status 5000 0
+
+	run _apply_stage_action '{"status":"error"}' "retry_same"
+	[ "$status" -eq 1 ]
+	assert_json_field "$STATUS_FILE" '.state' 'budget_exceeded'
+}
+
+@test "_apply_stage_action: within budget passes accept through (rc 0)" {
+	_source_orch_budget_fns
+	MAX_RUN_TOKENS=0        # disabled
+	MAX_RUN_COST_USD=0
+	_RUN_STAGE_NAME="implement"
+	_seed_status 100 0
+
+	run _apply_stage_action '{"status":"success"}' "accept"
+	[ "$status" -eq 0 ]
+	# State untouched by a passing budget check.
+	assert_json_field "$STATUS_FILE" '.state' 'running'
+}
+
+# =============================================================================
+# check_batch_budget — BATCH CUMULATIVE TALLY TRIPS THE LOOP BREAKER
+# =============================================================================
+
+@test "check_batch_budget: disabled (ceilings 0) returns 0" {
+	_source_batch_budget_fn
+	MAX_BATCH_TOKENS=0
+	MAX_BATCH_COST_USD=0
+	_BATCH_TOKENS_USED=999999
+	_BATCH_COST_USED=999
+	run check_batch_budget
+	[ "$status" -eq 0 ]
+}
+
+@test "check_batch_budget: hard token breach returns 1 (trips breaker)" {
+	_source_batch_budget_fn
+	MAX_BATCH_TOKENS=10000
+	MAX_BATCH_COST_USD=0
+	_BATCH_TOKENS_USED=12000
+	_BATCH_COST_USED=0
+	run check_batch_budget
+	[ "$status" -eq 1 ]
+}
+
+@test "check_batch_budget: hard cost breach returns 1" {
+	_source_batch_budget_fn
+	MAX_BATCH_TOKENS=0
+	MAX_BATCH_COST_USD=5.00
+	_BATCH_TOKENS_USED=0
+	_BATCH_COST_USED=6.50
+	run check_batch_budget
+	[ "$status" -eq 1 ]
+}
+
+@test "check_batch_budget: under budget returns 0" {
+	_source_batch_budget_fn
+	MAX_BATCH_TOKENS=10000
+	MAX_BATCH_COST_USD=0
+	_BATCH_TOKENS_USED=500
+	_BATCH_COST_USED=0
+	run check_batch_budget
+	[ "$status" -eq 0 ]
+}
+
+@test "check_batch_budget: soft threshold warns exactly once" {
+	_source_batch_budget_fn
+	MAX_BATCH_TOKENS=10000
+	MAX_BATCH_COST_USD=0
+	BATCH_BUDGET_SOFT_PCT=80
+	_BATCH_BUDGET_SOFT_WARNED=0
+	_BATCH_TOKENS_USED=8500   # >= 8000 soft, < 10000 hard
+	_BATCH_COST_USED=0
+
+	check_batch_budget
+	[ "$?" -eq 0 ]
+	check_batch_budget
+	[ "$?" -eq 0 ]
+
+	local warns
+	warns=$(grep -c 'soft threshold' "$WARN_LOG")
+	[ "$warns" -eq 1 ]
+}
+
+# =============================================================================
+# STATIC: env-configurable ceilings + documented state/exit code
+# =============================================================================
+
+@test "orchestrator declares MAX_RUN_TOKENS / MAX_RUN_COST_USD (non-breaking default)" {
+	grep -qE '^MAX_RUN_TOKENS="\$\{MAX_RUN_TOKENS:-0\}"' "$ORCHESTRATOR_SCRIPT"
+	grep -qE '^MAX_RUN_COST_USD="\$\{MAX_RUN_COST_USD:-0\}"' "$ORCHESTRATOR_SCRIPT"
+}
+
+@test "batch declares MAX_BATCH_TOKENS / MAX_BATCH_COST_USD (non-breaking default)" {
+	grep -qE '^MAX_BATCH_TOKENS="\$\{MAX_BATCH_TOKENS:-0\}"' "$BATCH_ORCHESTRATOR_SCRIPT_PATH"
+	grep -qE '^MAX_BATCH_COST_USD="\$\{MAX_BATCH_COST_USD:-0\}"' "$BATCH_ORCHESTRATOR_SCRIPT_PATH"
+}
+
+@test "batch header documents the budget_exceeded state under exit code 2" {
+	# Exit-code table mentions budget_exceeded as a shared exit-2 breaker.
+	grep -q 'budget_exceeded' "$BATCH_ORCHESTRATOR_SCRIPT_PATH"
+	run bash -c "awk '/^# Exit codes:/{f=1} f&&/budget_exceeded/{print; exit}' '$BATCH_ORCHESTRATOR_SCRIPT_PATH'"
+	[ -n "$output" ]
+}
+
+@test "batch main loop halts on check_batch_budget with budget_exceeded state" {
+	# The breaker sets the terminal state and breaks the loop.
+	grep -q 'if ! check_batch_budget; then' "$BATCH_ORCHESTRATOR_SCRIPT_PATH"
+	grep -q 'set_state "budget_exceeded"' "$BATCH_ORCHESTRATOR_SCRIPT_PATH"
+}

--- a/.claude/scripts/implement-issue-test/test-run-budget-ceiling.bats
+++ b/.claude/scripts/implement-issue-test/test-run-budget-ceiling.bats
@@ -320,3 +320,140 @@ _seed_status() {
 	grep -q 'if ! check_batch_budget; then' "$BATCH_ORCHESTRATOR_SCRIPT_PATH"
 	grep -q 'set_state "budget_exceeded"' "$BATCH_ORCHESTRATOR_SCRIPT_PATH"
 }
+
+# =============================================================================
+# INTEGRATION — the run-level halt is OBSERVABLE and actually stops spending
+#
+# Blocking bug 1 (issue #583): check_run_budget()/set_run_budget_exceeded() run
+# inside the run_stage command-substitution SUBSHELL.  Returning 1 there cannot
+# stop the parent — every caller is `x=$(run_stage ...)` and branches on the
+# JSON .status, never on $?.  So the halt was swallowed: the pipeline advanced
+# to the next stage and kept spending.
+#
+# These tests drive TWO sequential stages through the REAL run_stage machinery
+# (a stubbed `claude` that logs each call and emits a usage block).  A breach at
+# stage 1 must halt the run — exit 2, state budget_exceeded — BEFORE stage 2's
+# CLI call.  Pre-fix (no _halt_if_budget_exceeded guard) the stub is called
+# twice (pipeline continues → RED); post-fix it is called once (GREEN).
+# =============================================================================
+
+# Wire the full run_stage harness (mock claude + real decide-action backend) and
+# install a call-logging claude stub that emits a usage block on every call.
+_setup_run_stage_harness() {
+	install_mocks
+	install_decide_scripts
+
+	export ISSUE_NUMBER=123
+	export BASE_BRANCH=test
+	export STATUS_FILE="$TEST_TMP/status.json"
+	export LOG_BASE="$TEST_TMP/logs/test"
+	export LOG_FILE="$LOG_BASE/orchestrator.log"
+	export STAGE_COUNTER=0
+	export _CONSECUTIVE_TIMEOUTS=0
+	export SCHEMA_DIR="$TEST_TMP/schemas"
+	mkdir -p "$LOG_BASE/stages" "$LOG_BASE/context" "$SCHEMA_DIR"
+
+	cat > "$SCHEMA_DIR/budget-int.json" << 'EOF'
+{ "type": "object", "properties": { "status": { "type": "string" }, "result": { "type": "string" } } }
+EOF
+
+	# Per-call ledger — one line appended per CLI invocation, so the count is a
+	# direct proof of how many stages actually spent.
+	export CLAUDE_CALL_LOG="$TEST_TMP/claude-calls.log"
+	: > "$CLAUDE_CALL_LOG"
+
+	# Response emitted on every call: success + a real usage block (issue #583
+	# reads .usage.* / .total_cost_usd).  MOCK_STAGE_STATUS lets a test flip the
+	# structured status to "error" to exercise the escalate decision path.
+	export CLAUDE_RESPONSE_FILE="$TEST_TMP/claude-response.json"
+	_write_stub_response "success"
+
+	# Overwrite the default mock with a call-logging stub bound to the ledger and
+	# response file above (paths expand now, at write time).
+	cat > "$TEST_TMP/bin/claude" << STUB
+#!/usr/bin/env bash
+printf 'call\n' >> "$CLAUDE_CALL_LOG"
+cat "$CLAUDE_RESPONSE_FILE"
+STUB
+	chmod +x "$TEST_TMP/bin/claude"
+
+	source_orchestrator_functions
+}
+
+_write_stub_response() {
+	local status="$1"
+	jq -n --arg s "$status" '{
+		type: "result",
+		subtype: "success",
+		is_error: false,
+		result: "done",
+		total_cost_usd: 0.01,
+		structured_output: { status: $s, result: "done" },
+		usage: {
+			input_tokens: 50,
+			output_tokens: 50,
+			cache_creation_input_tokens: 0,
+			cache_read_input_tokens: 0
+		}
+	}' > "$CLAUDE_RESPONSE_FILE"
+}
+
+@test "INTEGRATION: hard breach halts the run so the next stage's CLI never runs" {
+	_setup_run_stage_harness
+	export MAX_RUN_TOKENS=1000
+	export MAX_RUN_COST_USD=0
+	# Accumulated prior spend already over the ceiling: the between-stage check
+	# at stage 1's completion trips, so stage 2 must never be reached.
+	_seed_status 2000 0
+
+	# REAL caller pattern: capture the stage result, then run the guard every
+	# caller now runs, then the next stage.  A subshell makes the guard's
+	# `exit 2` observable without killing the bats process.
+	set +e
+	(
+		rA=$(run_stage "stageA" "prompt A" "budget-int.json" "default")
+		_halt_if_budget_exceeded
+		# Reached only if the halt was swallowed (the pre-fix bug): stage 2 spends.
+		rB=$(run_stage "stageB" "prompt B" "budget-int.json" "default")
+		_halt_if_budget_exceeded
+	)
+	local rc=$?
+	set -e
+
+	# Halted in the parent shell with the issue's budget exit code.
+	[ "$rc" -eq 2 ] || fail "expected exit 2 (budget halt), got $rc"
+	# Durable terminal state recorded.
+	assert_json_field "$STATUS_FILE" '.state' 'budget_exceeded'
+	# The decisive proof: exactly ONE claude call (stage A). Stage B never spent.
+	local calls
+	calls=$(grep -c 'call' "$CLAUDE_CALL_LOG" 2>/dev/null || printf '0')
+	[ "$calls" -eq 1 ] || fail "expected exactly 1 CLI call (stage B must not run), got $calls"
+}
+
+@test "INTEGRATION: hard breach in the escalate path skips the pricier retry call" {
+	_setup_run_stage_harness
+	export MAX_RUN_TOKENS=1000
+	export MAX_RUN_COST_USD=0
+	_seed_status 2000 0
+	# A structured error at a NON-ceiling model (haiku, pinned via model_override
+	# arg 7) steers the bash decide-action backend to 'escalate' (a model at the
+	# opus ceiling would 'bail' instead).  This exercises blocking bug 2: the
+	# pre-escalation budget check must fire BEFORE the second (escalated) CLI
+	# call, so only the primary call is ever made.
+	_write_stub_response "error"
+
+	set +e
+	(
+		rA=$(run_stage "stageA" "prompt A" "budget-int.json" "default" "" "" "haiku")
+		_halt_if_budget_exceeded
+	)
+	local rc=$?
+	set -e
+
+	[ "$rc" -eq 2 ] || fail "expected exit 2 (budget halt), got $rc"
+	assert_json_field "$STATUS_FILE" '.state' 'budget_exceeded'
+	# Only the primary attempt spent — the escalated call was suppressed.
+	local calls
+	calls=$(grep -c 'call' "$CLAUDE_CALL_LOG" 2>/dev/null || printf '0')
+	[ "$calls" -eq 1 ] || fail "escalation was not suppressed: expected 1 CLI call, got $calls"
+}

--- a/.claude/scripts/schemas/pipeline-event.json
+++ b/.claude/scripts/schemas/pipeline-event.json
@@ -32,7 +32,8 @@
         "issue_start",
         "issue_end",
         "batch_paused",
-        "cost_trend_warning"
+        "cost_trend_warning",
+        "budget_exceeded"
       ],
       "description": "Event type discriminator"
     },
@@ -304,6 +305,38 @@
         }
       },
       "required": ["event", "latest_mt_per_issue", "baseline_mt_per_issue"]
+    },
+    {
+      "description": "A per-run or per-batch token/cost budget ceiling was exceeded; the run or batch halted with state budget_exceeded (issue #583). Terminal — never escalated or retried.",
+      "properties": {
+        "event": { "const": "budget_exceeded" },
+        "scope": {
+          "type": "string",
+          "enum": ["run", "batch"],
+          "description": "Whether the per-run or per-batch ceiling was breached"
+        },
+        "used_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Cumulative tokens consumed at the breach"
+        },
+        "max_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Configured token ceiling (0 = disabled)"
+        },
+        "used_cost_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Cumulative cost in USD at the breach"
+        },
+        "max_cost_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Configured cost ceiling in USD (0 = disabled)"
+        }
+      },
+      "required": ["event", "scope"]
     }
   ]
 }


### PR DESCRIPTION
Closes #583. Stacked on #589.

Adds a configurable per-run and per-batch token/cost budget ceiling with a circuit breaker. Builds on #580 cost accounting (reuses per-stage `.stages[].tokens`/`.stages[].estimated_cost` — no second CLI parse) and reconciles #585's epic-scope flag.

## What landed
- **implement-issue-orchestrator.sh**
  - Env-configurable `MAX_RUN_TOKENS`/`MAX_RUN_COST_USD` + `RUN_BUDGET_SOFT_PCT` (default 0 = disabled, non-breaking) mirroring the wall-clock budget idiom.
  - `check_run_budget` sums #580's accumulated per-stage tokens/cost from status.json into a run-level running total; float-safe comparison via awk.
  - `set_run_budget_exceeded` terminal-state writer beside `set_stage_failed`.
  - `_apply_stage_action` calls `check_run_budget` between stages: HARD breach halts with `budget_exceeded` and **overrides escalate/retry** (never escalates/retries); soft breach warns once.
  - `set_final_state` guard preserves `budget_exceeded` (robust across the `run_stage` subshell — state persists via status.json file).
- **batch-orchestrator.sh**
  - `MAX_BATCH_TOKENS`/`MAX_BATCH_COST_USD` + cumulative tally summed after each `process_issue`; `check_batch_budget` trips the loop breaker with batch state `budget_exceeded` (exit 2), mirroring the consecutive-failure breaker.
  - `budget_exceeded` issue-status arm (mirrors #577's `completed_partial`) treats a per-run budget halt as terminal, not success.
  - Exit-code table + config document the `budget_exceeded` state.
- **schemas/pipeline-event.json** — additive `budget_exceeded` event branch + enum.

## Overlap reconciliation
- **#580 (Task 2):** reused existing per-stage accounting for the running total; no duplicate parse.
- **#585 (Task 6):** epic-scope preflight gate (split-first `_SKIP_REASON`) already present in `validate_issue_for_processing`; left as-is (no duplicate mechanism).

## Tests
- New `test-run-budget-ceiling.bats`: 20/20 green (hard ceiling halts with budget_exceeded, soft warns once, escalate/retry override, batch tally trips breaker).
- Regressions: batch-orchestrator + stage-runner + event-emit + cost-accounting + cost-trend = 316/316 green, 0 failures.
- `bash -n` clean on both scripts.

Subagent-driven (no live orchestrator).