### PR TITLE
fix(tests): restore event-emission.bats (budget-fn harness regression from #583/#590)

### DIFF
--- a/tests/event-emission.bats
+++ b/tests/event-emission.bats
@@ -79,6 +79,8 @@ _source_orchestrator_functions() {
 		/^sync_status_to_log\(\) \{$/,/^\}$/ { print; next }
 		/^emit_event\(\) \{$/,/^\}$/         { print; next }
 		/^set_stage_failed\(\) \{$/,/^\}$/   { print; next }
+		/^check_run_budget\(\) \{$/,/^\}$/   { print; next }
+		/^set_run_budget_exceeded\(\) \{$/,/^\}$/ { print; next }
 		/^_apply_stage_action\(\) \{$/,/^\}$/ { print; next }
 	' "$ORCHESTRATOR" > "$func_file"
 	# shellcheck disable=SC1090


### PR DESCRIPTION
The stacked cost/budget work merged in #590 added a `check_run_budget`/`set_run_budget_exceeded` call to `_apply_stage_action`. `tests/event-emission.bats` extracts a subset of orchestrator functions into a temp file and sources it; it did not include the two new functions, so `_apply_stage_action` hit `command not found` and 2 tests failed in the **Decision Script BATS Tests** CI job.

This adds both functions to the awk extraction. `check_run_budget` short-circuits (`return 0`) when no ceiling is set (the test default), so behavior is unchanged.

Verified: `bats tests/event-emission.bats` → 3/3 pass.

Note: this fixes the *only* CI regression from the 8-PR batch. The other Decision-Script-BATS failures (agent-frontmatter, agent-name-normalization, timeout-budget) are pre-existing on main (tracked separately).