### PR TITLE
fix(process-pr): block merge on pr_review:max_iterations (#594)

### DIFF
--- a/.claude/scripts/implement-issue-test/test-merge-block-convergence.bats
+++ b/.claude/scripts/implement-issue-test/test-merge-block-convergence.bats
@@ -360,6 +360,69 @@ teardown() {
 }
 
 # =============================================================================
+# FUNCTIONAL: pr_review:max_iterations blocks merge (issue #594)
+# =============================================================================
+# A PR-review loop that exhausts its iterations without an approved verdict
+# records "pr_review:max_iterations:*" in degraded_stages. The merge gate must
+# treat this as a blocking condition (review never converged), same as a
+# quality:convergence_failure, and leave the PR OPEN instead of auto-merging.
+
+@test "orchestrator merge gate scans DEGRADED_STAGES for pr_review:max_iterations" {
+	local script_content
+	script_content=$(< "$ORCHESTRATOR_SCRIPT")
+
+	# The merge-gate fallback loop must match a pr_review:max_iterations entry
+	[[ "$script_content" == *'pr_review:max_iterations:*'* ]]
+}
+
+@test "pr_review:max_iterations in degraded_stages produces a merge block" {
+	# Mirror the merge-gate fallback scan (Gate B): a pr_review:max_iterations
+	# entry must yield a non-empty blocked_reason so merge-mr.sh is skipped.
+	declare -a deg=("pr_review:max_iterations:iter=3")
+
+	local blocked_reason=""
+	local _dsp
+	for _dsp in "${deg[@]}"; do
+		if [[ "$_dsp" == pr_review:max_iterations:* || "$_dsp" == pr_review:wall_timeout ]]; then
+			blocked_reason="PR review loop ended without an approved verdict (degraded_stages: $_dsp)."
+			break
+		fi
+	done
+
+	[[ -n "$blocked_reason" ]]
+	[[ "$blocked_reason" == *"pr_review:max_iterations:iter=3"* ]]
+}
+
+@test "quality:convergence_failure still blocks when pr_review entry absent (regression)" {
+	# AC2: existing convergence blocking behaviour is unaffected.
+	declare -a deg=("quality:convergence_failure:main:iter=3")
+
+	local blocked_reason=""
+	local _ds
+	for _ds in "${deg[@]}"; do
+		if [[ "$_ds" == quality:convergence_failure:* ]]; then
+			blocked_reason="Quality loop convergence failure recorded in degraded_stages: $_ds"
+			break
+		fi
+	done
+
+	[[ -n "$blocked_reason" ]]
+	[[ "$blocked_reason" == *"quality:convergence_failure:main:iter=3"* ]]
+}
+
+@test "process-pr SKILL.md falls back to degraded_stages scan for pr_review:max_iterations" {
+	local skill_file
+	# Prefer the post-git-mv plugin layout; fall back to the legacy layout.
+	skill_file="$(dirname "$(dirname "$(dirname "$ORCHESTRATOR_SCRIPT")")")/plugins/pipeline-core/skills/process-pr/SKILL.md"
+	[[ -f "$skill_file" ]] || skill_file="$(dirname "$(dirname "$ORCHESTRATOR_SCRIPT")")/skills/process-pr/SKILL.md"
+
+	[[ -f "$skill_file" ]]
+	# Skill must document the pr_review:max_iterations fallback path (AC4: no
+	# orchestrator<->process-pr drift).
+	grep -q 'pr_review:max_iterations' "$skill_file"
+}
+
+# =============================================================================
 # STATIC ANALYSIS: process-pr schema includes merge_blocked status
 # =============================================================================
 

--- a/plugins/pipeline-core/skills/process-pr/SKILL.md
+++ b/plugins/pipeline-core/skills/process-pr/SKILL.md
@@ -93,7 +93,7 @@ digraph process_pr {
 
     approved -> check_block;
     check_block -> merge [label="no block"];
-    check_block -> output_blocked [label="merge_blocked_reason set\nor quality:convergence_failure\nin degraded_stages"];
+    check_block -> output_blocked [label="merge_blocked_reason set\nor quality:convergence_failure\nor pr_review:max_iterations\nin degraded_stages"];
     merge -> comment -> close -> delete -> parse -> create_issues -> output_success;
     changes -> rerun -> output_rerun;
 }
@@ -208,6 +208,16 @@ if [[ -f "$STATUS_JSON" ]]; then
         CONVERGENCE_ENTRY=$(jq -r '(.degraded_stages // [])[] | select(startswith("quality:convergence_failure"))' "$STATUS_JSON" 2>/dev/null | head -1)
         if [[ -n "$CONVERGENCE_ENTRY" ]]; then
             MERGE_BLOCKED_REASON="Quality loop convergence failure recorded in degraded_stages: $CONVERGENCE_ENTRY"
+        fi
+    fi
+
+    # Fall back to scanning degraded_stages for a pr_review:max_iterations entry —
+    # the PR-review loop exhausted its iterations without an approved verdict, so
+    # the review never converged (mirrors the orchestrator merge gate).
+    if [[ -z "$MERGE_BLOCKED_REASON" ]]; then
+        MAX_ITER_ENTRY=$(jq -r '(.degraded_stages // [])[] | select(startswith("pr_review:max_iterations"))' "$STATUS_JSON" 2>/dev/null | head -1)
+        if [[ -n "$MAX_ITER_ENTRY" ]]; then
+            MERGE_BLOCKED_REASON="PR review loop ended without an approved verdict recorded in degraded_stages: $MAX_ITER_ENTRY"
         fi
     fi
 fi
@@ -466,6 +476,7 @@ Re-running /implement-issue $ISSUE_NUMBER $BASE_BRANCH to address requested chan
 | No review status in comments | Stop, report - need code review comment with Status line first |
 | `merge_blocked_reason` set in `status.json` | Leave PR open, post block comment, return `merge_blocked` — do NOT close issue or delete branch |
 | `quality:convergence_failure` in `degraded_stages` | Same as above (fallback when `merge_blocked_reason` absent) |
+| `pr_review:max_iterations` in `degraded_stages` | Same as above — PR-review loop exhausted iterations without an approved verdict (fallback when `merge_blocked_reason` absent) |
 | Issue creation fails (`create-followup-issue.sh` exits non-zero) | Log warning, skip that item — NEVER fall back to `gh issue create` or `create-issue.sh` |
 | Merge fails | Stop, return failure, do NOT close issue |
 | Issue close fails | Log warning (merge succeeded) |


### PR DESCRIPTION
Closes #594.

**Root cause:** the orchestrator gate was already fixed by #577 (scans `pr_review:max_iterations` in DEGRADED_STAGES). The remaining drift was in `plugins/pipeline-core/skills/process-pr/SKILL.md`: its standalone merge-block fallback scanned `degraded_stages` only for `quality:convergence_failure`, so a standalone `/process-pr` on a PR that hit max_iterations (no persisted `merge_blocked_reason`) would auto-merge an unconverged PR.

**Fix:** add a `pr_review:max_iterations` fallback mirroring the orchestrator gate; update flowchart label + error-handling table.

**Tests:** test-merge-block-convergence 35/35 (4 new: orchestrator gate scan, max_iterations block, convergence_failure regression, SKILL.md doc).