### PR TITLE
feat(issue-582): enforce per-task file-path requirement

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -4032,6 +4032,15 @@ _parse_task_lines() {
 			desc="**(M)** $desc"
 		fi
 
+		# Warn-only mirror of assert_issue_valid criterion 7 (issue #582):
+		# a task with no recognisable file path forces the specialist to scan
+		# the codebase blind — the #1 explore-stage token sink.  This is a
+		# run-time nudge only; the hard gate lives in assert_issue_valid, so
+		# issues that bypass validation still surface the warning here.
+		if [[ -z "$(_extract_task_files_from_desc "$desc")" ]]; then
+			log_warn "No file path in task (scans codebase blind): $line"
+		fi
+
 		task_id=$((task_id + 1))
 		# Store task for now; affected_files will be attached in the second pass.
 		tasks_json=$(printf '%s' "$tasks_json" | jq \

--- a/.claude/scripts/implement-issue-test/test-batch-orchestrator.bats
+++ b/.claude/scripts/implement-issue-test/test-batch-orchestrator.bats
@@ -1797,7 +1797,7 @@ GHEOF
 	# Re-fetch after enrich returns a structurally valid body → proceed.
 	_install_gh_two_phase_mock \
 		'{"body":"## Background\n\nNo tasks here.","labels":[]}' \
-		'{"body":"## Implementation Tasks\n\n- [ ] `[default]` do the thing\n\n## Acceptance Criteria\n\n- it works","labels":[]}'
+		'{"body":"## Implementation Tasks\n\n- [ ] `[default]` do the thing — `.claude/scripts/x.sh`\n\n## Acceptance Criteria\n\n- it works","labels":[]}'
 
 	source_revalidate_functions \
 		|| skip "revalidate_issue_after_enrich() not yet present"
@@ -1834,7 +1834,7 @@ GHEOF
 	# post-enrich re-fetch returns a structurally valid body → proceed.
 	_install_gh_two_phase_mock \
 		'{"body":"<!-- pipeline-autocreated -->\n## Implementation Tasks\n\nProse only, no task lines.","labels":[]}' \
-		'{"body":"## Implementation Tasks\n\n- [ ] `[default]` do the thing\n\n## Acceptance Criteria\n\n- it works","labels":[]}'
+		'{"body":"## Implementation Tasks\n\n- [ ] `[default]` do the thing — `.claude/scripts/x.sh`\n\n## Acceptance Criteria\n\n- it works","labels":[]}'
 
 	source_revalidate_functions \
 		|| skip "revalidate_issue_after_enrich() not yet present"

--- a/.claude/scripts/implement-issue-test/test-create-issue-parent.bats
+++ b/.claude/scripts/implement-issue-test/test-create-issue-parent.bats
@@ -381,7 +381,7 @@ MOCK
 	# A body with ## Implementation Tasks AND proper task format plus Acceptance
 	# Criteria must pass assert_issue_valid and proceed to create the issue.
 	local body
-	body=$(printf 'Context.\n\n## Implementation Tasks\n\n- [ ] `[default]` **(S)** Fix the bug\n\n## Acceptance Criteria\n\n- [ ] Bug is fixed\n')
+	body=$(printf 'Context.\n\n## Implementation Tasks\n\n- [ ] `[default]` **(S)** Fix the bug — `.claude/scripts/issue-body-lib.sh`\n\n## Acceptance Criteria\n\n- [ ] Bug is fixed\n')
 	unset DEPLOY_VERIFY_CMD
 	_run_create_issue --title "Test" --body "$body"
 	[ "$status" -eq 0 ]

--- a/.claude/scripts/implement-issue-test/test-issue-body-lib.bats
+++ b/.claude/scripts/implement-issue-test/test-issue-body-lib.bats
@@ -900,6 +900,87 @@ Some prose but no task checkboxes.
 }
 
 # =============================================================================
+# assert_issue_valid() — CRITERION 7: every open task carries a file path
+# =============================================================================
+
+@test "assert_issue_valid: rejects an open task that references no file path" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(S)** Refactor the retry logic for reliability
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"task has no file path"* ]]
+	# The diagnostic must name the offending task.
+	[[ "$output" == *"Refactor the retry logic for reliability"* ]]
+}
+
+@test "assert_issue_valid: accepts an open task that references a resolvable file path" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(S)** Add a helper — \`.claude/scripts/issue-body-lib.sh\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"task has no file path"* ]]
+}
+
+@test "assert_issue_valid: accepts an open task whose only path carries a :Lnn suffix" {
+	# Reuses #581's :Lnn-tolerant path counter — a lone line-range-suffixed
+	# path must satisfy the file-path requirement, not be silently skipped.
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(S)** Patch one spot — \`.claude/scripts/issue-body-lib.sh:L10-40\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"task has no file path"* ]]
+}
+
+@test "assert_issue_valid: accepts an open task whose only path is a directory" {
+	# Dir-only paths still count as a path — no regression from criterion 7.
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(S)** Touch the scripts dir — \`.claude/scripts/\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"task has no file path"* ]]
+}
+
+@test "assert_issue_valid: exempts a checked [x] task that has no file path" {
+	# Only OPEN tasks are gated; a completed task with no path must not fail.
+	local body
+	body="## Implementation Tasks
+
+- [x] \`[bash-script-craftsman]\` **(S)** Legacy done task with no path at all
+- [ ] \`[bash-script-craftsman]\` **(S)** Open task — \`.claude/scripts/x.sh\`
+
+## Acceptance Criteria
+
+- [ ] done"
+	run assert_issue_valid "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"task has no file path"* ]]
+}
+
+# =============================================================================
 # assert_issue_valid() — TASK-MIX ADVISORY WARNING (non-failing)
 # =============================================================================
 

--- a/.claude/scripts/issue-body-lib.sh
+++ b/.claude/scripts/issue-body-lib.sh
@@ -9,7 +9,7 @@
 #       unique — derived from the .claude/agents/*.md definitions.
 #
 #   assert_issue_valid <body>
-#       Validates an issue body string against six structural criteria:
+#       Validates an issue body string against seven structural criteria:
 #         1. at least one parseable (open) task line
 #         2. every task agent resolves to a known agent (or "default")
 #         3. every file path referenced in a task resolves (file exists or
@@ -19,6 +19,8 @@
 #            DEPLOY_VERIFY_CMD is set
 #         6. task granularity — no M/L task references more than two distinct
 #            file paths (decomposable tasks must be split into S sub-tasks)
+#         7. every open task references at least one file path (a task with
+#            zero path tokens is rejected — the #1 explore-stage token sink)
 #       Additionally emits a non-failing stderr WARNING reporting the
 #       M/L-vs-S task count whenever the body has any non-S task.
 #       Returns 0 when valid; prints one diagnostic per failure to stderr
@@ -350,6 +352,10 @@ _issue_body_parse_tasks() {
 #   5. a "Deploy Verification" section iff DEPLOY_VERIFY_CMD is set
 #   6. task granularity — no M/L task references more than two distinct file
 #      paths (a decomposable task that should be split into S sub-tasks)
+#   7. every open task references at least one file path — a task whose
+#      description yields zero path tokens is rejected (the diagnostic names
+#      the offending task).  Checked [x] tasks are exempt (the parser skips
+#      them, so only OPEN tasks reach this gate)
 #
 # Soft advisory (never fails the body):
 #   * emits a stderr WARNING reporting the M/L-vs-S task count whenever the
@@ -379,7 +385,8 @@ assert_issue_valid() {
 		errors+=("no parseable task lines found")
 	fi
 
-	# Criteria 2, 3 & 6: agents resolve, path suffixes resolve, granularity.
+	# Criteria 2, 3, 6 & 7: agents resolve, path suffixes resolve, granularity,
+	# and every open task carries at least one file path.
 	local agent desc remapped path parent complexity path_count
 	local -i s_count=0 nons_count=0
 	while IFS=$'\t' read -r agent desc; do
@@ -406,6 +413,20 @@ assert_issue_valid() {
 			fi
 		done < <(_issue_body_extract_paths "$desc")
 
+		# Distinct file-path count (":Lnn"-suffix aware — reuses #581's
+		# _issue_body_task_path_count so a lone `file.ts:L10-40` still counts as
+		# one path).  Computed once and shared by criteria 7 and 6.
+		path_count=$(_issue_body_task_path_count "$desc")
+
+		# Criterion 7: every open task must reference at least one file path.
+		# A task with zero path tokens forces the implement stage to scan the
+		# codebase blind — the #1 token sink the explore skill warns about.
+		# The parser already skips checked [x] tasks, so only OPEN tasks are
+		# gated here; the diagnostic names the offending task.
+		if (( path_count == 0 )); then
+			errors+=("task has no file path: ${desc}")
+		fi
+
 		# Criterion 6: task granularity.  Tally the S/non-S mix for the
 		# advisory warning, and hard-fail any M/L task that names more than
 		# two distinct file paths — a decomposable task the explore step
@@ -415,7 +436,6 @@ assert_issue_valid() {
 			s_count=$((s_count + 1))
 		else
 			nons_count=$((nons_count + 1))
-			path_count=$(_issue_body_task_path_count "$desc")
 			if (( path_count > 2 )); then
 				errors+=("task granularity: (${complexity}) task references ${path_count} distinct file paths (>2); split into S sub-tasks — ${desc}")
 			fi

--- a/plugins/pipeline-core/skills/explore/SKILL.md
+++ b/plugins/pipeline-core/skills/explore/SKILL.md
@@ -291,7 +291,7 @@ Task sizing directly controls model cost via `model-config.sh`:
 
 - **Prefer S-complexity tasks** — S and M tasks use sonnet; only L tasks use opus. Prefer S over M/L for smaller scope, not model savings.
 - **Split M/L tasks into multiple S tasks** when the work is decomposable into independent steps. **This is now enforced:** `assert_issue_valid` hard-rejects a decomposable M/L task (M/L hint AND >2 distinct file paths) and warns on the overall non-S mix — see the Task Format Specification. Decompose at explore time; do not rely on the gate to catch it.
-- **Every task MUST include at least one file path. Tasks without file paths will cause subagents to scan broadly — this is the #1 token waste in the pipeline.**
+- **Every task MUST include at least one file path. This is now ENFORCED, not advised:** `assert_issue_valid` (`.claude/scripts/issue-body-lib.sh`) hard-rejects any OPEN task whose description yields zero file paths (the diagnostic names the offending task), so an issue with a path-less task is bounced before creation. Line-range suffixes count (`file.ts:L10-40` satisfies the rule) and directory-only paths count (`.claude/scripts/`); already-completed `[x]` tasks are exempt. Tasks without file paths otherwise cause subagents to scan broadly — the #1 token waste in the pipeline.
 - **Each task's affected file list reduces subagent exploration cost** — include file paths in the task description.
 
 ## Integration
@@ -310,7 +310,7 @@ Task sizing directly controls model cost via `model-config.sh`:
 | Combine multiple concerns in one issue | One issue = one problem = one PR |
 | Ask too many clarifying questions | 0-2 questions max; research answers most questions |
 | Single task modifies 5+ files | Split into focused subtasks |
-| Task has no file paths | Subagent reads 13+ files to orient; include at least 1 file path per task |
+| Task has no file paths | **Rejected by `assert_issue_valid`** — an OPEN task with zero file paths fails validation before the issue is created (subagents would otherwise read 13+ files to orient). Include at least 1 file path per task |
 | File path doesn't exist in repo | Subagent wastes a full search cycle; verify paths before writing them |
 | Task description over ~200 chars | Truncated in UI and hard to scan; put details in the issue body instead |
 | Writing `[test-engineer]` as agent | Legacy alias — write `[playwright-test-developer]` for E2E or `[default]` for general tests |


### PR DESCRIPTION
Closes #582. Stacked on #591. Builds on #581's path-count helper + :Lnn fix.

## Summary
Adds **criterion 7** to `assert_issue_valid` (`.claude/scripts/issue-body-lib.sh`): every OPEN task must reference at least one file path. Previously a task with zero path tokens passed validation silently — the exact enforcement hole #581 flagged as #582's job. The check reuses #581's `_issue_body_task_path_count` helper, so a lone `:Lnn`-suffixed path (e.g. `file.ts:L10-40`) and directory-only paths (e.g. `.claude/scripts/`) both still count. Checked `[x]` tasks are exempt (the parser skips them). The diagnostic names the offending task.

Also mirrors a **warn-only** `log_warn` in the orchestrator's `_parse_task_lines` (`implement-issue-orchestrator.sh`) alongside the existing complexity-hint warning, and updates the explore skill's **Token Efficiency** + **Red Flags** sections to state the rule is now ENFORCED, not advised.

## Tests (TDD: failing case written first, confirmed RED with lib change stashed)
- `test-issue-body-lib.bats`: **75 passed** (70 existing + 5 new — no-path rejection incl. task-name in message, resolvable path passes, `:Lnn`-only passes, dir-only passes, checked `[x]` exempt).
- Regression suites sourcing the validator all green: create-issue-parent (28), create-followup-issue (36), adj-body-validation (30), enrich-issue (26), batch-orchestrator (135), skill-golden-lib (64), fuzzy-task-parsing (21), stage-runner (105), block-gh-issue-create (15), triage-classify-golden (4).
- Two structurally-valid fixtures that predated the rule (1 in create-issue-parent, 2 in batch-orchestrator) updated to carry a resolvable path.
- `bash -n` clean on both edited scripts.

Subagent-driven (no live orchestrator).