### PR TITLE
feat(issue-584): harden parse-issue task extraction

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -185,6 +185,20 @@ readonly RATE_LIMIT_DEFAULT_WAIT=3600
 readonly RATE_LIMIT_EXHAUSTION_THRESHOLD="${RATE_LIMIT_EXHAUSTION_THRESHOLD:-1800}"
 readonly _AGENT_SENTINEL_DEFAULT="default"
 
+# Canonical "Implementation Tasks" heading matcher (issue #584 parity) — the
+# SINGLE source of truth shared by both orchestrator heading sites: the PARSE
+# ISSUE awk slice and the resume-path grep guard.  Mirrors the library's
+# ISSUE_BODY_TASKS_HEADING_RE (issue-body-lib.sh) behaviour EXACTLY:
+#   * UNANCHORED tail — annotated headings ("## Implementation Tasks (draft)")
+#     are recognised so the per-line lint report actually fires (do NOT anchor).
+#   * Case-insensitive — awk folds via tolower($0); grep folds via -i.  The
+#     literal is kept lowercase so the awk `tolower($0) ~ h` comparison matches.
+#   * CRLF-tolerant — the awk strips a trailing CR; grep matches the unanchored
+#     substring regardless of a trailing CR.
+# test-parser-parity.bats runs shared fixtures through BOTH this path and the
+# library parsers and asserts identical results, guarding against drift.
+readonly ISSUE_TASKS_HEADING_ERE='^##+[[:space:]]+implementation tasks'
+
 # =============================================================================
 # PORTABLE TIMEOUT (macOS does not ship GNU timeout)
 # =============================================================================
@@ -4184,6 +4198,34 @@ _infer_agent_from_path() {
 #   JSON array of task objects on stdout
 #   Warnings for fuzzy matches on stderr
 #
+#
+# Slice the "## Implementation Tasks" section out of an issue body — the
+# orchestrator's mirror of _issue_body_tasks_section() in issue-body-lib.sh,
+# and the SINGLE definition the PARSE ISSUE stage, the tests, and the parity
+# guard all share (no hand-copied awk literal anywhere else).
+#
+# Behaviour (kept identical to the library — see ISSUE_TASKS_HEADING_ERE):
+#   * CRLF-tolerant — strips a trailing CR before matching.
+#   * Case-insensitive heading — folds the line with tolower($0).
+#   * UNANCHORED heading — annotated headings ("## Implementation Tasks
+#     (draft)") are recognised so the per-line lint report fires (issue #584).
+#   * Section spans from the heading (any depth: ##, ###, …) to the next ## or
+#     deeper heading (or end of body).
+#
+# Arguments:
+#   $1 - issue body text
+# Outputs:
+#   Section text on stdout (empty when the heading is absent or has no lines)
+#
+_extract_tasks_section() {
+	printf '%s' "$1" | awk -v h="$ISSUE_TASKS_HEADING_ERE" '
+		{ sub(/\r$/, "") }
+		tolower($0) ~ h { found = 1; next }
+		found && /^##+[[:space:]]/ { exit }
+		found { print }
+	'
+}
+
 _parse_task_lines() {
 	local tasks_section="$1"
 
@@ -7456,11 +7498,15 @@ Log directory: \`$LOG_BASE\`"
         # Extract tasks from ## Implementation Tasks section
         # Format: - [ ] `[agent-name]` Task description
         log "Parsing implementation tasks from issue body..."
-        # Section slice mirrors _issue_body_tasks_section: strip CR for CRLF
-        # tolerance and match the heading case-insensitively (via tolower) so
-        # "## implementation tasks" and CRLF bodies both parse.
+        # Section slice via the shared _extract_tasks_section helper, which
+        # mirrors _issue_body_tasks_section exactly (CRLF-tolerant, heading
+        # matched case-insensitively and UNANCHORED via ISSUE_TASKS_HEADING_ERE)
+        # so "## implementation tasks", "## Implementation Tasks (draft)", and
+        # CRLF bodies all parse.  Using the one helper (rather than an inline awk
+        # literal) keeps this path, the resume grep guard, and the tests from
+        # ever drifting apart.
         local tasks_section
-        tasks_section=$(printf '%s' "$issue_body" | awk '{ sub(/\r$/, "") } tolower($0) ~ /^##+[[:space:]]+implementation tasks/{found=1; next} found && /^##+[[:space:]]/{exit} found{print}')
+        tasks_section=$(_extract_tasks_section "$issue_body")
 
         if [[ -z "$tasks_section" ]]; then
             log_error "No 'Implementation Tasks' section found in issue #$ISSUE_NUMBER"
@@ -7678,9 +7724,11 @@ $excerpt
         local issue_body_file="$LOG_BASE/context/issue-body.md"
         if [[ -f "$issue_body_file" ]]; then
             # Case-insensitive (-i) to match the hardened section extractor —
-            # a lowercase "## implementation tasks" heading must not trip this
-            # resume-path guard after the parser accepted it.
-            if ! grep -qiE '^##+[[:space:]]+Implementation Tasks' "$issue_body_file"; then
+            # a lowercase "## implementation tasks" or annotated
+            # "## Implementation Tasks (draft)" heading must not trip this
+            # resume-path guard after the parser accepted it.  Uses the shared
+            # ISSUE_TASKS_HEADING_ERE so it stays identical to the PARSE ISSUE awk.
+            if ! grep -qiE "$ISSUE_TASKS_HEADING_ERE" "$issue_body_file"; then
                 log_error "Issue body missing 'Implementation Tasks' section"
                 set_final_state "error"
                 exit 1

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -3960,6 +3960,11 @@ _infer_agent_from_path() {
 _parse_task_lines() {
 	local tasks_section="$1"
 
+	# Strip carriage returns so a CRLF issue body parses identically to an LF
+	# one — otherwise "\r" leaks into descriptions and defeats the $-anchored
+	# task regexes (mirrors _issue_body_tasks_section in issue-body-lib.sh).
+	tasks_section="${tasks_section//$'\r'/}"
+
 	# Strip backslash-escaped backticks (gh API returns \` instead of `)
 	tasks_section="${tasks_section//\\\`/\`}"
 
@@ -7208,8 +7213,11 @@ Log directory: \`$LOG_BASE\`"
         # Extract tasks from ## Implementation Tasks section
         # Format: - [ ] `[agent-name]` Task description
         log "Parsing implementation tasks from issue body..."
+        # Section slice mirrors _issue_body_tasks_section: strip CR for CRLF
+        # tolerance and match the heading case-insensitively (via tolower) so
+        # "## implementation tasks" and CRLF bodies both parse.
         local tasks_section
-        tasks_section=$(printf '%s' "$issue_body" | awk '/^##+[[:space:]]+Implementation Tasks/{found=1; next} found && /^##+[[:space:]]/{exit} found{print}')
+        tasks_section=$(printf '%s' "$issue_body" | awk '{ sub(/\r$/, "") } tolower($0) ~ /^##+[[:space:]]+implementation tasks/{found=1; next} found && /^##+[[:space:]]/{exit} found{print}')
 
         if [[ -z "$tasks_section" ]]; then
             log_error "No 'Implementation Tasks' section found in issue #$ISSUE_NUMBER"
@@ -7225,11 +7233,40 @@ Log directory: \`$LOG_BASE\`"
         task_count=$(printf '%s' "$tasks_json" | jq length)
 
         if (( task_count == 0 )); then
-            local excerpt="${issue_body:0:500}"
-            log_error "No parseable tasks found in issue #$ISSUE_NUMBER. Issue body excerpt (first 500 chars):
+            # LOUD failure (issue #584): rather than dump a raw body excerpt and
+            # leave the operator guessing, run the shared preflight lint and
+            # report WHY each in-section candidate line was rejected
+            # (format / agent-unresolved / path-unresolved).  This replaces the
+            # silent per-line `continue` drop in _parse_task_lines with an
+            # actionable, per-line report before the run aborts.
+            #
+            # The library is sourced inside a subshell so its helper definitions
+            # (e.g. _infer_agent_from_path, which the orchestrator defines with
+            # different internals) never collide with this script's own.
+            local lint_report=""
+            if [[ -f "$SCRIPT_DIR/issue-body-lib.sh" ]]; then
+                lint_report=$(
+                    source "$SCRIPT_DIR/issue-body-lib.sh" 2>/dev/null \
+                        && lint_task_lines "$issue_body"
+                )
+            fi
+
+            log_error "No parseable tasks found in issue #$ISSUE_NUMBER's '## Implementation Tasks' section."
+            if [[ -n "$lint_report" ]]; then
+                log_error "Per-line rejection report (cause <TAB> line):"
+                local _lint_line
+                while IFS= read -r _lint_line; do
+                    [[ -z "$_lint_line" ]] && continue
+                    log_error "  rejected: $_lint_line"
+                done <<< "$lint_report"
+                log_error "Fix: each task must be '- [ ] \`[agent-name]\` **(S)** desc — \`path\`'. See plugins/pipeline-core/skills/explore/SKILL.md (Task Format Specification)."
+            else
+                local excerpt="${issue_body:0:500}"
+                log_error "Preflight lint found no candidate lines to classify. Issue body excerpt (first 500 chars):
 ---
 $excerpt
 ---"
+            fi
             set_final_state "error"
             exit 1
         fi
@@ -7397,7 +7434,10 @@ $excerpt
         # (c) Validate ## Implementation Tasks section exists in saved issue body
         local issue_body_file="$LOG_BASE/context/issue-body.md"
         if [[ -f "$issue_body_file" ]]; then
-            if ! grep -qE '^##+[[:space:]]+Implementation Tasks' "$issue_body_file"; then
+            # Case-insensitive (-i) to match the hardened section extractor —
+            # a lowercase "## implementation tasks" heading must not trip this
+            # resume-path guard after the parser accepted it.
+            if ! grep -qiE '^##+[[:space:]]+Implementation Tasks' "$issue_body_file"; then
                 log_error "Issue body missing 'Implementation Tasks' section"
                 set_final_state "error"
                 exit 1

--- a/.claude/scripts/implement-issue-test/test-fuzzy-task-parsing.bats
+++ b/.claude/scripts/implement-issue-test/test-fuzzy-task-parsing.bats
@@ -261,17 +261,17 @@ Another random line'
 }
 
 # =============================================================================
-# SECTION-EXTRACTION AWK (inline awk in main() at L6733)
-# Tests the widened regex: ##+[[:space:]]+Implementation Tasks
-# and the section-end pattern: ##+[[:space:]]
-# These cover the codepath distinct from _issue_body_parse_tasks().
+# SECTION-EXTRACTION (parse_issue stage's _extract_tasks_section helper)
+# Exercises the depth-agnostic, CRLF-tolerant, case-insensitive, UNANCHORED
+# heading matcher (ISSUE_TASKS_HEADING_ERE) and the section-end pattern
+# ##+[[:space:]].  Distinct codepath from _issue_body_parse_tasks().
 # =============================================================================
 
-# Helper: runs the section-extraction awk from L6733 against $1 (body text).
-# Keeps the pattern in one place so tests stay in sync with the production code.
+# Helper: delegates to the REAL orchestrator section slicer
+# (_extract_tasks_section, sourced via source_orchestrator_functions) so these
+# tests can never drift from the production pattern.
 _run_section_awk() {
-	printf '%s' "$1" | awk \
-		'/^##+[[:space:]]+Implementation Tasks/{found=1; next} found && /^##+[[:space:]]/{exit} found{print}'
+	_extract_tasks_section "$1"
 }
 
 @test "section-extraction awk: extracts lines under ## Implementation Tasks" {

--- a/.claude/scripts/implement-issue-test/test-issue-body-lib.bats
+++ b/.claude/scripts/implement-issue-test/test-issue-body-lib.bats
@@ -1031,3 +1031,121 @@ Some prose but no task checkboxes.
 	[[ "$output" == *"2 non-S task(s)"* ]]
 	[[ "$output" == *"1 S task(s)"* ]]
 }
+
+# =============================================================================
+# Hardened section extraction (issue #584): CRLF + case-insensitive heading
+# =============================================================================
+
+@test "_issue_body_parse_tasks: parses a CRLF-terminated body and strips CR" {
+	local body
+	body=$(printf '## Implementation Tasks\r\n\r\n- [ ] `[bash-script-craftsman]` **(S)** Do it — `.claude/scripts/a.sh`\r\n\r\n## Acceptance Criteria\r\n')
+	run _issue_body_parse_tasks "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"bash-script-craftsman"* ]]
+	# No carriage return leaks into the emitted record.
+	[[ "$output" != *$'\r'* ]]
+}
+
+@test "_issue_body_parse_tasks: matches a lowercase 'implementation tasks' heading" {
+	local body
+	body="## implementation tasks
+
+- [ ] \`[bash-script-craftsman]\` **(S)** Do it — \`.claude/scripts/a.sh\`
+
+## Acceptance Criteria"
+	run _issue_body_parse_tasks "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"bash-script-craftsman"* ]]
+}
+
+@test "_issue_body_parse_tasks: keeps valid tasks and drops prose in a mixed section" {
+	local body
+	body="## Implementation Tasks
+
+Task 1: prose that should be ignored
+- [ ] \`[bash-script-craftsman]\` **(S)** Real task — \`.claude/scripts/a.sh\`
+
+## Acceptance Criteria"
+	run _issue_body_parse_tasks "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"bash-script-craftsman"* ]]
+	[[ "$output" != *"prose that should be ignored"* ]]
+}
+
+@test "assert_issue_valid: accepts a CRLF body with a lowercase heading" {
+	local body
+	body=$(printf '## implementation tasks\r\n\r\n- [ ] `[bash-script-craftsman]` **(S)** Do it — `.claude/scripts/a.sh`\r\n\r\n## Acceptance Criteria\r\n\r\n- [ ] done\r\n')
+	run assert_issue_valid "$body"
+	[ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# lint_task_lines (issue #584): per-line rejection report
+# =============================================================================
+
+@test "lint_task_lines: reports prose 'Task N:' lines as format rejections" {
+	local body
+	body="## Implementation Tasks
+
+Task 1: build the thing
+Task 2: test the thing
+
+## Acceptance Criteria"
+	run lint_task_lines "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"format"*"Task 1: build the thing"* ]]
+	[[ "$output" == *"format"*"Task 2: test the thing"* ]]
+}
+
+@test "lint_task_lines: reports a task missing both brackets and backticks as format" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] bash-script-craftsman do the work here
+
+## Acceptance Criteria"
+	run lint_task_lines "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"format"* ]]
+}
+
+@test "lint_task_lines: reports an unresolved agent" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[nonexistent-agent]\` **(S)** Do it — \`.claude/scripts/a.sh\`
+
+## Acceptance Criteria"
+	run lint_task_lines "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"agent-unresolved"* ]]
+	[[ "$output" == *"nonexistent-agent"* ]]
+}
+
+@test "lint_task_lines: reports an unresolved file path" {
+	local body
+	body="## Implementation Tasks
+
+- [ ] \`[bash-script-craftsman]\` **(S)** Do it — \`nonexistent/dir/ghost.sh\`
+
+## Acceptance Criteria"
+	run lint_task_lines "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"path-unresolved"* ]]
+	[[ "$output" == *"nonexistent/dir/ghost.sh"* ]]
+}
+
+@test "lint_task_lines: emits nothing for a well-formed task list" {
+	run lint_task_lines "$(valid_body)"
+	[ "$status" -eq 0 ]
+	[ -z "$output" ]
+}
+
+@test "lint_task_lines: tolerates CRLF and a lowercase heading" {
+	local body
+	body=$(printf '## implementation tasks\r\n\r\nTask 1: prose form\r\n\r\n## Acceptance Criteria\r\n')
+	run lint_task_lines "$body"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"format"*"Task 1: prose form"* ]]
+	[[ "$output" != *$'\r'* ]]
+}

--- a/.claude/scripts/implement-issue-test/test-parser-parity.bats
+++ b/.claude/scripts/implement-issue-test/test-parser-parity.bats
@@ -1,0 +1,230 @@
+#!/usr/bin/env bats
+#
+# test-parser-parity.bats
+# Parity guard (issue #584) — proves the orchestrator's task extraction and the
+# issue-body-lib.sh parsers stay behaviourally identical.  A SHARED set of
+# fixtures is run through BOTH real code paths and asserted to agree:
+#
+#   Orchestrator path : _extract_tasks_section  ->  _parse_task_lines
+#                       (implement-issue-orchestrator.sh, sourced via
+#                        source_orchestrator_functions)
+#   Library path      : _issue_body_tasks_section -> _issue_body_parse_tasks
+#                       and lint_task_lines (issue-body-lib.sh)
+#
+# The two parsers intentionally differ in POST-processing (the orchestrator
+# normalises agent names and injects a default **(M)** complexity hint), so
+# parity is asserted on the behaviour that MUST match:
+#   (A) section extraction is byte-identical
+#   (B) the recognised task COUNT is identical
+#   (C) the recognised task DESCRIPTIONS are identical
+#       (fixtures carry explicit **(S)** hints so no **(M)** injection occurs)
+#
+# Fixtures cover: canonical heading, lowercase heading, CRLF line endings, an
+# ANNOTATED heading ("## Implementation Tasks (draft)"), and a prose "Task N:"
+# line in an otherwise-empty section.  The annotated-heading fixture is the
+# regression: before the heading matcher was unified it diverged (the
+# orchestrator's UNANCHORED awk found the section while the library's
+# $-anchored regex did not), which silently disabled the per-line lint report.
+#
+
+bats_require_minimum_version 1.5.0
+
+load 'helpers/test-helper.bash'
+
+LIB_PATH="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)/issue-body-lib.sh"
+
+setup() {
+	setup_test_env
+
+	# Required by log / log_error helpers sourced with the orchestrator.
+	export ISSUE_NUMBER=99
+	export BASE_BRANCH=main
+	export LOG_BASE="$TEST_TMP/logs/test"
+	export LOG_FILE="$LOG_BASE/orchestrator.log"
+	export STAGE_COUNTER=0
+	mkdir -p "$LOG_BASE"
+
+	# Sandbox agents dir consulted by the library's valid_agents() (used by
+	# lint_task_lines).  Keep it minimal — parity compares descriptions, not
+	# agent resolution.
+	export ISSUE_BODY_AGENTS_DIR="$TEST_TMP/agents"
+	mkdir -p "$ISSUE_BODY_AGENTS_DIR"
+	: > "$ISSUE_BODY_AGENTS_DIR/bash-script-craftsman.md"
+	export ISSUE_BODY_REPO_ROOT="$TEST_TMP/repo"
+	mkdir -p "$ISSUE_BODY_REPO_ROOT"
+
+	source_orchestrator_functions
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# ---------------------------------------------------------------------------
+# Real code-path shims (no hand-copied logic — every call reaches production).
+# ---------------------------------------------------------------------------
+
+# Orchestrator: exact PARSE ISSUE stage sequence.
+_orch_section() { _extract_tasks_section "$1"; }
+_orch_count()   { _parse_task_lines "$(_extract_tasks_section "$1")" 2>/dev/null | jq 'length'; }
+_orch_descs()   { _parse_task_lines "$(_extract_tasks_section "$1")" 2>/dev/null | jq -r '.[].description'; }
+
+# Library: run in a subshell so its helper defs never collide with the
+# orchestrator's identically-named internals.
+_lib_section() { ( source "$LIB_PATH"; _issue_body_tasks_section "$1" ); }
+_lib_count()   { ( source "$LIB_PATH"; _issue_body_parse_tasks "$1" ) | grep -c . ; }
+_lib_descs()   { ( source "$LIB_PATH"; _issue_body_parse_tasks "$1" ) | cut -f2- ; }
+_lib_lint()    { ( source "$LIB_PATH"; lint_task_lines "$1" ); }
+
+# Assert both parsers agree on section, count, and descriptions for one body.
+assert_full_parity() {
+	local label="$1" body="$2"
+	local o_sec l_sec o_cnt l_cnt o_desc l_desc
+
+	o_sec=$(_orch_section "$body"); l_sec=$(_lib_section "$body")
+	[ "$o_sec" = "$l_sec" ] || \
+		fail "[$label] section extraction diverged:
+--- orchestrator ---
+$o_sec
+--- library ---
+$l_sec"
+
+	o_cnt=$(_orch_count "$body"); l_cnt=$(_lib_count "$body")
+	[ "$o_cnt" = "$l_cnt" ] || \
+		fail "[$label] task count diverged: orchestrator=$o_cnt library=$l_cnt"
+
+	o_desc=$(_orch_descs "$body"); l_desc=$(_lib_descs "$body")
+	[ "$o_desc" = "$l_desc" ] || \
+		fail "[$label] task descriptions diverged:
+--- orchestrator ---
+$o_desc
+--- library ---
+$l_desc"
+}
+
+# ---------------------------------------------------------------------------
+# Well-formed fixtures — both parsers must agree end to end.
+# ---------------------------------------------------------------------------
+
+@test "parity: canonical '## Implementation Tasks' heading" {
+	local body
+	body=$(printf '%s\n' \
+		'## Implementation Tasks' \
+		'' \
+		'- [ ] `[bash-script-craftsman]` **(S)** Task one — `a.sh`' \
+		'- [ ] `[bash-script-craftsman]` **(S)** Task two — `b.sh`' \
+		'' \
+		'## Acceptance Criteria' \
+		'' \
+		'- [ ] Something else')
+	assert_full_parity "canonical" "$body"
+	[ "$(_orch_count "$body")" -eq 2 ]
+}
+
+@test "parity: lowercase '## implementation tasks' heading" {
+	local body
+	body=$(printf '%s\n' \
+		'## implementation tasks' \
+		'' \
+		'- [ ] `[bash-script-craftsman]` **(S)** Lowercase-heading task — `a.sh`')
+	assert_full_parity "lowercase" "$body"
+	[ "$(_orch_count "$body")" -eq 1 ]
+}
+
+@test "parity: CRLF line endings" {
+	# Real Windows/gh CRLF body — carriage returns must not leak or defeat
+	# either parser.
+	local body
+	body=$(printf '## Implementation Tasks\r\n\r\n- [ ] `[bash-script-craftsman]` **(S)** CRLF task — `a.sh`\r\n')
+	assert_full_parity "crlf" "$body"
+	[ "$(_orch_count "$body")" -eq 1 ]
+	# The parsed description must be CR-free in both parsers.
+	printf '%s' "$(_orch_descs "$body")" | grep -q $'\r' && \
+		fail "orchestrator leaked CR into description"
+	printf '%s' "$(_lib_descs "$body")" | grep -q $'\r' && \
+		fail "library leaked CR into description"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Regression fixtures — the divergence issue #584's fix closes.
+# ---------------------------------------------------------------------------
+
+@test "parity: ANNOTATED heading '## Implementation Tasks (draft)' is recognised by BOTH parsers" {
+	# Pre-fix RED: the orchestrator's unanchored awk matched this heading while
+	# the library's $-anchored regex did not, so section extraction diverged and
+	# lint_task_lines saw no section.  Post-fix GREEN: both find it.
+	local body
+	body=$(printf '%s\n' \
+		'## Implementation Tasks (draft)' \
+		'' \
+		'- [ ] `[bash-script-craftsman]` **(S)** Annotated-heading task — `a.sh`')
+
+	# Both must actually find a (non-empty) section — proves neither silently
+	# missed the annotated heading.
+	[ -n "$(_orch_section "$body")" ] || fail "orchestrator missed annotated heading"
+	[ -n "$(_lib_section "$body")" ]  || fail "library missed annotated heading"
+
+	assert_full_parity "annotated" "$body"
+	[ "$(_orch_count "$body")" -eq 1 ]
+}
+
+@test "parity: annotated heading + prose 'Task N:' — sections agree and lint fires" {
+	# The deliverable of issue #584: with a non-canonical heading and a
+	# prose-only section, both parsers must agree (0 tasks, identical section)
+	# AND the shared lint must report the un-parseable prose line.  Pre-fix the
+	# library returned no section, lint was empty, and the run fell back to the
+	# unhelpful raw-excerpt message.
+	local body
+	body=$(printf '%s\n' \
+		'## Implementation Tasks (draft)' \
+		'' \
+		'Task 1: do a thing but this is prose, not a task line')
+
+	# Sections identical and non-empty.
+	local o_sec l_sec
+	o_sec=$(_orch_section "$body"); l_sec=$(_lib_section "$body")
+	[ -n "$o_sec" ] || fail "orchestrator missed annotated heading (prose case)"
+	[ "$o_sec" = "$l_sec" ] || fail "section extraction diverged on prose case"
+
+	# Neither parser recognises the prose line as a task.
+	[ "$(_orch_count "$body")" -eq 0 ]
+	[ "$(_lib_count "$body")" -eq 0 ]
+
+	# The shared lint fires with an actionable per-line 'format' rejection.
+	local lint
+	lint=$(_lib_lint "$body")
+	[ -n "$lint" ] || fail "lint_task_lines produced no report (regression: silent fallback)"
+	printf '%s' "$lint" | grep -q $'^format\t' || \
+		fail "lint did not classify the prose line as 'format': $lint"
+	printf '%s' "$lint" | grep -q 'do a thing' || \
+		fail "lint report missing the offending prose line: $lint"
+}
+
+# ---------------------------------------------------------------------------
+# Direct heading-matcher parity — the single divergence issue #584 unifies.
+# ---------------------------------------------------------------------------
+
+@test "parity: section slicers agree byte-for-byte across all headings" {
+	local h
+	for h in '## Implementation Tasks' '### Implementation Tasks' \
+		'## implementation tasks' '## Implementation Tasks (draft)' \
+		'## IMPLEMENTATION TASKS'; do
+		local body
+		body=$(printf '%s\n\n- [ ] `[bash-script-craftsman]` **(S)** Task — `a.sh`\n' "$h")
+		[ "$(_orch_section "$body")" = "$(_lib_section "$body")" ] || \
+			fail "section slicers diverged for heading: $h"
+	done
+}
+
+@test "parity: a body with NO Implementation Tasks heading yields empty in both" {
+	local body
+	body=$(printf '%s\n' \
+		'## Acceptance Criteria' \
+		'' \
+		'- [ ] `[bash-script-craftsman]` **(S)** Not under a tasks heading')
+	[ -z "$(_orch_section "$body")" ]
+	[ -z "$(_lib_section "$body")" ]
+	[ "$(_orch_count "$body")" -eq 0 ]
+	[ "$(_lib_count "$body")" -eq 0 ]
+}

--- a/.claude/scripts/implement-issue-test/test-stage-runner.bats
+++ b/.claude/scripts/implement-issue-test/test-stage-runner.bats
@@ -1853,12 +1853,14 @@ EOF
 }
 
 # =============================================================================
-# TASK-EXTRACTION AWK — DEPTH-AGNOSTIC HEADING ACCEPTANCE
+# TASK-EXTRACTION — DEPTH-AGNOSTIC HEADING ACCEPTANCE
 #
-# The inline awk in main()'s parse_issue stage must accept any ATX heading
-# depth (## and ###) for the Implementation Tasks section, mirroring the
-# depth-agnostic behaviour of _issue_body_parse_tasks in issue-body-lib.sh.
-# Fixed depth-agnostic pattern: /^##+[[:space:]]+Implementation Tasks/
+# The parse_issue stage slices the section via the shared _extract_tasks_section
+# helper (real orchestrator code, sourced by source_orchestrator_functions), so
+# these tests exercise the production matcher directly instead of a hand-copied
+# awk literal — they cannot drift when the pattern changes.  The helper accepts
+# any ATX heading depth (## and ###), mirroring _issue_body_tasks_section in
+# issue-body-lib.sh (see ISSUE_TASKS_HEADING_ERE).
 # =============================================================================
 
 @test "task-extraction awk: ##-headed body yields non-empty tasks_section" {
@@ -1869,9 +1871,7 @@ EOF
 		'- [ ] `[bash-script-craftsman]` Task one')
 
 	local tasks_section
-	tasks_section=$(printf '%s' "$body" \
-		| awk '/^##+[[:space:]]+Implementation Tasks/{found=1; next} \
-			found && /^##+[[:space:]]/{exit} found{print}')
+	tasks_section=$(_extract_tasks_section "$body")
 
 	[[ -n "$tasks_section" ]] || \
 		fail "##-headed body must yield non-empty tasks_section"
@@ -1885,9 +1885,7 @@ EOF
 		'- [ ] `[bash-script-craftsman]` Task one')
 
 	local tasks_section
-	tasks_section=$(printf '%s' "$body" \
-		| awk '/^##+[[:space:]]+Implementation Tasks/{found=1; next} \
-			found && /^##+[[:space:]]/{exit} found{print}')
+	tasks_section=$(_extract_tasks_section "$body")
 
 	[[ -n "$tasks_section" ]] || \
 		fail "###-headed body must yield non-empty tasks_section"
@@ -1908,9 +1906,7 @@ EOF
 		'- [ ] All tasks complete')
 
 	local tasks_section
-	tasks_section=$(printf '%s' "$body" \
-		| awk '/^##+[[:space:]]+Implementation Tasks/{found=1; next} \
-			found && /^##+[[:space:]]/{exit} found{print}')
+	tasks_section=$(_extract_tasks_section "$body")
 
 	[[ "$tasks_section" != *"All tasks complete"* ]] || \
 		fail "Section extraction must stop at next heading"
@@ -1922,8 +1918,9 @@ EOF
 # VALIDATE_PLAN GREP — DEPTH-AGNOSTIC HEADING ACCEPTANCE
 #
 # The validate_plan stage grep gate must accept any ATX heading depth
-# (## and ###) for the Implementation Tasks section.
-# Fixed depth-agnostic pattern: grep -qE '^##+[[:space:]]+Implementation Tasks'
+# (## and ###) for the Implementation Tasks section.  These tests assert
+# against the real shared matcher ISSUE_TASKS_HEADING_ERE (grep -qiE), the same
+# constant the production resume-path guard uses, so they cannot drift.
 # =============================================================================
 
 @test "validate_plan grep: ##-headed body file passes section check" {
@@ -1934,7 +1931,7 @@ EOF
 		'- [ ] `[bash-script-craftsman]` Task one' \
 		> "$issue_body_file"
 
-	grep -qE '^##+[[:space:]]+Implementation Tasks' "$issue_body_file" || \
+	grep -qiE "$ISSUE_TASKS_HEADING_ERE" "$issue_body_file" || \
 		fail "validate_plan grep must accept ##-headed Implementation Tasks"
 }
 
@@ -1946,7 +1943,7 @@ EOF
 		'- [ ] `[bash-script-craftsman]` Task one' \
 		> "$issue_body_file"
 
-	grep -qE '^##+[[:space:]]+Implementation Tasks' "$issue_body_file" || \
+	grep -qiE "$ISSUE_TASKS_HEADING_ERE" "$issue_body_file" || \
 		fail "validate_plan grep must accept ###-headed Implementation Tasks"
 }
 

--- a/.claude/scripts/issue-body-lib.sh
+++ b/.claude/scripts/issue-body-lib.sh
@@ -53,6 +53,20 @@ _ISSUE_BODY_LIB_SOURCED=1
 # are excluded).
 readonly ISSUE_BODY_KNOWN_EXTS='sh|bats|bash|ts|tsx|js|jsx|mjs|cjs|py|go|rb|rs|java|kt|swift|json|yaml|yml|toml|sql|md|css|html|tf'
 
+# Canonical "Implementation Tasks" heading matcher (issue #584 parity) — the
+# SINGLE source of truth for both library parsers, which both route section
+# slicing through _issue_body_tasks_section.  Behaviour, applied IDENTICALLY at
+# every mirror site:
+#   * ERE, UNANCHORED at the tail — annotated headings such as
+#     "## Implementation Tasks (draft)" are recognised (do NOT re-add a `$`).
+#   * Case-insensitive — folded at the call site (bash: nocasematch; awk:
+#     tolower($0); grep: -i).
+#   * CRLF-tolerant — the caller strips carriage returns before matching.
+# The orchestrator mirrors this exact behaviour via ISSUE_TASKS_HEADING_ERE in
+# implement-issue-orchestrator.sh; a parity test (test-parser-parity.bats)
+# guards the two against drift.
+readonly ISSUE_BODY_TASKS_HEADING_RE='^##+[[:space:]]+Implementation Tasks'
+
 # Resolve this library's own directory so the default agents dir can be
 # located relative to it.
 _issue_body_lib_dir() {
@@ -279,7 +293,8 @@ _issue_body_task_path_count() {
 # Hardening (issue #584):
 #   * CRLF tolerance — strips carriage returns first so a Windows/gh CRLF
 #     body cannot leak "\r" into descriptions or defeat the $-anchored
-#     heading and task regexes.
+#     task regexes (the heading matcher is deliberately UNANCHORED — see
+#     ISSUE_BODY_TASKS_HEADING_RE — so annotated headings still match).
 #   * Case-insensitive heading — matches "## Implementation Tasks",
 #     "## implementation tasks", etc. via a locally-scoped nocasematch
 #     (bash-3.2-safe; ${x,,} is deliberately avoided elsewhere in this lib).
@@ -312,7 +327,7 @@ _issue_body_tasks_section() {
 	local section=""
 	local line
 	while IFS= read -r line; do
-		if [[ "$line" =~ ^##+[[:space:]]+Implementation\ Tasks$ ]]; then
+		if [[ "$line" =~ $ISSUE_BODY_TASKS_HEADING_RE ]]; then
 			in_section=true
 			continue
 		fi

--- a/.claude/scripts/issue-body-lib.sh
+++ b/.claude/scripts/issue-body-lib.sh
@@ -2,11 +2,17 @@
 #
 # issue-body-lib.sh - Validation helpers for pipeline issue bodies
 #
-# Sourceable library (no main()).  Exposes two public functions:
+# Sourceable library (no main()).  Exposes three public functions:
 #
 #   valid_agents
 #       Prints the set of known agent names — one per line, sorted and
 #       unique — derived from the .claude/agents/*.md definitions.
+#
+#   lint_task_lines <body>
+#       Preflight lint for the "Implementation Tasks" section — emits one
+#       "<cause>\t<line>" record (cause: format / agent-unresolved /
+#       path-unresolved) per in-section line a parse would silently drop or
+#       degrade.  Makes 0-task / mis-extracted parses loud and actionable.
 #
 #   assert_issue_valid <body>
 #       Validates an issue body string against seven structural criteria:
@@ -264,17 +270,44 @@ _issue_body_task_path_count() {
 # Outputs:
 #   Tab-separated agent/description records on stdout
 #
-_issue_body_parse_tasks() {
+#
+# Extracts the raw text of the "Implementation Tasks" section from an issue
+# body — the single source of truth for section slicing shared by
+# _issue_body_parse_tasks and lint_task_lines so the two stay behaviourally
+# identical.
+#
+# Hardening (issue #584):
+#   * CRLF tolerance — strips carriage returns first so a Windows/gh CRLF
+#     body cannot leak "\r" into descriptions or defeat the $-anchored
+#     heading and task regexes.
+#   * Case-insensitive heading — matches "## Implementation Tasks",
+#     "## implementation tasks", etc. via a locally-scoped nocasematch
+#     (bash-3.2-safe; ${x,,} is deliberately avoided elsewhere in this lib).
+#
+# The section spans from the "Implementation Tasks" heading (any depth:
+# ##, ###, …) up to the next ## or deeper heading (or end of body).
+#
+# Arguments:
+#   $1 - issue body text
+# Outputs:
+#   Section text on stdout (may be empty when the section has no lines)
+# Returns:
+#   0 when an "Implementation Tasks" heading was found, 1 otherwise
+#
+_issue_body_tasks_section() {
 	local body="$1"
+	# Strip carriage returns so CRLF bodies parse identically to LF bodies.
+	body="${body//$'\r'/}"
 	# Normalize gh API's backslash-escaped backticks.
 	body="${body//\\\`/\`}"
 
-	# Extract only the lines under "Implementation Tasks" (any heading
-	# level: ##, ###, etc.), stopping at the next ## or deeper heading (or
-	# end of body).  Lines from other sections
-	# (Acceptance Criteria, Notes, Deploy Verification, etc.) are never
-	# matched as tasks, preventing false positives from prose that happens
-	# to resemble a task line.
+	# Case-insensitive heading match — save/restore nocasematch so callers
+	# are unaffected.  Only the heading detection needs it; the task-line
+	# regexes below run case-sensitively (agent names, [x] markers).
+	local _ci_saved
+	_ci_saved=$(shopt -p nocasematch)
+	shopt -s nocasematch
+
 	local in_section=false
 	local section=""
 	local line
@@ -292,8 +325,25 @@ _issue_body_parse_tasks() {
 		fi
 	done <<< "$body"
 
-	# No "Implementation Tasks" heading found (any depth) — emit nothing.
-	$in_section || return 0
+	eval "$_ci_saved"
+
+	$in_section || return 1
+	printf '%s' "$section"
+	return 0
+}
+
+_issue_body_parse_tasks() {
+	local body="$1"
+
+	# Extract only the lines under "Implementation Tasks" (any heading
+	# level: ##, ###, etc.), stopping at the next ## or deeper heading (or
+	# end of body).  Lines from other sections
+	# (Acceptance Criteria, Notes, Deploy Verification, etc.) are never
+	# matched as tasks, preventing false positives from prose that happens
+	# to resemble a task line.  No "Implementation Tasks" heading (any
+	# depth) — emit nothing.
+	local section
+	section=$(_issue_body_tasks_section "$body") || return 0
 
 	# Backtick-bearing regex must live in a variable — bash cannot escape a
 	# backtick inside an inline [[ =~ ]] pattern reliably.
@@ -339,6 +389,120 @@ _issue_body_parse_tasks() {
 
 		printf '%s\t%s\n' "$agent" "$desc"
 	done <<< "$section"
+}
+
+#
+# Preflight lint for the "Implementation Tasks" section (issue #584).
+#
+# Emits one tab-separated rejection record — "<cause>\t<line>" — for every
+# in-section candidate line that a downstream parse would silently drop or
+# silently degrade.  This makes the failure classes the mirrored parsers hide
+# LOUD and actionable:
+#
+#   format            the line matches no task pattern (canonical or any of
+#                     the four fuzzy fallbacks) — e.g. a prose "Task 1: …"
+#                     line or a bullet with neither backticks nor brackets.
+#                     _parse_task_lines / _issue_body_parse_tasks would
+#                     `continue` past it with no diagnostic.
+#   agent-unresolved  the line parses, but its agent name resolves to neither
+#                     a known agent nor "default" — the parser would silently
+#                     degrade it to "default".
+#   path-unresolved   the line parses, but a backtick-quoted file path it
+#                     references neither exists nor has an existing parent
+#                     directory (mirrors assert_issue_valid criterion 3).
+#
+# Well-formed tasks emit nothing.  Blank lines, checked [x] tasks, and
+# "Affected files:" continuation lines are skipped (never candidates).  One
+# record per line, cause priority: format > agent-unresolved > path-unresolved.
+#
+# Section slicing (CRLF tolerance + case-insensitive heading) is shared with
+# _issue_body_parse_tasks via _issue_body_tasks_section, so the lint sees
+# exactly the lines the parser would.
+#
+# Arguments:
+#   $1 - issue body text
+# Outputs:
+#   Zero or more "<cause>\t<line>" records on stdout
+# Returns:
+#   0 always (a lint report is informational, not a failure signal)
+#
+lint_task_lines() {
+	local body="$1"
+	local repo_root="${ISSUE_BODY_REPO_ROOT:-.}"
+
+	# No "Implementation Tasks" heading — nothing to lint.
+	local section
+	section=$(_issue_body_tasks_section "$body") || return 0
+
+	local valid_set
+	valid_set=$(valid_agents)
+
+	local bt='`'
+	local re_bare_agent="^- (\[ \] )?${bt}([^${bt}]+)${bt} (.+)\$"
+
+	local line agent desc remapped path parent unresolved_path
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		# Checked [x] tasks are complete; the parser skips them, so does lint.
+		[[ "$line" =~ \[x\] ]] && continue
+		# "Affected files:" continuation lines are metadata, not candidates.
+		[[ "$line" =~ ^[[:space:]]*[Aa]ffected[[:space:]][Ff]iles: ]] && continue
+
+		agent=""
+		desc=""
+
+		# Same pattern ladder as _issue_body_parse_tasks — a line that matches
+		# none of these is a format rejection.
+		if [[ "$line" =~ ^-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+		elif [[ "$line" =~ ^-\ (\[\ \]\ )?\[([^\]\ ]+)\]\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+		elif [[ "$line" =~ ^\*\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+		elif [[ "$line" =~ ^[[:space:]]+-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+		elif [[ "$line" =~ $re_bare_agent ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+		else
+			printf 'format\t%s\n' "$line"
+			continue
+		fi
+
+		# Criterion-2 mirror: agent must resolve to a known agent or "default".
+		remapped=$(_issue_body_remap_agent "$agent")
+		if [[ "$remapped" != "default" ]] \
+			&& ! grep -qxF "$remapped" <<< "$valid_set"; then
+			printf 'agent-unresolved\t%s\n' "$line"
+			continue
+		fi
+
+		# Criterion-3 mirror: every referenced path must resolve.
+		unresolved_path=""
+		while IFS= read -r path; do
+			[[ -z "$path" ]] && continue
+			if [[ "$path" == */* ]]; then
+				parent="${path%/*}"
+			else
+				parent="."
+			fi
+			if [[ ! -e "$repo_root/$path" && ! -d "$repo_root/$parent" ]]; then
+				unresolved_path="$path"
+				break
+			fi
+		done < <(_issue_body_extract_paths "$desc")
+
+		if [[ -n "$unresolved_path" ]]; then
+			printf 'path-unresolved\t%s\n' "$line"
+			continue
+		fi
+	done <<< "$section"
+
+	return 0
 }
 
 #

--- a/plugins/pipeline-core/skills/explore/SKILL.md
+++ b/plugins/pipeline-core/skills/explore/SKILL.md
@@ -96,7 +96,7 @@ Example — a single "**(L)** Add auth middleware, wire routes, add tests" namin
 - [ ] `[fastify-backend-developer]` **(S)** Apply middleware to protected routes — `src/routes/index.ts:L20-55`
 - [ ] `[default]` **(S)** Add middleware unit tests — `tests/unit/auth.test.ts:L1-60`
 ```
-- **Parseable format required:** Every task line in `## Implementation Tasks` MUST begin with `- [ ] \`[agent-name]\``. Prose lines such as "Task 1: Do something" are **silently skipped** by the orchestrator — no error is raised and no warning is emitted; the task simply never executes.
+- **Parseable format required:** Every task line in `## Implementation Tasks` MUST begin with `- [ ] \`[agent-name]\``. Prose lines such as "Task 1: Do something" are **not parsed as tasks**. As of the hardened parser (issue #584) this failure is **loud, not silent**: if the section yields zero parseable tasks the run aborts with a per-line rejection report (`lint_task_lines`) naming each rejected line and its cause — `format` (matches no task pattern), `agent-unresolved` (agent name resolves to neither a known agent nor `default`), or `path-unresolved` (a backtick-quoted path neither exists nor has an existing parent). Do not rely on the parser to skip a mis-formatted line — it will now bounce the whole run.
 - Frontend and backend changes in the same task should be split — backend first (data layer), then frontend (presentation)
 - **E2E tests (REQUIRED for UI changes):** If `TEST_E2E_CMD` is configured in `.claude/config/platform.sh`, include an E2E task for ANY issue touching user-visible UI — CSS, components, layouts, forms, navigation, visual regressions. This is NOT optional for UI work.
   `- [ ] \`[playwright-test-developer]\` **(S)** Write Playwright E2E test for [flow description]`
@@ -249,6 +249,11 @@ The `## Implementation Tasks` section must use this parseable convention:
 **Files suffix:** Append ` — \`path/to/file.ts:L10-40\`` (em dash, space, backtick-quoted path with optional line range) to every task description. Multiple files: ` — \`file1.ts:L5\`, \`file2.ts:L20-35\``. This tells subagents exactly where to look, eliminating broad codebase scans.
 - **Paths must be real repo paths** — verify each path exists in the repository before writing it. Never invent or guess file paths.
 - **Task descriptions must stay under ~200 characters** — keep the description concise; put details in the Research Findings section of the issue body instead.
+
+**Parser hardening (issue #584) — the section extractor is tolerant, the failure mode is loud:** the two mirrored parsers (`_parse_task_lines` in the orchestrator and `_issue_body_parse_tasks` in `issue-body-lib.sh`) stay behaviourally identical and both now:
+- **Match the heading case-insensitively** — `## Implementation Tasks`, `## implementation tasks`, `### IMPLEMENTATION TASKS`, etc. all resolve the same section.
+- **Tolerate CRLF line endings** — carriage returns are stripped before matching, so a Windows/`gh`-sourced body parses identically to an LF body (no `\r` leaks into descriptions or defeats the anchored regexes).
+- **Fail loudly on a 0-task section** — when the section yields no parseable tasks the PARSE ISSUE stage runs `lint_task_lines` and prints a **per-line rejection report** before aborting, tagging each rejected line with its cause (`format` / `agent-unresolved` / `path-unresolved`). There is no silent-skip path: a mis-formatted task list stops the run with an actionable reason instead of proceeding with an empty set.
 
 **Granularity is enforced by `assert_issue_valid` (not advisory):** the shared validator every created issue passes through (`.claude/scripts/issue-body-lib.sh`) now applies a hard granularity criterion in addition to the structural checks:
 - **HARD error — issue is rejected:** any `**(M)**` or `**(L)**` task whose files-suffix names **more than two distinct file paths** (line-range suffixes like `:L10-40` are ignored, so `file.ts:L10` and `file.ts:L90` count as one path). A hint-less task is treated as `**(M)**`. Split such a task into ordered S sub-tasks (see Step 4) before creating the issue.


### PR DESCRIPTION
Closes #584. Stacked on `feature/issue-582` (#580→#581→#577→#585→#583→#579→#582 chain).

Builds on #581/#582 parser hardening; replaces the silent-skip drop with a per-line rejection report.

## What changed
- **CRLF tolerance + case-insensitive heading** in both mirrored parsers (`_issue_body_parse_tasks` in `issue-body-lib.sh` and `_parse_task_lines` in the orchestrator), the PARSE ISSUE awk slice, and the resume-path section grep. `## implementation tasks` and Windows/gh CRLF bodies now parse.
- **New `lint_task_lines`** in `issue-body-lib.sh` — emits one `<cause>\t<line>` record per problematic in-section line: `format` (matches no task pattern), `agent-unresolved` (agent resolves to neither a known agent nor `default`), `path-unresolved` (a backtick path neither exists nor has an existing parent). Well-formed tasks emit nothing. Section slicing is shared via a new `_issue_body_tasks_section` helper so lint sees exactly what the parser sees.
- **Loud 0-task failure**: the PARSE ISSUE stage now sources the lib in a subshell and prints the per-line rejection report before `exit 1`, instead of dumping a raw body excerpt.
- **Spec updated** (`explore/SKILL.md`): corrected the stale "silently skipped" note; documented case-insensitive heading, CRLF tolerance, and the per-line rejection report.

## Reconciliation with #582
#582 added a warn-only `log_warn "No file path in task..."` per parsed task in the orchestrator — that stays as the per-task run-time nudge. `lint_task_lines` is the richer preflight diagnostic used only on the 0-task failure gate, so the two do not duplicate or contradict: #582 warns about a *parsed* task lacking a path; lint classifies *unparsed/degraded* lines when zero tasks survive.

## Parity / safety
- The two parsers stay behaviourally identical — verified with a parity harness across canonical, lowercase-heading, CRLF, prose-dropped, and all four fuzzy fallbacks (5/5 identical task sets).
- No silent-skip path remains at the 0-task gate.
- bash 3.2-safe (`shopt -s nocasematch`, no `${x,,}`).

## Tests
- `test-issue-body-lib.bats`: **85 pass / 0 fail** (10 new #584 fixtures: CRLF, lowercase heading, prose-drop, format/agent/path rejection, clean-body no-op).
- Regression suites all green: `test-fuzzy-task-parsing` (21), `test-create-issue-parent` (28), `test-create-followup-issue` (36), `test-enrich-issue` (26), `test-stage-runner` (105), `test-batch-orchestrator` (135).
- `bash -n` clean on both `issue-body-lib.sh` and `implement-issue-orchestrator.sh`.

Implemented with Edit/bats/git only — no live orchestrator invoked (self-modification-safe).
