### PR TITLE
feat(pipeline): self-locating script/schema resolver (part of #599)

### DIFF
--- a/.claude/scripts/implement-issue-test/test-pipeline-root-resolver.bats
+++ b/.claude/scripts/implement-issue-test/test-pipeline-root-resolver.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+#
+# Tests for resolve-pipeline-root.sh — the self-locating pipeline scripts/schemas
+# root resolver (issue #599).
+#
+# The resolver must self-locate via ${BASH_SOURCE[0]} and must NOT depend on
+# $CLAUDE_PLUGIN_ROOT at runtime: that variable is UNSET in the model's Bash-tool
+# shell (it is only a hooks.json path-substitution placeholder). CLAUDE_PLUGIN_ROOT
+# is honored ONLY as an optional hint when set AND the target file exists there.
+#
+# Each scenario copies the real resolver into a temp layout and sources it in a
+# fresh `bash -c` subshell so BASH_SOURCE self-location is exercised per layout
+# (and the idempotent sourcing guard starts clean every time).
+
+RESOLVER_SRC="$BATS_TEST_DIRNAME/../resolve-pipeline-root.sh"
+
+setup() {
+    # Normalize through cd/pwd so the temp root matches what the resolver's own
+    # `cd ... && pwd` produces (macOS resolves /var -> /private/var).
+    TEST_TMP="$(cd "$(mktemp -d)" && pwd)"
+}
+
+teardown() {
+    [[ -n "${TEST_TMP:-}" && -d "$TEST_TMP" ]] && rm -rf "$TEST_TMP"
+}
+
+# Copy the resolver into <layout_dir>, creating it, and echo the copied path.
+_install_resolver() {
+    local layout_dir="$1"
+    mkdir -p "$layout_dir"
+    cp "$RESOLVER_SRC" "$layout_dir/resolve-pipeline-root.sh"
+    printf '%s\n' "$layout_dir/resolve-pipeline-root.sh"
+}
+
+@test "resolver source file exists" {
+    [ -f "$RESOLVER_SRC" ]
+}
+
+@test "(a) resolves a sibling file via BASH_SOURCE self-location with CLAUDE_PLUGIN_ROOT unset" {
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+    mkdir -p "$scripts_dir/schemas"
+    printf '{}' > "$scripts_dir/schemas/stage-result.json"
+
+    run bash -c "unset CLAUDE_PLUGIN_ROOT; source '$resolver'; resolve_pipeline_file schemas/stage-result.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$scripts_dir/schemas/stage-result.json" ]
+}
+
+@test "(b) resolves correctly when the resolver lives in the plugin-bundle layout" {
+    local scripts_dir="$TEST_TMP/plugins/pipeline-core/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+    mkdir -p "$scripts_dir/schemas"
+    printf '{}' > "$scripts_dir/schemas/stage-result.json"
+
+    run bash -c "unset CLAUDE_PLUGIN_ROOT; source '$resolver'; resolve_pipeline_file schemas/stage-result.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$scripts_dir/schemas/stage-result.json" ]
+}
+
+@test "(c) prefers CLAUDE_PLUGIN_ROOT when set AND the file exists there" {
+    # Self-location dir has the file too, but the plugin-root hint must win.
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+    mkdir -p "$scripts_dir/schemas"
+    printf 'local' > "$scripts_dir/schemas/stage-result.json"
+
+    local plugin_root="$TEST_TMP/plugin-cache/pipeline-core"
+    mkdir -p "$plugin_root/scripts/schemas"
+    printf 'plugin' > "$plugin_root/scripts/schemas/stage-result.json"
+
+    run bash -c "export CLAUDE_PLUGIN_ROOT='$plugin_root'; source '$resolver'; resolve_pipeline_file schemas/stage-result.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$plugin_root/scripts/schemas/stage-result.json" ]
+}
+
+@test "(c) falls back to self-location when CLAUDE_PLUGIN_ROOT is set but the file is absent there" {
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+    mkdir -p "$scripts_dir/schemas"
+    printf 'local' > "$scripts_dir/schemas/stage-result.json"
+
+    # Plugin root is set but does NOT contain the requested file.
+    local plugin_root="$TEST_TMP/plugin-cache/pipeline-core"
+    mkdir -p "$plugin_root/scripts"
+
+    run bash -c "export CLAUDE_PLUGIN_ROOT='$plugin_root'; source '$resolver'; resolve_pipeline_file schemas/stage-result.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$scripts_dir/schemas/stage-result.json" ]
+}
+
+@test "(d) returns non-zero and empty output for a missing file" {
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+
+    run bash -c "unset CLAUDE_PLUGIN_ROOT; source '$resolver'; resolve_pipeline_file schemas/does-not-exist.json"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "(d) returns non-zero for an empty relative-path argument" {
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+
+    run bash -c "unset CLAUDE_PLUGIN_ROOT; source '$resolver'; resolve_pipeline_file ''"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "resolves nested relative paths (not just schemas/)" {
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+    mkdir -p "$scripts_dir/prompts"
+    printf '#stub' > "$scripts_dir/prompts/triage-prompt.sh"
+
+    run bash -c "unset CLAUDE_PLUGIN_ROOT; source '$resolver'; resolve_pipeline_file prompts/triage-prompt.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$scripts_dir/prompts/triage-prompt.sh" ]
+}

--- a/.claude/scripts/resolve-pipeline-root.sh
+++ b/.claude/scripts/resolve-pipeline-root.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# resolve-pipeline-root.sh — self-locating pipeline scripts/schemas root resolver.
+#
+# Pipeline orchestration scripts + JSON schemas live in one of two layouts:
+#   - the marketplace plugin bundle:  plugins/pipeline-core/scripts/
+#   - repo-local (pipeline repo + mid-transition consumers):  .claude/scripts/
+#
+# This helper resolves a file relative to whichever layout the caller is running
+# from WITHOUT depending on $CLAUDE_PLUGIN_ROOT being exported at runtime.
+#
+# Why not CLAUDE_PLUGIN_ROOT? Per issue #599 (Task 1 verification): that variable
+# is UNSET in the model's Bash-tool shell. It is only a path-substitution
+# placeholder the harness expands inside hooks.json command strings — NOT an env
+# var exported to scripts a skill instructs the model to run. So the resolver
+# SELF-LOCATES via ${BASH_SOURCE[0]} and treats CLAUDE_PLUGIN_ROOT only as an
+# optional hint (use-if-set-and-present, never a hard dependency).
+#
+# Because this library ships as a sibling of the orchestrator scripts and the
+# schemas/ directory, the directory it lives in IS the pipeline scripts root —
+# identically in the plugin bundle and in the repo-local .claude/scripts/ layout.
+# That makes the repo-local fallback inherent: no big-bang cutover needed.
+#
+# Usage:
+#   source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+#   schema="$(resolve_pipeline_file schemas/stage-result.json)" || {
+#       echo "schema not found" >&2; exit 1;
+#   }
+#
+# resolve_pipeline_file <relative/path>
+#   Prints the first existing absolute path for <relative/path>, searching:
+#     1. $CLAUDE_PLUGIN_ROOT/scripts/<rel>  — optional hint; only when the var is
+#        non-empty AND the file exists there.
+#     2. <dir-of-this-library>/<rel>        — self-location via BASH_SOURCE; the
+#        canonical path for both layouts.
+#   On a hit: prints the absolute path and returns 0.
+#   On a miss (or empty argument): prints nothing and returns non-zero.
+
+# Idempotent sourcing guard — skip re-definition on repeated source.
+if [[ -z "${_RESOLVE_PIPELINE_ROOT_SOURCED:-}" ]]; then
+    _RESOLVE_PIPELINE_ROOT_SOURCED=1
+
+    # Directory this library lives in, captured once at source time. At the top
+    # level of the file, ${BASH_SOURCE[0]} is this file's own path regardless of
+    # who sourced it, so this pins the pipeline scripts root for later calls even
+    # if the caller's own BASH_SOURCE context changes.
+    _PIPELINE_SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    # resolve_pipeline_file <relative/path>
+    resolve_pipeline_file() {
+        local rel="$1"
+        [[ -n "$rel" ]] || return 1
+
+        # 1. Optional CLAUDE_PLUGIN_ROOT hint. Used only when the var is set AND
+        #    the file actually exists under it — never a hard runtime dependency.
+        if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -e "${CLAUDE_PLUGIN_ROOT}/scripts/${rel}" ]]; then
+            printf '%s\n' "${CLAUDE_PLUGIN_ROOT}/scripts/${rel}"
+            return 0
+        fi
+
+        # 2. Self-location: sibling of this library. Canonical for the plugin
+        #    bundle and the repo-local .claude/scripts/ layout alike.
+        if [[ -e "${_PIPELINE_SCRIPTS_DIR}/${rel}" ]]; then
+            printf '%s\n' "${_PIPELINE_SCRIPTS_DIR}/${rel}"
+            return 0
+        fi
+
+        return 1
+    }
+fi


### PR DESCRIPTION
Part of #599 (does **not** close it — later tasks bundle scripts, repoint references, pilot).

**What:** adds `.claude/scripts/resolve-pipeline-root.sh` — `resolve_pipeline_file <rel>` resolves pipeline scripts/schemas via `BASH_SOURCE` self-location, working in both the plugin bundle and repo-local `.claude/scripts/` layouts; `CLAUDE_PLUGIN_ROOT` is an optional hint (use-if-set-and-present), never a hard dependency.

**Why:** #599 Task 1 verification confirmed (empirically + via Claude Code docs) that `CLAUDE_PLUGIN_ROOT` is **unset in the model's Bash-tool shell** — it's only a hooks.json path-substitution placeholder. So runtime resolution must self-locate. This makes the repo-local fallback inherent (no big-bang cutover).

**Not wired yet** — orchestrators already self-locate schemas via `SCRIPT_DIR`; repointing the 9 skills / 9 scripts + bundling under `plugins/pipeline-core/scripts/` are later #599 tasks.

**Tests:** `test-pipeline-root-resolver.bats` 8/8 (unset / plugin-dir / hint / missing / nested / empty-arg), `test-skill-load` 5/5 regression, shellcheck clean.