### PR TITLE
fix(issue-596): make Decision Script BATS Tests green (3 pre-existing failures)

### DIFF
--- a/.claude/agents/research-agent.md
+++ b/.claude/agents/research-agent.md
@@ -1,3 +1,9 @@
+---
+name: research-agent
+description: Codebase research specialist. Investigates code structure, maps affected files, and produces structured findings for the explore workflow. Use for read-only investigation that reports facts without proposing solutions.
+model: sonnet
+---
+
 # Research Agent
 
 Codebase research specialist. Investigates code structure, maps affected files, and produces structured findings for the explore workflow.

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -96,15 +96,19 @@ MAX_ESCALATIONS_PER_RUN="${MAX_ESCALATIONS_PER_RUN:-5}"
 # Default = sum of per-phase budgets so the global cap never pre-empts
 # a loop that is within its own budget.  See calc_orchestrator_wall_time()
 # for the formula; the numeric default mirrors its calculation:
-#   test-loop  (900s × 3 + 120s slack)               = 2820s
+#   test-loop  (1500s × 3 + 120s slack)              = 4620s
 #   pr-review  (1200s × 2 + 120s slack, 200+ lines)  = 2520s
 #   overhead   (validate 1800 + implement 1800
 #               + task-review 900 + test 600 + pr 600) = 5700s
-#                                              Total : 11040s (~3h)
+#                                              Total : 12840s (~3.5h)
 # Recalculated at runtime by calc_orchestrator_wall_time() using the
-# actual env-overridden per-phase budget variables.
+# actual env-overridden per-phase budget variables.  The invariant
+# MAX_ORCHESTRATOR_WALL_TIME >= calc_orchestrator_wall_time() must hold so
+# the global cap never fires while a per-loop budget still has time left;
+# the default therefore tracks the test-iter timeout (raised 900→1500 in
+# issue #512, which the earlier 11040 default was never reconciled with).
 # Override via MAX_ORCHESTRATOR_WALL_TIME env to set a different base.
-MAX_ORCHESTRATOR_WALL_TIME="${MAX_ORCHESTRATOR_WALL_TIME:-11040}"
+MAX_ORCHESTRATOR_WALL_TIME="${MAX_ORCHESTRATOR_WALL_TIME:-12840}"
 MAX_TASK_WALL_TIME_SECS="${MAX_TASK_WALL_TIME_SECS:-1800}"
 # Slack added on top of the per-iteration timeout when computing the
 # PR-review loop wall-clock budget.  Override via env to tune.
@@ -4112,8 +4116,13 @@ _normalize_agent_name() {
 	fi
 
 	# Unknown name with no local definition — fall back to generic agent.
-	log_warn "_normalize_agent_name: unknown agent '${name}' — falling back to '$_AGENT_SENTINEL_DEFAULT'"
-	printf '%s' "$_AGENT_SENTINEL_DEFAULT"
+	# Degrade to the literal "default" when _AGENT_SENTINEL_DEFAULT is not in
+	# scope (e.g. when this function is sourced in isolation by a test harness
+	# that strips module-level `readonly` declarations) so the documented
+	# fall-back contract holds in every sourcing context.
+	local fallback="${_AGENT_SENTINEL_DEFAULT:-default}"
+	log_warn "_normalize_agent_name: unknown agent '${name}' — falling back to '$fallback'"
+	printf '%s' "$fallback"
 }
 
 #

--- a/.claude/scripts/implement-issue-test/test-soft-fail-convergence.bats
+++ b/.claude/scripts/implement-issue-test/test-soft-fail-convergence.bats
@@ -83,7 +83,7 @@ teardown() {
 	[ "$MAX_TEST_ITERATIONS" -eq 7 ]
 	[ "$MAX_PR_REVIEW_ITERATIONS" -eq 2 ]
 	# platform.sh sets MAX_ORCHESTRATOR_WALL_TIME=10800 (3h) before the
-	# orchestrator's own ${VAR:-11040} default runs, so the orchestrator
+	# orchestrator's own ${VAR:-12840} default runs, so the orchestrator
 	# default is a no-op and the effective runtime value is platform's 10800.
 	[ "$MAX_ORCHESTRATOR_WALL_TIME" -eq 10800 ]
 }
@@ -106,7 +106,7 @@ teardown() {
 	[[ "$script_content" == *'MAX_QUALITY_ITERATIONS="${MAX_QUALITY_ITERATIONS:-5}"'* ]]
 	[[ "$script_content" == *'MAX_TEST_ITERATIONS="${MAX_TEST_ITERATIONS:-7}"'* ]]
 	[[ "$script_content" == *'MAX_PR_REVIEW_ITERATIONS="${MAX_PR_REVIEW_ITERATIONS:-2}"'* ]]
-	[[ "$script_content" == *'MAX_ORCHESTRATOR_WALL_TIME="${MAX_ORCHESTRATOR_WALL_TIME:-11040}"'* ]]
+	[[ "$script_content" == *'MAX_ORCHESTRATOR_WALL_TIME="${MAX_ORCHESTRATOR_WALL_TIME:-12840}"'* ]]
 }
 
 # =============================================================================

--- a/.claude/scripts/implement-issue-test/test-soft-fail-convergence.bats
+++ b/.claude/scripts/implement-issue-test/test-soft-fail-convergence.bats
@@ -222,28 +222,41 @@ teardown() {
 # Historically the quality/test/pr loops hard-failed with `exit 2` when they
 # exceeded their iteration budget; that was replaced with the soft-fail pattern
 # (break + DEGRADED_STAGES) so the pipeline continues to PR/merge reporting.
-# Issue #577 reintroduces a SINGLE, TERMINAL `exit 2` at the merge gate for the
+# Issue #577 reintroduces a TERMINAL `exit 2` at the merge gate for the
 # completed_partial state (after the PR exists) — a distinct non-zero exit so
 # batch metrics and operators can tell a partial delivery from an error or a
-# full success.  These tests guard the original invariant (loops soft-fail)
-# while permitting that one terminal exit.
+# full success.  Issue #583/#590 adds a SECOND terminal `exit 2` in the
+# parent-shell budget guard (_halt_if_budget_exceeded → set_final_state
+# "budget_exceeded"; exit 2), which halts the whole run when the token/cost
+# ceiling is breached — again a run-halt, not a mid-loop hard-fail.  These
+# tests guard the original invariant (loops soft-fail) while permitting those
+# two terminal exits, and only those two.
 # =============================================================================
 
-@test "the only exit 2 is the terminal completed_partial merge-gate path" {
+@test "every exit 2 is a terminal run-halt (completed_partial or budget_exceeded)" {
 	local script_content
 	script_content=$(< "$ORCHESTRATOR_SCRIPT")
 
-	# Exactly one `exit 2` (line-terminal) may remain.
+	# Exactly two line-terminal `exit 2` sites may remain — the completed_partial
+	# merge gate (#577) and the budget_exceeded run halt (#583/#590).
 	local exit2_count
 	exit2_count=$(grep -c 'exit 2$' "$ORCHESTRATOR_SCRIPT" || true)
-	[ "$exit2_count" -eq 1 ]
+	[ "$exit2_count" -eq 2 ]
 
-	# ...and it must follow set_final_state "completed_partial" (issue #577),
-	# i.e. it is the terminal partial-delivery exit, not a mid-loop hard-fail.
-	local block_pos next_exit
-	block_pos=$(grep -n 'set_final_state "completed_partial"' <<< "$script_content" \
+	# Each terminal state's set_final_state must be immediately followed by an
+	# `exit 2` (its next exit is exit 2), i.e. both exits are terminal run-halts
+	# and neither is a mid-loop hard-fail.  Two accounted-for terminal exits +
+	# a total count of exactly two ⇒ no unaccounted mid-loop exit 2 remains.
+	local partial_pos budget_pos next_exit
+
+	partial_pos=$(grep -n 'set_final_state "completed_partial"' <<< "$script_content" \
 		| tail -1 | cut -d: -f1)
-	next_exit=$(awk "NR>$block_pos && /exit [0-9]/{ print; exit }" <<< "$script_content")
+	next_exit=$(awk "NR>$partial_pos && /exit [0-9]/{ print; exit }" <<< "$script_content")
+	[[ "$next_exit" == *'exit 2'* ]]
+
+	budget_pos=$(grep -n 'set_final_state "budget_exceeded"' <<< "$script_content" \
+		| tail -1 | cut -d: -f1)
+	next_exit=$(awk "NR>$budget_pos && /exit [0-9]/{ print; exit }" <<< "$script_content")
 	[[ "$next_exit" == *'exit 2'* ]]
 }
 
@@ -257,10 +270,11 @@ teardown() {
 	[[ "$script_content" == *'DEGRADED_STAGES+=("quality:max_iterations:'* ]]
 	[[ "$script_content" == *'DEGRADED_STAGES+=("quality:convergence_failure:'* ]]
 
-	# No more than the single terminal completed_partial exit 2 may exist.
+	# No more than the two terminal run-halt exit 2 sites (completed_partial +
+	# budget_exceeded) may exist; any third would be a mid-loop hard-fail.
 	local exit2_count
 	exit2_count=$(grep -c 'exit 2$' "$ORCHESTRATOR_SCRIPT" || true)
-	[ "$exit2_count" -le 1 ]
+	[ "$exit2_count" -le 2 ]
 }
 
 # =============================================================================

--- a/.claude/scripts/model-config.sh
+++ b/.claude/scripts/model-config.sh
@@ -282,10 +282,10 @@ readonly -a _STAGE_PREFIXES=(
 #                               + PR_REVIEW_WALL_TIME_SLACK)
 #       + overhead (validate_plan 1800 + implement 1800 + task-review 900
 #                   + test 600 + pr-create 600 = 5700s)
-#   Default: 11040s (2820 + 2520 + 5700)
+#   Default: 12840s (4620 + 2520 + 5700)
 #   Enforced at the complexity-adjustment step (after env vars take effect).
 #   Env vars:
-#     MAX_ORCHESTRATOR_WALL_TIME — initial base (default 11040s; raised to
+#     MAX_ORCHESTRATOR_WALL_TIME — initial base (default 12840s; raised to
 #                                  the phase-budget sum if env value is less)
 #   After the phase-budget floor, per-L-task bumps (1800s each) are added
 #   on top, capped at 4× the phase-budget-floored base value.

--- a/tests/timeout-budget.bats
+++ b/tests/timeout-budget.bats
@@ -11,7 +11,7 @@
 #       session (no premature kill before one pass completes).
 #
 #   (2) MAX_TASK_WALL_TIME_SECS default (1800) >= get_stage_timeout("test-iter-*")
-#       (900) — the task wall-time budget allows at least one complete test
+#       (1500) — the task wall-time budget allows at least one complete test
 #       iteration before the wall-clock guard fires.
 #
 #   (3) MAX_PR_REVIEW_ITERATIONS and MAX_TEST_ITERATIONS environment variables
@@ -170,7 +170,7 @@ _mock_diff_count() {
 # (2) Test loop: task wall-time budget >= one test-iter stage timeout
 # =============================================================================
 
-@test "(2a) get_stage_timeout test-iter returns 900" {
+@test "(2a) get_stage_timeout test-iter returns 1500" {
 	[[ -f "$ORCHESTRATOR" ]] \
 		|| fail "orchestrator not present: $ORCHESTRATOR"
 
@@ -179,8 +179,11 @@ _mock_diff_count() {
 	local timeout
 	timeout=$(get_stage_timeout "test-iter-1" "")
 
-	[[ "$timeout" -eq 900 ]] || {
-		printf 'FAIL: expected 900, got %s\n' "$timeout" >&2
+	# test-iter was raised 900→1500 in issue #512 (task-2); this asserts the
+	# established value that test-stage-runner.bats / test-constants.bats also
+	# encode.
+	[[ "$timeout" -eq 1500 ]] || {
+		printf 'FAIL: expected 1500, got %s\n' "$timeout" >&2
 		return 1
 	}
 }
@@ -577,7 +580,7 @@ _mock_diff_count() {
 	}
 }
 
-@test "(5d) calc_orchestrator_wall_time default value is 11040" {
+@test "(5d) calc_orchestrator_wall_time default value is 12840" {
 	[[ -f "$ORCHESTRATOR" ]] \
 		|| fail "orchestrator not present: $ORCHESTRATOR"
 
@@ -589,11 +592,11 @@ _mock_diff_count() {
 	local budget
 	budget=$(calc_orchestrator_wall_time)
 
-	# Default: test-loop(900×3+120=2820) + pr-review(1200×2+120=2520)
-	#          + overhead(5700) = 11040
-	[[ "$budget" -eq 11040 ]] || {
+	# Default: test-loop(1500×3+120=4620) + pr-review(1200×2+120=2520)
+	#          + overhead(5700) = 12840  (test-iter raised 900→1500, issue #512)
+	[[ "$budget" -eq 12840 ]] || {
 		printf \
-			'FAIL: expected default budget=11040, got %s\n' \
+			'FAIL: expected default budget=12840, got %s\n' \
 			"$budget" >&2
 		return 1
 	}


### PR DESCRIPTION
Closes #596.

The **Decision Script BATS Tests** CI job (`bats tests/`, non-live subset) has been red on `main` for weeks — 3 files / 8 tests. Each failure was triaged independently to decide whether the **code** or the **test** was authoritative (AC3), rather than blindly aligning tests to current output.

## 1. `tests/agent-frontmatter.bats` — data fix (test authoritative)
- Offender: **`.claude/agents/research-agent.md`** — its first non-empty line was `# Research Agent`, missing the `---` YAML front-matter opener. Claude Code silently skips agent files without front-matter, so the agent was effectively unavailable. The test asserts a real loader invariant.
- Fix: added a valid `---` front-matter block (`name` / `description` / `model`) at the top of the file. The **data** was wrong; the test stays as-is.

## 2. `tests/agent-name-normalization.bats` — code fix (test/contract authoritative)
- `_normalize_agent_name` returned the empty string `''` instead of `default` for unknown/empty names (the WARN literally printed `falling back to ''`).
- Root cause: commit `a3d7053b` (#507) replaced the literal `"default"` with the module-level `readonly _AGENT_SENTINEL_DEFAULT`. The test harness sources the function in isolation and strips `^readonly ` lines, so the sentinel was undefined → the function emitted empty. The documented contract ("Falls back to 'default'") and dispatch safety (an empty agent breaks task routing) make `default` authoritative.
- Fix: the function now uses `${_AGENT_SENTINEL_DEFAULT:-default}` for both the WARN and the return, so it degrades to the literal `default` in every sourcing context while keeping the constant for normal runs. Tests 3/4/9/10 pass.

## 3. `tests/timeout-budget.bats` — mixed (1500 test-iter is code-authoritative; wall ceiling is a code fix)
- **test-iter timeout = 1500 is authoritative.** The 900→1500 bump was an intentional change in issue #512 (task-2) and is encoded by `test-stage-runner.bats` and `test-constants.bats`. Reverting to 900 would break those. So `(2a)` expecting 900 was **stale test** → updated to 1500. `(5d)` expecting 11040 was **stale test** → updated to 12840 (= 1500×3+120 test-loop + 1200×2+120 pr-review + 5700 overhead).
- **`MAX_ORCHESTRATOR_WALL_TIME` default was a code regression.** It stayed at 11040 when test-iter was raised, so the invariant `MAX_ORCHESTRATOR_WALL_TIME >= calc_orchestrator_wall_time()` (`5b`) broke (11040 < 12840). **Code fix**: raised the default to 12840 so the wall ceiling covers the phase-budget sum, preserving the invariant instead of just silencing the assertion. Stale doc comments in the orchestrator and `model-config.sh` were updated to match. `test-soft-fail-convergence.bats`'s literal-string assertion was updated 11040→12840 for consistency.

## Results
- `bats tests/agent-frontmatter.bats tests/agent-name-normalization.bats tests/timeout-budget.bats` → **36/36, 0 failures**.
- Whole non-live `tests/*.bats` suite → **0 failures** (no collateral breakage).
- `bash -n .claude/scripts/implement-issue-orchestrator.sh` → clean.
- Note: `.claude/scripts/implement-issue-test/test-soft-fail-convergence.bats` tests 22/23 (`exit 2` counting) fail on clean `main` too — pre-existing, unrelated, and outside the `bats tests/` CI job scope.

Implemented subagent-driven (no live orchestrator) to avoid the self-modification hazard of editing `implement-issue-orchestrator.sh` while running it.

---

## Additional fix (folded into this PR): `test-soft-fail-convergence.bats` tests 22/23

Verified a second pre-existing regression this PR now also resolves: `.claude/scripts/implement-issue-test/test-soft-fail-convergence.bats` tests 22 & 23 (`exit 2` accounting) pass on pre-batch `8f2125bf` but fail on current `main`.

- **Root cause (not test-staleness of a bug):** issue #583/#590 added a legitimate SECOND terminal `exit 2`. `_halt_if_budget_exceeded()` runs in the PARENT shell after spending stages and does `set_final_state "budget_exceeded"; exit 2` (orchestrator line ~1090) — a genuine run-halt ("no further stages will run"), NOT a mid-loop hard-fail inside a retry/quality loop. The pre-existing terminal `exit 2` is the `completed_partial` merge gate (#577). So there are now exactly two legitimate terminal `exit 2` paths; test 22 (expecting exactly 1) and test 23 broke.
- **Fix (test recognizes the new terminal path, invariant preserved):** test 22 now asserts `exit 2$` count == 2 AND that BOTH `set_final_state "completed_partial"` and `set_final_state "budget_exceeded"` are each immediately followed by `exit 2` — proving each exit is terminal. Count-exactly-two + both-accounted-for ⇒ no unaccounted mid-loop `exit 2` can exist, preserving the original guarantee (loops soft-fail, never hard-exit mid-loop). Test 23 relaxed `-le 1` → `-le 2` with the matching plural rationale. The test was NOT weakened to a no-op.

**Results after this fix:** `bats .claude/scripts/implement-issue-test/test-soft-fail-convergence.bats` → 0 failures; 3 `tests/` target files → 0; whole non-live `tests/*.bats` suite → 0; `bash -n` clean.
