### PR TITLE
feat(issue-579): trim short-task Opus escalation + per-run cap

### DIFF
--- a/.claude/scripts/decide-action.sh
+++ b/.claude/scripts/decide-action.sh
@@ -61,6 +61,20 @@ _next_model() {
 }
 
 # ---------------------------------------------------------------------------
+# _s_opus_gate_bail <error_kind>
+# Emit the S-complexity Opus-gate bail action (issue #579).  A short task at
+# sonnet must not auto-escalate to opus on a single stage failure — Opus buys
+# no completion lift for S tasks, only cost — so bail and require a bounded
+# trigger.  Shared by _bash_decide (double_timeout + default branches) and
+# _compose_decide (escalate branch) so both backends emit identical output.
+# ---------------------------------------------------------------------------
+_s_opus_gate_bail() {
+	local error_kind="${1:-unknown}"
+	printf '{"action":"bail","reason":"%s: S-complexity task at sonnet — not escalating to opus (issue #579)"}\n' \
+		"$error_kind"
+}
+
+# ---------------------------------------------------------------------------
 # _bash_decide <stage_result_json> <history_json>
 # Inline decision tree matching escalation-policy SKILL.md.
 # Prints action JSON to stdout; never calls external scripts.
@@ -120,11 +134,8 @@ _bash_decide() {
 				'{"action":"bail","reason":"double_timeout"}'
 		elif [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
 			# S-complexity gate (issue #579): a short task at sonnet must
-			# not auto-escalate to opus on a single double_timeout — Opus
-			# buys no completion lift for S tasks, only cost.  Bail so Opus
-			# requires a bounded trigger, not one stage failure.
-			printf '%s\n' \
-				'{"action":"bail","reason":"double_timeout: S-complexity task at sonnet — not escalating to opus (issue #579)"}'
+			# not auto-escalate to opus on a single double_timeout.
+			_s_opus_gate_bail "double_timeout"
 		else
 			local next_model
 			next_model=$(_next_model "$model")
@@ -159,8 +170,7 @@ _bash_decide() {
 	# rate_limit retry_same and opus-ceiling checks so those paths are
 	# unaffected — only the sonnet→opus escalation is gated.
 	if [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
-		printf '{"action":"bail","reason":"%s: S-complexity task at sonnet — not escalating to opus (issue #579)"}\n' \
-			"${error_kind:-unknown}"
+		_s_opus_gate_bail "${error_kind:-unknown}"
 		return 0
 	fi
 
@@ -279,8 +289,7 @@ _compose_decide() {
 			# Checked before model-fallback delegation because sonnet's next
 			# tier is opus.
 			if [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
-				printf '{"action":"bail","reason":"%s: S-complexity task at sonnet — not escalating to opus (issue #579)"}\n' \
-					"${error_kind:-unknown}"
+				_s_opus_gate_bail "${error_kind:-unknown}"
 				return 0
 			fi
 

--- a/.claude/scripts/decide-action.sh
+++ b/.claude/scripts/decide-action.sh
@@ -33,6 +33,13 @@ set -o pipefail
 readonly SCRIPT_NAME="${0##*/}"
 readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Per-run escalation cap (issue #579).  Mirrors the orchestrator constant of the
+# same name.  Once the escalation history reaches this length, main() bails fast
+# instead of dispatching another escalation — this prevents the pathological 6+
+# escalation bucket where completion rate collapses.  Env-overridable; set to a
+# large value (e.g. 999) to restore prior unbounded behaviour.
+MAX_ESCALATIONS_PER_RUN="${MAX_ESCALATIONS_PER_RUN:-5}"
+
 die() {
 	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
 	exit 1
@@ -62,10 +69,11 @@ _bash_decide() {
 	local stage_result="$1"
 	local history="$2"
 
-	local status error_kind model
+	local status error_kind model complexity
 	status=$(printf '%s' "$stage_result" | jq -r '.status')
 	error_kind=$(printf '%s' "$stage_result" | jq -r '.error_kind')
 	model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+	complexity=$(printf '%s' "$stage_result" | jq -r '.complexity // empty')
 
 	# success at top level → accept regardless of .output.status presence
 	if [[ "$status" == "success" ]]; then
@@ -110,6 +118,13 @@ _bash_decide() {
 		if [[ "$model" == "opus" ]]; then
 			printf '%s\n' \
 				'{"action":"bail","reason":"double_timeout"}'
+		elif [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
+			# S-complexity gate (issue #579): a short task at sonnet must
+			# not auto-escalate to opus on a single double_timeout — Opus
+			# buys no completion lift for S tasks, only cost.  Bail so Opus
+			# requires a bounded trigger, not one stage failure.
+			printf '%s\n' \
+				'{"action":"bail","reason":"double_timeout: S-complexity task at sonnet — not escalating to opus (issue #579)"}'
 		else
 			local next_model
 			next_model=$(_next_model "$model")
@@ -137,6 +152,16 @@ _bash_decide() {
 				'{"action":"retry_same","reason":"rate_limit: transient throttle, retrying with same model"}'
 			return 0
 		fi
+	fi
+
+	# S-complexity gate (issue #579): before the default escalate, bail an
+	# S task at sonnet rather than promoting it to opus.  Placed after the
+	# rate_limit retry_same and opus-ceiling checks so those paths are
+	# unaffected — only the sonnet→opus escalation is gated.
+	if [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
+		printf '{"action":"bail","reason":"%s: S-complexity task at sonnet — not escalating to opus (issue #579)"}\n' \
+			"${error_kind:-unknown}"
+		return 0
 	fi
 
 	# default: escalate to next tier
@@ -185,10 +210,11 @@ _compose_decide() {
 	local stage_result="$1"
 	local history="$2"
 
-	local status error_kind model
+	local status error_kind model complexity
 	status=$(printf '%s' "$stage_result" | jq -r '.status')
 	error_kind=$(printf '%s' "$stage_result" | jq -r '.error_kind')
 	model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+	complexity=$(printf '%s' "$stage_result" | jq -r '.complexity // empty')
 
 	# success at top level → accept regardless of .output.status presence
 	if [[ "$status" == "success" ]]; then
@@ -247,6 +273,17 @@ _compose_decide() {
 			return 0
 			;;
 		escalate)
+			# S-complexity gate (issue #579): keep the skill-native path in
+			# agreement with _bash_decide — an S task at sonnet bails rather
+			# than escalating to opus, so Opus requires a bounded trigger.
+			# Checked before model-fallback delegation because sonnet's next
+			# tier is opus.
+			if [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
+				printf '{"action":"bail","reason":"%s: S-complexity task at sonnet — not escalating to opus (issue #579)"}\n' \
+					"${error_kind:-unknown}"
+				return 0
+			fi
+
 			# Delegate model selection to decide-model-fallback.sh.
 			# Defaults to bash backend unless MODEL_FALLBACK_BACKEND is set.
 			local retry_reason fallback_out
@@ -300,6 +337,22 @@ main() {
 
 	local stage_result="$1"
 	local history="$2"
+
+	# Per-run escalation cap (issue #579): once the run has accrued
+	# MAX_ESCALATIONS_PER_RUN escalations, fail fast instead of continuing into
+	# the pathological 6+ bucket where completion rate collapses.  Checked here,
+	# before either backend, so the inline bash and skill-native compose paths
+	# agree.  Only an error stage is capped — a success must still be accepted
+	# regardless of history length, so both backends still run for success.
+	local _status _esc_count
+	_status=$(printf '%s' "$stage_result" | jq -r '.status // empty' 2>/dev/null)
+	_esc_count=$(printf '%s' "$history" | jq 'length' 2>/dev/null) || _esc_count=0
+	if [[ "$_status" != "success" ]] \
+		&& (( _esc_count >= MAX_ESCALATIONS_PER_RUN )); then
+		printf '{"action":"bail","reason":"escalation cap reached: %s escalations >= MAX_ESCALATIONS_PER_RUN=%s (issue #579)"}\n' \
+			"$_esc_count" "$MAX_ESCALATIONS_PER_RUN"
+		return 0
+	fi
 
 	# Kill-switch: bypass composition and use inline bash directly
 	if [[ "${ESCALATION_POLICY_BACKEND:-}" == "bash" ]]; then

--- a/.claude/scripts/decide-action.sh
+++ b/.claude/scripts/decide-action.sh
@@ -118,6 +118,18 @@ _bash_decide() {
 		if [[ "$model" == "opus" ]]; then
 			printf '%s\n' \
 				'{"action":"bail","reason":"quality_stall: already at opus ceiling"}'
+		elif [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
+			# S-complexity gate (issue #579): a short task at sonnet must
+			# not auto-escalate to opus on a quality_stall — mirrors the
+			# double_timeout branch, and matches the compose backend which
+			# already bails this case.  run_quality_loop threads task_size
+			# through, so a fix/simplify stage quality-stalling on an S task
+			# reaches here on a realistic path.
+			#
+			# NOTE: M/L quality_stall backend divergence (bash escalates,
+			# compose bails "not a recognised upgrade trigger") is
+			# pre-existing and NOT introduced by #579 — left unchanged here.
+			_s_opus_gate_bail "quality_stall"
 		else
 			local next_model
 			next_model=$(_next_model "$model")

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -86,6 +86,13 @@ MAX_QUALITY_ITERATIONS="${MAX_QUALITY_ITERATIONS:-5}"
 MAX_TEST_ITERATIONS="${MAX_TEST_ITERATIONS:-7}"
 MAX_PR_REVIEW_ITERATIONS="${MAX_PR_REVIEW_ITERATIONS:-2}"
 MAX_VALIDATION_FIX_ITERATIONS="${MAX_VALIDATION_FIX_ITERATIONS:-2}"
+# Per-run escalation cap (issue #579).  Bounds the number of model escalations
+# a single run may accrue.  Once .escalations[] reaches this length,
+# decide-action.sh bails fast instead of continuing into the pathological 6+
+# escalation bucket where completion rate collapses (85% at 0-2 vs 60% at 6+).
+# Purely a cost lever — env-overridable, so operators can restore prior
+# unbounded behaviour with MAX_ESCALATIONS_PER_RUN=999.
+MAX_ESCALATIONS_PER_RUN="${MAX_ESCALATIONS_PER_RUN:-5}"
 # Default = sum of per-phase budgets so the global cap never pre-empts
 # a loop that is within its own budget.  See calc_orchestrator_wall_time()
 # for the formula; the numeric default mirrors its calculation:
@@ -1839,6 +1846,10 @@ _emit_stage_result() {
     local error_kind_json="$6"
     local elapsed_ms="$7"
     local usage_json="${8:-}"
+    # Task complexity (S/M/L or empty) threaded into the envelope so the
+    # escalation decision (decide-action.sh) can gate S-task Opus routing
+    # (issue #579).  Empty when the stage carries no complexity hint.
+    local complexity="${9:-}"
 
     if [[ -z "$usage_json" || "$usage_json" == "null" ]]; then
         usage_json='{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"total_cost_usd":0}'
@@ -1871,8 +1882,10 @@ _emit_stage_result() {
         --argjson cache_read_tokens "${cache_read_tokens:-0}" \
         --argjson reported_usd "${reported_usd:-0}" \
         --argjson computed_usd "$computed_usd" \
+        --arg complexity "$complexity" \
         '{status: $status, output: $output, raw: $raw, denials: $denials,
           model: $model, error_kind: $error_kind, elapsed_ms: $elapsed_ms,
+          complexity: $complexity,
           tokens: {input_tokens: $input_tokens, output_tokens: $output_tokens,
                     cache_creation_input_tokens: $cache_creation_tokens,
                     cache_read_input_tokens: $cache_read_tokens},
@@ -1997,7 +2010,8 @@ run_stage() {
         _sr=$(_emit_stage_result \
             "error" "null" "" "[]" \
             "$result_model" '"schema_not_found"' \
-            "$(( $(_epoch_ms) - result_start_ms ))")
+            "$(( $(_epoch_ms) - result_start_ms ))" \
+            "" "${complexity:-}")
         _apply_stage_action "$_sr" "bail" "schema_not_found"
         return $?
     fi
@@ -2218,7 +2232,7 @@ run_stage() {
                 "$(_extract_denials "$output")" \
                 "$result_model" "null" \
                 "$(( $(_epoch_ms) - result_start_ms ))" \
-                "$_stage_usage")
+                "$_stage_usage" "${complexity:-}")
             _apply_stage_action "$_sr" "accept"
             return $?
         fi
@@ -2239,7 +2253,7 @@ run_stage() {
                 "$(_extract_denials "$output")" \
                 "$result_model" "null" \
                 "$(( $(_epoch_ms) - result_start_ms ))" \
-                "$_stage_usage")
+                "$_stage_usage" "${complexity:-}")
             _apply_stage_action "$_sr" "accept"
             return $?
         fi
@@ -2506,7 +2520,7 @@ for m in re.finditer(r'\[\s*\{', t):
         "$(_extract_denials "$output")" \
         "$result_model" "$_error_kind_json" \
         "$(( $(_epoch_ms) - result_start_ms ))" \
-        "$_stage_usage")
+        "$_stage_usage" "${complexity:-}")
 
     # Escalation history from status file
     local _history="[]"
@@ -2541,7 +2555,7 @@ for m in re.finditer(r'\[\s*\{', t):
                 "$(_extract_denials "$output")" \
                 "$result_model" "null" \
                 "$(( $(_epoch_ms) - result_start_ms ))" \
-                "$_stage_usage")
+                "$_stage_usage" "${complexity:-}")
             _apply_stage_action "$_sr_accept" "accept"
             return $?
             ;;
@@ -2645,7 +2659,7 @@ for m in re.finditer(r'\[\s*\{', t):
                     "$(_extract_denials "$output")" \
                     "$result_model" "null" \
                     "$(( $(_epoch_ms) - result_start_ms ))" \
-                    "$_stage_usage")
+                    "$_stage_usage" "${complexity:-}")
             else
                 emit_event "schema_validation_fail" \
                     "stage=$stage_name" \
@@ -2659,7 +2673,7 @@ for m in re.finditer(r'\[\s*\{', t):
                     "$(_extract_denials "$output")" \
                     "$result_model" '"no_structured_output"' \
                     "$(( $(_epoch_ms) - result_start_ms ))" \
-                    "$_stage_usage")
+                    "$_stage_usage" "${complexity:-}")
             fi
             _apply_stage_action "$_sr_esc" "escalate" "$_da_reason"
             return $?
@@ -2727,14 +2741,14 @@ for m in re.finditer(r'\[\s*\{', t):
                     "$(_extract_denials "$output")" \
                     "$result_model" "null" \
                     "$(( $(_epoch_ms) - result_start_ms ))" \
-                    "$_stage_usage")
+                    "$_stage_usage" "${complexity:-}")
             else
                 _sr_retry=$(_emit_stage_result \
                     "error" "null" "$output" \
                     "$(_extract_denials "$output")" \
                     "$result_model" '"no_structured_output"' \
                     "$(( $(_epoch_ms) - result_start_ms ))" \
-                    "$_stage_usage")
+                    "$_stage_usage" "${complexity:-}")
             fi
             _apply_stage_action "$_sr_retry" "retry_same" "$_da_reason"
             return $?

--- a/.claude/scripts/implement-issue-test/test-timeout-escalation.bats
+++ b/.claude/scripts/implement-issue-test/test-timeout-escalation.bats
@@ -295,6 +295,61 @@ teardown() {
         fail "Expected cap-reached reason in compose, got: $output"
 }
 
+# =============================================================================
+# S-COMPLEXITY OPUS GATE — quality_stall branch (issue #579, AC1 + AC4)
+#
+# The S-gate must also cover error_kind=quality_stall, not only double_timeout
+# and the default escalate.  run_quality_loop threads task_size through, so a
+# fix/simplify stage quality-stalling on an S task reaches _bash_decide's
+# quality_stall branch on a realistic path.  Both backends must agree.
+# =============================================================================
+
+@test "S-complexity quality_stall at sonnet bails in bash backend (does not escalate to opus)" {
+    local sr='{"status":"error","error_kind":"quality_stall","model":"sonnet","complexity":"S"}'
+    run env ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[]'
+    [ "$status" -eq 0 ]
+    local action
+    action=$(printf '%s' "$output" | jq -r '.action')
+    [ "$action" = "bail" ] || fail "Expected bail for S-at-sonnet quality_stall, got: $action ($output)"
+    [[ "$output" == *"S-complexity"* ]] || fail "Expected S-complexity reason, got: $output"
+}
+
+@test "backend parity: compose path also bails S-at-sonnet quality_stall" {
+    local sr='{"status":"error","error_kind":"quality_stall","model":"sonnet","complexity":"S"}'
+    # Skill-native compose path (bash sub-backends), NOT ESCALATION_POLICY_BACKEND=bash
+    run env RETRY_POLICY_BACKEND=bash MODEL_FALLBACK_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[]'
+    [ "$status" -eq 0 ]
+    local action
+    action=$(printf '%s' "$output" | jq -r '.action')
+    [ "$action" = "bail" ] || fail "Expected compose bail for S-at-sonnet quality_stall, got: $action ($output)"
+}
+
+@test "M-complexity quality_stall at sonnet still escalates to opus (bash backend, no over-blocking)" {
+    local sr='{"status":"error","error_kind":"quality_stall","model":"sonnet","complexity":"M"}'
+    run env ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[]'
+    [ "$status" -eq 0 ]
+    local action model
+    action=$(printf '%s' "$output" | jq -r '.action')
+    model=$(printf '%s' "$output" | jq -r '.model')
+    [ "$action" = "escalate" ] || fail "Expected escalate for M quality_stall, got: $action ($output)"
+    [ "$model" = "opus" ] || fail "Expected opus for M quality_stall, got: $model"
+}
+
+@test "L-complexity quality_stall at sonnet still escalates to opus (bash backend, no over-blocking)" {
+    local sr='{"status":"error","error_kind":"quality_stall","model":"sonnet","complexity":"L"}'
+    run env ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[]'
+    [ "$status" -eq 0 ]
+    local action model
+    action=$(printf '%s' "$output" | jq -r '.action')
+    model=$(printf '%s' "$output" | jq -r '.model')
+    [ "$action" = "escalate" ] || fail "Expected escalate for L quality_stall, got: $action ($output)"
+    [ "$model" = "opus" ] || fail "Expected opus for L quality_stall, got: $model"
+}
+
 @test "stage_result envelope carries complexity field (issue #579)" {
     source "$MODEL_CONFIG_ARRAYS_FILE"
     local sr

--- a/.claude/scripts/implement-issue-test/test-timeout-escalation.bats
+++ b/.claude/scripts/implement-issue-test/test-timeout-escalation.bats
@@ -160,6 +160,151 @@ teardown() {
 }
 
 # =============================================================================
+# PER-RUN ESCALATION CAP + S-COMPLEXITY OPUS GATE (issue #579)
+#
+# These exercise decide-action.sh directly (bash backend, pinned by
+# install_decide_scripts) with crafted stage_result + history JSON.  The cap
+# bail is checked in main() before dispatch; the S-Opus gate lives in both
+# _bash_decide and _compose_decide so the two backends agree.
+# =============================================================================
+
+@test "escalation cap: history length >= MAX_ESCALATIONS_PER_RUN bails" {
+    local sr='{"status":"error","error_kind":"double_timeout","model":"sonnet","complexity":"M"}'
+    local history='[{},{},{},{},{}]'   # length 5 == default cap
+    run env MAX_ESCALATIONS_PER_RUN=5 ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" "$history"
+    [ "$status" -eq 0 ]
+    local action
+    action=$(printf '%s' "$output" | jq -r '.action')
+    [ "$action" = "bail" ] || fail "Expected bail at cap, got: $action ($output)"
+    [[ "$output" == *"escalation cap reached"* ]] || \
+        fail "Expected cap-reached reason, got: $output"
+}
+
+@test "escalation cap: history under cap still escalates" {
+    local sr='{"status":"error","error_kind":"double_timeout","model":"sonnet","complexity":"M"}'
+    local history='[{},{},{},{}]'   # length 4 < cap 5
+    run env MAX_ESCALATIONS_PER_RUN=5 ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" "$history"
+    [ "$status" -eq 0 ]
+    local action model
+    action=$(printf '%s' "$output" | jq -r '.action')
+    model=$(printf '%s' "$output" | jq -r '.model')
+    [ "$action" = "escalate" ] || fail "Expected escalate under cap, got: $action"
+    [ "$model" = "opus" ] || fail "Expected opus, got: $model"
+}
+
+@test "escalation cap: env override raises the cap" {
+    local sr='{"status":"error","error_kind":"double_timeout","model":"sonnet","complexity":"M"}'
+    local history='[{},{},{},{},{}]'   # length 5, but cap raised to 7
+    run env MAX_ESCALATIONS_PER_RUN=7 ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" "$history"
+    [ "$status" -eq 0 ]
+    local action
+    action=$(printf '%s' "$output" | jq -r '.action')
+    [ "$action" = "escalate" ] || \
+        fail "Expected escalate with raised cap, got: $action ($output)"
+}
+
+@test "escalation cap: success at cap still accepts (cap only bails errors)" {
+    local sr='{"status":"success","error_kind":"null","model":"sonnet","complexity":"S"}'
+    local history='[{},{},{},{},{}]'
+    run env MAX_ESCALATIONS_PER_RUN=5 ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" "$history"
+    [ "$status" -eq 0 ]
+    local action
+    action=$(printf '%s' "$output" | jq -r '.action')
+    [ "$action" = "accept" ] || fail "Expected accept for success, got: $action"
+}
+
+@test "S-complexity double_timeout at sonnet bails (does not escalate to opus)" {
+    local sr='{"status":"error","error_kind":"double_timeout","model":"sonnet","complexity":"S"}'
+    run env ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[]'
+    [ "$status" -eq 0 ]
+    local action
+    action=$(printf '%s' "$output" | jq -r '.action')
+    [ "$action" = "bail" ] || fail "Expected bail for S-at-sonnet, got: $action ($output)"
+    [[ "$output" == *"S-complexity"* ]] || fail "Expected S-complexity reason, got: $output"
+}
+
+@test "S-complexity default error at sonnet bails (does not escalate to opus)" {
+    local sr='{"status":"error","error_kind":"no_structured_output","model":"sonnet","complexity":"S"}'
+    run env ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[]'
+    [ "$status" -eq 0 ]
+    local action
+    action=$(printf '%s' "$output" | jq -r '.action')
+    [ "$action" = "bail" ] || fail "Expected bail for S default-error, got: $action ($output)"
+}
+
+@test "M-complexity double_timeout at sonnet still escalates to opus" {
+    local sr='{"status":"error","error_kind":"double_timeout","model":"sonnet","complexity":"M"}'
+    run env ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[]'
+    [ "$status" -eq 0 ]
+    local action model
+    action=$(printf '%s' "$output" | jq -r '.action')
+    model=$(printf '%s' "$output" | jq -r '.model')
+    [ "$action" = "escalate" ] || fail "Expected escalate for M, got: $action"
+    [ "$model" = "opus" ] || fail "Expected opus for M, got: $model"
+}
+
+@test "L-complexity default error at sonnet still escalates to opus" {
+    local sr='{"status":"error","error_kind":"no_structured_output","model":"sonnet","complexity":"L"}'
+    run env ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[]'
+    [ "$status" -eq 0 ]
+    local action model
+    action=$(printf '%s' "$output" | jq -r '.action')
+    model=$(printf '%s' "$output" | jq -r '.model')
+    [ "$action" = "escalate" ] || fail "Expected escalate for L, got: $action"
+    [ "$model" = "opus" ] || fail "Expected opus for L, got: $model"
+}
+
+@test "empty complexity at sonnet still escalates to opus (no gate)" {
+    local sr='{"status":"error","error_kind":"double_timeout","model":"sonnet","complexity":""}'
+    run env ESCALATION_POLICY_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[]'
+    [ "$status" -eq 0 ]
+    local action
+    action=$(printf '%s' "$output" | jq -r '.action')
+    [ "$action" = "escalate" ] || fail "Expected escalate for empty complexity, got: $action"
+}
+
+@test "backend parity: compose path also bails S-at-sonnet double_timeout" {
+    local sr='{"status":"error","error_kind":"double_timeout","model":"sonnet","complexity":"S"}'
+    # Skill-native compose path (bash sub-backends), NOT ESCALATION_POLICY_BACKEND=bash
+    run env RETRY_POLICY_BACKEND=bash MODEL_FALLBACK_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[]'
+    [ "$status" -eq 0 ]
+    local action
+    action=$(printf '%s' "$output" | jq -r '.action')
+    [ "$action" = "bail" ] || fail "Expected compose bail for S-at-sonnet, got: $action ($output)"
+}
+
+@test "backend parity: compose path also bails at per-run cap" {
+    local sr='{"status":"error","error_kind":"double_timeout","model":"sonnet","complexity":"M"}'
+    run env MAX_ESCALATIONS_PER_RUN=5 RETRY_POLICY_BACKEND=bash MODEL_FALLBACK_BACKEND=bash \
+        bash "$TEST_TMP/decide-action.sh" "$sr" '[{},{},{},{},{}]'
+    [ "$status" -eq 0 ]
+    local action
+    action=$(printf '%s' "$output" | jq -r '.action')
+    [ "$action" = "bail" ] || fail "Expected compose cap bail, got: $action ($output)"
+    [[ "$output" == *"escalation cap reached"* ]] || \
+        fail "Expected cap-reached reason in compose, got: $output"
+}
+
+@test "stage_result envelope carries complexity field (issue #579)" {
+    source "$MODEL_CONFIG_ARRAYS_FILE"
+    local sr
+    sr=$(_emit_stage_result "error" "null" "" "[]" "sonnet" '"double_timeout"' 100 "" "S")
+    local cx
+    cx=$(printf '%s' "$sr" | jq -r '.complexity')
+    [ "$cx" = "S" ] || fail "Expected complexity=S in envelope, got: $cx ($sr)"
+}
+
+# =============================================================================
 # EMPTY OUTPUT → MODEL ESCALATION (AC2)
 # =============================================================================
 

--- a/plugins/pipeline-core/skills/escalation-policy/SKILL.md
+++ b/plugins/pipeline-core/skills/escalation-policy/SKILL.md
@@ -36,9 +36,12 @@ Model escalation path: **haiku → sonnet → opus** (no tier above opus; opus i
   "denials":    ["<tool_name>"]   ,
   "model":      "haiku | sonnet | opus",
   "error_kind": "timeout | schema_not_found | no_structured_output | quality_stall | max_turns_exhausted_at_ceiling | rate_limit | permission_denied | null",
-  "elapsed_ms": 12345
+  "elapsed_ms": 12345,
+  "complexity": "S | M | L | \"\"  — task complexity hint; gates S-task Opus routing"
 }
 ```
+
+`complexity` is threaded from `run_stage()` into the envelope (issue #579) so the escalation decision can distinguish a short (S) task from an M/L task when deciding whether Opus is worth spending.
 
 ### `escalation_history` — from `STATUS_FILE.escalations[]`
 
@@ -56,6 +59,8 @@ Array of records appended by `record_escalation()` each time a stage is retried 
 ```
 
 Filter to records where `stage == current_stage_name` before reasoning.
+
+**Per-run escalation cap (issue #579).** The whole `escalation_history` array (run-wide, not stage-filtered) is also bounded by `MAX_ESCALATIONS_PER_RUN` (default 5, env-overridable). Once `escalation_history | length >= MAX_ESCALATIONS_PER_RUN`, any non-success stage_result routes to **bail** — before any other rule — so a run cannot spend into the pathological 6+ escalation bucket where completion rate collapses (85% at 0–2 escalations vs 60% at 6+). A `success` stage_result is still accepted regardless of history length.
 
 ## Output Contract
 
@@ -117,6 +122,8 @@ Re-run the stage with the next higher model tier.
 - `stage_result.model == "opus"` — already at ceiling; use `bail` instead
 - `error_kind == "permission_denied"` — a higher model cannot bypass permissions
 - `error_kind == "schema_not_found"` — a configuration error, not a capability gap
+- `complexity == "S"` AND `stage_result.model == "sonnet"` — **S-Opus gate (issue #579):** a short task at sonnet must NOT auto-escalate to opus on a single stage failure (Opus buys no completion lift for S tasks, only cost). Use `bail` so Opus requires a bounded trigger, not one `double_timeout`/`no_structured_output`. M and L tasks at sonnet still escalate to opus normally.
+- `escalation_history | length >= MAX_ESCALATIONS_PER_RUN` — per-run cap reached; use `bail`
 
 **Model selection:** always the next tier up from `stage_result.model`:
 - haiku → sonnet
@@ -135,6 +142,8 @@ Terminate the stage as a permanent failure; propagate the error to the caller.
 - `error_kind == "schema_not_found"` — missing schema file; fix the configuration
 - `error_kind == "max_turns_exhausted_at_ceiling"` — explicitly set by `run_stage` when opus exhausted turns
 - `escalation_history` shows the stage has already been escalated to opus and failed again
+- `escalation_history | length >= MAX_ESCALATIONS_PER_RUN` (default 5) — **per-run escalation cap (issue #579):** the run has already escalated too many times; fail fast rather than continuing into the 6+ bucket
+- `complexity == "S"` AND `stage_result.model == "sonnet"` AND a non-transient failure — **S-Opus gate (issue #579):** bail instead of escalating sonnet→opus for a short task
 
 **Required output fields:** `action`, `reason`
 
@@ -178,6 +187,11 @@ status == "success" AND output valid?
   no  ↓
         │
         ▼
+escalation_history | length >= MAX_ESCALATIONS_PER_RUN (default 5)?   ← per-run cap (issue #579)
+  yes → bail  (escalation cap reached: fail fast, do not enter the 6+ bucket)
+  no  ↓
+        │
+        ▼
 error_kind == "permission_denied" OR "schema_not_found"?
   yes → bail
   no  ↓
@@ -187,6 +201,15 @@ error_kind == "quality_stall"?
   yes → model == "opus"?
           yes → bail  (quality_stall: already at opus ceiling)
           no  → escalate (quality_stall: escalating from <model> to <next>)
+  no  ↓
+        │
+        ▼
+error_kind == "double_timeout"?
+  yes → model == "opus"?
+          yes → bail  (double_timeout: already at opus ceiling)
+          no  → complexity == "S" AND model == "sonnet"?     ← S-Opus gate (issue #579)
+                  yes → bail  (S-complexity task at sonnet — not escalating to opus)
+                  no  → escalate (double_timeout)
   no  ↓
         │
         ▼
@@ -200,7 +223,9 @@ error_kind == "rate_limit" AND no prior retry at same model?
   no  ↓
         │
         ▼
-escalate  (double_timeout | max_turns_exhausted | empty_output | structured_error | quality_stall)
+complexity == "S" AND model == "sonnet"?                     ← S-Opus gate (issue #579)
+  yes → bail  (S-complexity task at sonnet — not escalating to opus)
+  no  → escalate  (max_turns_exhausted | empty_output | structured_error)
 ```
 
 ## Common Mistakes
@@ -212,3 +237,5 @@ escalate  (double_timeout | max_turns_exhausted | empty_output | structured_erro
 | retry_same after a prior retry | Check `escalation_history` for same stage+model; escalate if present |
 | Omitting `model` on escalate action | `model` is required when action is `escalate` |
 | Escalating on `permission_denied` | A higher model cannot bypass permission hooks; bail |
+| Escalating an S task from sonnet to opus | S-Opus gate (issue #579): bail instead; only M/L tasks escalate sonnet→opus |
+| Continuing to escalate past the per-run cap | Bail once `escalation_history \| length >= MAX_ESCALATIONS_PER_RUN` (default 5) |


### PR DESCRIPTION
Closes #579. Stacked on #590 (feature/issue-583). Adds `complexity` to #580's stage_result envelope.

## Summary
Two independent, cost-only levers to stop spending Opus turns that buy no completion lift (evidence: escalation 1–5 tracks the 85% baseline; 6+ collapses to 60%):

1. **Per-run escalation cap** — new `MAX_ESCALATIONS_PER_RUN` (default 5, env-overridable). `decide-action.sh main()` bails fast once `escalation_history | length >= cap` (before dispatch, so both backends agree). A `success` still accepts regardless of history length.
2. **S-complexity Opus gate** — an S task at sonnet bails instead of auto-escalating to opus on `double_timeout`/default-error branches. M/L tasks still escalate normally. Requires threading `complexity` into the stage_result envelope.

## Changes
- `implement-issue-orchestrator.sh`: added `MAX_ESCALATIONS_PER_RUN` alongside the run caps; added `complexity` param+field to `_emit_stage_result` and threaded `${complexity:-}` through all 9 call sites.
- `decide-action.sh`: cap-bail in `main()`; S-Opus gate in both `_bash_decide` (double_timeout + default branches) and `_compose_decide` (escalate branch) for backend parity; mirrored `MAX_ESCALATIONS_PER_RUN` constant.
- `escalation-policy/SKILL.md`: documented the cap and S-Opus gate in the input contract, action types, decision flowchart, and common mistakes.

## #580 overlap
#580 already extended `_emit_stage_result` with token/cost (`tokens`/`cost`) fields and an 8th `usage_json` param. This PR **adds** `complexity` as the 9th param and a sibling `complexity` envelope field — the token/cost fields are untouched. The one 7-arg call site (schema_not_found) passes `"" "${complexity:-}"` so usage keeps its zero default.

## Tests
- `test-timeout-escalation.bats`: 25/25 pass (12 new: cap-bail, cap-under, env-override, success-at-cap, S-gate double_timeout + default, M/L still escalate, empty-complexity escalates, compose parity ×2, envelope carries complexity).
- Regression: `test-stage-runner.bats` 105/105, `tests/decide-action.bats` 14/14, `tests/escalation-policy-golden.bats` 4/4.
- `bash -n` clean on both scripts.

Subagent-driven (no live orchestrator).