### PR TITLE
feat(pipeline): bundle scripts+schemas under plugins/pipeline-core/scripts (part of #599)

### DIFF
--- a/.claude/scripts/implement-issue-test/test-pipeline-root-resolver.bats
+++ b/.claude/scripts/implement-issue-test/test-pipeline-root-resolver.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+#
+# Tests for resolve-pipeline-root.sh — the self-locating pipeline scripts/schemas
+# root resolver (issue #599).
+#
+# The resolver must self-locate via ${BASH_SOURCE[0]} and must NOT depend on
+# $CLAUDE_PLUGIN_ROOT at runtime: that variable is UNSET in the model's Bash-tool
+# shell (it is only a hooks.json path-substitution placeholder). CLAUDE_PLUGIN_ROOT
+# is honored ONLY as an optional hint when set AND the target file exists there.
+#
+# Each scenario copies the real resolver into a temp layout and sources it in a
+# fresh `bash -c` subshell so BASH_SOURCE self-location is exercised per layout
+# (and the idempotent sourcing guard starts clean every time).
+
+RESOLVER_SRC="$BATS_TEST_DIRNAME/../resolve-pipeline-root.sh"
+
+setup() {
+    # Normalize through cd/pwd so the temp root matches what the resolver's own
+    # `cd ... && pwd` produces (macOS resolves /var -> /private/var).
+    TEST_TMP="$(cd "$(mktemp -d)" && pwd)"
+}
+
+teardown() {
+    [[ -n "${TEST_TMP:-}" && -d "$TEST_TMP" ]] && rm -rf "$TEST_TMP"
+}
+
+# Copy the resolver into <layout_dir>, creating it, and echo the copied path.
+_install_resolver() {
+    local layout_dir="$1"
+    mkdir -p "$layout_dir"
+    cp "$RESOLVER_SRC" "$layout_dir/resolve-pipeline-root.sh"
+    printf '%s\n' "$layout_dir/resolve-pipeline-root.sh"
+}
+
+@test "resolver source file exists" {
+    [ -f "$RESOLVER_SRC" ]
+}
+
+@test "(a) resolves a sibling file via BASH_SOURCE self-location with CLAUDE_PLUGIN_ROOT unset" {
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+    mkdir -p "$scripts_dir/schemas"
+    printf '{}' > "$scripts_dir/schemas/stage-result.json"
+
+    run bash -c "unset CLAUDE_PLUGIN_ROOT; source '$resolver'; resolve_pipeline_file schemas/stage-result.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$scripts_dir/schemas/stage-result.json" ]
+}
+
+@test "(b) resolves correctly when the resolver lives in the plugin-bundle layout" {
+    local scripts_dir="$TEST_TMP/plugins/pipeline-core/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+    mkdir -p "$scripts_dir/schemas"
+    printf '{}' > "$scripts_dir/schemas/stage-result.json"
+
+    run bash -c "unset CLAUDE_PLUGIN_ROOT; source '$resolver'; resolve_pipeline_file schemas/stage-result.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$scripts_dir/schemas/stage-result.json" ]
+}
+
+@test "(c) prefers CLAUDE_PLUGIN_ROOT when set AND the file exists there" {
+    # Self-location dir has the file too, but the plugin-root hint must win.
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+    mkdir -p "$scripts_dir/schemas"
+    printf 'local' > "$scripts_dir/schemas/stage-result.json"
+
+    local plugin_root="$TEST_TMP/plugin-cache/pipeline-core"
+    mkdir -p "$plugin_root/scripts/schemas"
+    printf 'plugin' > "$plugin_root/scripts/schemas/stage-result.json"
+
+    run bash -c "export CLAUDE_PLUGIN_ROOT='$plugin_root'; source '$resolver'; resolve_pipeline_file schemas/stage-result.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$plugin_root/scripts/schemas/stage-result.json" ]
+}
+
+@test "(c) falls back to self-location when CLAUDE_PLUGIN_ROOT is set but the file is absent there" {
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+    mkdir -p "$scripts_dir/schemas"
+    printf 'local' > "$scripts_dir/schemas/stage-result.json"
+
+    # Plugin root is set but does NOT contain the requested file.
+    local plugin_root="$TEST_TMP/plugin-cache/pipeline-core"
+    mkdir -p "$plugin_root/scripts"
+
+    run bash -c "export CLAUDE_PLUGIN_ROOT='$plugin_root'; source '$resolver'; resolve_pipeline_file schemas/stage-result.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$scripts_dir/schemas/stage-result.json" ]
+}
+
+@test "(d) returns non-zero and empty output for a missing file" {
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+
+    run bash -c "unset CLAUDE_PLUGIN_ROOT; source '$resolver'; resolve_pipeline_file schemas/does-not-exist.json"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "(d) returns non-zero for an empty relative-path argument" {
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+
+    run bash -c "unset CLAUDE_PLUGIN_ROOT; source '$resolver'; resolve_pipeline_file ''"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "resolves nested relative paths (not just schemas/)" {
+    local scripts_dir="$TEST_TMP/.claude/scripts"
+    local resolver
+    resolver="$(_install_resolver "$scripts_dir")"
+    mkdir -p "$scripts_dir/prompts"
+    printf '#stub' > "$scripts_dir/prompts/triage-prompt.sh"
+
+    run bash -c "unset CLAUDE_PLUGIN_ROOT; source '$resolver'; resolve_pipeline_file prompts/triage-prompt.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$scripts_dir/prompts/triage-prompt.sh" ]
+}

--- a/.claude/scripts/resolve-pipeline-root.sh
+++ b/.claude/scripts/resolve-pipeline-root.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# resolve-pipeline-root.sh — self-locating pipeline scripts/schemas root resolver.
+#
+# Pipeline orchestration scripts + JSON schemas live in one of two layouts:
+#   - the marketplace plugin bundle:  plugins/pipeline-core/scripts/
+#   - repo-local (pipeline repo + mid-transition consumers):  .claude/scripts/
+#
+# This helper resolves a file relative to whichever layout the caller is running
+# from WITHOUT depending on $CLAUDE_PLUGIN_ROOT being exported at runtime.
+#
+# Why not CLAUDE_PLUGIN_ROOT? Per issue #599 (Task 1 verification): that variable
+# is UNSET in the model's Bash-tool shell. It is only a path-substitution
+# placeholder the harness expands inside hooks.json command strings — NOT an env
+# var exported to scripts a skill instructs the model to run. So the resolver
+# SELF-LOCATES via ${BASH_SOURCE[0]} and treats CLAUDE_PLUGIN_ROOT only as an
+# optional hint (use-if-set-and-present, never a hard dependency).
+#
+# Because this library ships as a sibling of the orchestrator scripts and the
+# schemas/ directory, the directory it lives in IS the pipeline scripts root —
+# identically in the plugin bundle and in the repo-local .claude/scripts/ layout.
+# That makes the repo-local fallback inherent: no big-bang cutover needed.
+#
+# Usage:
+#   source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+#   schema="$(resolve_pipeline_file schemas/stage-result.json)" || {
+#       echo "schema not found" >&2; exit 1;
+#   }
+#
+# resolve_pipeline_file <relative/path>
+#   Prints the first existing absolute path for <relative/path>, searching:
+#     1. $CLAUDE_PLUGIN_ROOT/scripts/<rel>  — optional hint; only when the var is
+#        non-empty AND the file exists there.
+#     2. <dir-of-this-library>/<rel>        — self-location via BASH_SOURCE; the
+#        canonical path for both layouts.
+#   On a hit: prints the absolute path and returns 0.
+#   On a miss (or empty argument): prints nothing and returns non-zero.
+
+# Idempotent sourcing guard — skip re-definition on repeated source.
+if [[ -z "${_RESOLVE_PIPELINE_ROOT_SOURCED:-}" ]]; then
+    _RESOLVE_PIPELINE_ROOT_SOURCED=1
+
+    # Directory this library lives in, captured once at source time. At the top
+    # level of the file, ${BASH_SOURCE[0]} is this file's own path regardless of
+    # who sourced it, so this pins the pipeline scripts root for later calls even
+    # if the caller's own BASH_SOURCE context changes.
+    _PIPELINE_SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    # resolve_pipeline_file <relative/path>
+    resolve_pipeline_file() {
+        local rel="$1"
+        [[ -n "$rel" ]] || return 1
+
+        # 1. Optional CLAUDE_PLUGIN_ROOT hint. Used only when the var is set AND
+        #    the file actually exists under it — never a hard runtime dependency.
+        if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -e "${CLAUDE_PLUGIN_ROOT}/scripts/${rel}" ]]; then
+            printf '%s\n' "${CLAUDE_PLUGIN_ROOT}/scripts/${rel}"
+            return 0
+        fi
+
+        # 2. Self-location: sibling of this library. Canonical for the plugin
+        #    bundle and the repo-local .claude/scripts/ layout alike.
+        if [[ -e "${_PIPELINE_SCRIPTS_DIR}/${rel}" ]]; then
+            printf '%s\n' "${_PIPELINE_SCRIPTS_DIR}/${rel}"
+            return 0
+        fi
+
+        return 1
+    }
+fi

--- a/plugins/pipeline-core/scripts/ab-harness.sh
+++ b/plugins/pipeline-core/scripts/ab-harness.sh
@@ -1,0 +1,604 @@
+#!/usr/bin/env bash
+#
+# ab-harness.sh
+# A/B harness comparing CONTEXT_MODE_ENABLED=0 (control) vs =1
+# (treatment) on real issues via two isolated git worktrees.
+#
+# Two arm branches are forked from the base branch and checked out
+# in separate worktrees.  batch-orchestrator.sh runs in parallel in
+# each worktree with CONTEXT_MODE_ENABLED toggled.  Both arms are
+# awaited; ab-report.sh is invoked to produce a comparison report.
+# Worktrees and arm branches are removed on EXIT.
+#
+# Usage:
+#   ab-harness.sh --issues "N1,N2,N3" --base-branch main
+#   ab-harness.sh --manifest <path> --base-branch main
+#
+# Options:
+#   --issues <list>        Comma-separated issue numbers
+#   --manifest <path>      manifest.json with issues/base_branch keys
+#   --base-branch <name>   Branch to fork arm branches from
+#   --agent <name>         Agent for implement-issue (optional)
+#   -h, --help             Show this help
+#
+# Outputs:
+#   logs/ab-TIMESTAMP/
+#     harness.log            This harness's log
+#     control-run.log        Control arm (batch-orchestrator) output
+#     treatment-run.log      Treatment arm output
+#     preserved-control/     Arm logs preserved before cleanup
+#     preserved-treatment/   Arm logs preserved before cleanup
+#     report.md              Comparison report (from ab-report.sh)
+#     ab-results.json        Structured results (from ab-report.sh)
+#
+# Exit codes:
+#   0  Arms ran; report generated (check arm state for per-arm errors)
+#   1  Fatal error (worktree setup, report failure, etc.)
+#   3  Configuration / argument error
+#
+
+# -e (errexit) is intentionally omitted: every command that may fail is
+# checked explicitly (|| die / if !), so failure paths stay visible and
+# controllable rather than silently aborting on any non-zero exit.
+set -uo pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# =============================================================================
+# USAGE / ERROR HELPERS
+# =============================================================================
+
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 1
+}
+
+die_usage() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 3
+}
+
+usage() {
+	cat <<EOF
+Usage: $SCRIPT_NAME [options]
+
+A/B harness comparing CONTEXT_MODE_ENABLED=0 (control) vs =1 (treatment).
+
+Options:
+    --issues <list>        Comma-separated issue numbers
+    --manifest <path>      manifest.json with issues/base_branch keys
+    --base-branch <name>   Branch to fork arm branches from
+    --agent <name>         Agent for implement-issue stage (optional)
+    -h, --help             Show this help
+
+Exit codes:
+    0  Arms ran; report generated
+    1  Fatal error
+    3  Configuration / argument error
+
+Example:
+    $SCRIPT_NAME --issues "537,538" --base-branch main
+EOF
+}
+
+# =============================================================================
+# ARGUMENT PARSING
+# =============================================================================
+
+MANIFEST=""
+ISSUES=""
+BASE_BRANCH=""
+AGENT=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--issues)
+			[[ -n "${2:-}" ]] || die_usage "--issues requires a value"
+			ISSUES="$2"
+			shift 2
+			;;
+		--manifest)
+			[[ -n "${2:-}" ]] || \
+				die_usage "--manifest requires a value"
+			MANIFEST="$2"
+			shift 2
+			;;
+		--base-branch)
+			[[ -n "${2:-}" ]] || \
+				die_usage "--base-branch requires a value"
+			BASE_BRANCH="$2"
+			shift 2
+			;;
+		--agent)
+			[[ -n "${2:-}" ]] || die_usage "--agent requires a value"
+			AGENT="$2"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		--)
+			shift
+			break
+			;;
+		-*)
+			die_usage "unknown option: $1"
+			;;
+		*)
+			die_usage "unexpected argument: $1"
+			;;
+	esac
+done
+
+if [[ -n "$MANIFEST" ]]; then
+	[[ -f "$MANIFEST" ]] || die_usage "manifest not found: $MANIFEST"
+	if [[ -z "$ISSUES" ]]; then
+		ISSUES=$(jq -r '.issues | join(",")' "$MANIFEST") \
+			|| die "failed to parse issues from manifest"
+	fi
+	if [[ -z "$BASE_BRANCH" ]]; then
+		BASE_BRANCH=$(jq -r '.base_branch' "$MANIFEST") \
+			|| die "failed to parse base_branch from manifest"
+	fi
+	if [[ -z "$AGENT" ]]; then
+		AGENT=$(jq -r '.agent // empty' "$MANIFEST" \
+			2>/dev/null) \
+			|| printf '%s: warn: jq failed parsing .agent in %s\n' \
+				"$SCRIPT_NAME" "$MANIFEST" >&2
+	fi
+fi
+
+[[ -n "$ISSUES" ]] \
+	|| die_usage "must provide --issues or --manifest with issues"
+[[ -n "$BASE_BRANCH" ]] \
+	|| die_usage \
+		"must provide --base-branch or --manifest with base_branch"
+
+# =============================================================================
+# RUNTIME CONFIGURATION
+# =============================================================================
+
+readonly AB_TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+
+# Arm branch names — unique to this run so parallel runs do not clash
+readonly CONTROL_BRANCH="ab-${AB_TIMESTAMP}-control"
+readonly TREATMENT_BRANCH="ab-${AB_TIMESTAMP}-treatment"
+
+# All output lands under logs/ab-TIMESTAMP/ (logs/ is gitignored)
+readonly AB_LOG_DIR="$REPO_ROOT/logs/ab-$AB_TIMESTAMP"
+readonly CONTROL_WT="$AB_LOG_DIR/worktrees/control"
+readonly TREATMENT_WT="$AB_LOG_DIR/worktrees/treatment"
+
+# Background arm PIDs (populated by launch_arm)
+CONTROL_PID=""
+TREATMENT_PID=""
+
+# Guards for selective cleanup on EXIT
+CONTROL_BRANCH_CREATED=false
+TREATMENT_BRANCH_CREATED=false
+CONTROL_WT_CREATED=false
+TREATMENT_WT_CREATED=false
+
+# Establish log dir before first log() call
+mkdir -p "$AB_LOG_DIR"
+readonly LOG_FILE="$AB_LOG_DIR/harness.log"
+
+# =============================================================================
+# LOGGING (stderr + file; never stdout — this script produces no stdout data)
+# =============================================================================
+
+log() {
+	local msg="[$(date -Iseconds)] $*"
+	printf '%s\n' "$msg" >> "$LOG_FILE"
+	printf '%s\n' "$msg" >&2
+}
+
+log_warn() {
+	local msg="[$(date -Iseconds)] WARN: $*"
+	printf '%s\n' "$msg" >> "$LOG_FILE"
+	printf '%s\n' "$msg" >&2
+}
+
+log_error() {
+	local msg="[$(date -Iseconds)] ERROR: $*"
+	printf '%s\n' "$msg" >> "$LOG_FILE"
+	printf '%s\n' "$msg" >&2
+}
+
+# =============================================================================
+# CLEANUP (EXIT TRAP)
+# =============================================================================
+
+# cleanup — called on EXIT.
+#
+# Execution order:
+#   1. Preserve arm log dirs so they survive worktree removal.
+#   2. Kill any still-running arm processes.
+#   3. Remove worktrees (git worktree remove --force).
+#   4. Prune stale worktree refs.
+#   5. Delete arm branches.
+#
+# Non-fatal: all git/cp commands use || true so a partial cleanup
+# does not mask the real exit code.
+
+cleanup() {
+	log "Cleanup: preserving arm artifacts before worktree removal"
+
+	if $CONTROL_WT_CREATED; then
+		local ctrl_save="$AB_LOG_DIR/preserved-control"
+		mkdir -p "$ctrl_save"
+		if [[ -f "$CONTROL_WT/status.json" ]]; then
+			cp "$CONTROL_WT/status.json" \
+				"$ctrl_save/status.json" 2>/dev/null || true
+		fi
+		if [[ -d "$CONTROL_WT/logs" ]]; then
+			cp -r "$CONTROL_WT/logs" \
+				"$ctrl_save/logs" 2>/dev/null || true
+		fi
+	fi
+
+	if $TREATMENT_WT_CREATED; then
+		local treat_save="$AB_LOG_DIR/preserved-treatment"
+		mkdir -p "$treat_save"
+		if [[ -f "$TREATMENT_WT/status.json" ]]; then
+			cp "$TREATMENT_WT/status.json" \
+				"$treat_save/status.json" 2>/dev/null || true
+		fi
+		if [[ -d "$TREATMENT_WT/logs" ]]; then
+			cp -r "$TREATMENT_WT/logs" \
+				"$treat_save/logs" 2>/dev/null || true
+		fi
+	fi
+
+	if [[ -n "$CONTROL_PID" ]] \
+			&& kill -0 "$CONTROL_PID" 2>/dev/null; then
+		log "Cleanup: terminating control arm (PID $CONTROL_PID)"
+		kill "$CONTROL_PID" 2>/dev/null || true
+	fi
+	if [[ -n "$TREATMENT_PID" ]] \
+			&& kill -0 "$TREATMENT_PID" 2>/dev/null; then
+		log "Cleanup: terminating treatment arm" \
+			"(PID $TREATMENT_PID)"
+		kill "$TREATMENT_PID" 2>/dev/null || true
+	fi
+
+	log "Cleanup: removing arm worktrees"
+
+	if $CONTROL_WT_CREATED; then
+		git -C "$REPO_ROOT" worktree remove --force \
+			"$CONTROL_WT" 2>/dev/null || true
+	fi
+	if $TREATMENT_WT_CREATED; then
+		git -C "$REPO_ROOT" worktree remove --force \
+			"$TREATMENT_WT" 2>/dev/null || true
+	fi
+
+	git -C "$REPO_ROOT" worktree prune 2>/dev/null || true
+
+	log "Cleanup: deleting arm branches"
+
+	if $CONTROL_BRANCH_CREATED; then
+		git -C "$REPO_ROOT" branch -D \
+			"$CONTROL_BRANCH" 2>/dev/null || true
+	fi
+	if $TREATMENT_BRANCH_CREATED; then
+		git -C "$REPO_ROOT" branch -D \
+			"$TREATMENT_BRANCH" 2>/dev/null || true
+	fi
+
+	log "Cleanup complete. Artifacts preserved in $AB_LOG_DIR"
+}
+
+trap cleanup EXIT
+
+# =============================================================================
+# WORKTREE SETUP
+# =============================================================================
+
+# setup_arm_branch <arm_name> <arm_branch>
+#
+# Creates the arm branch from BASE_BRANCH without checking it out
+# (git branch, not git checkout -b). The branch is used as the
+# target for PRs created by batch-orchestrator.sh inside the arm.
+setup_arm_branch() {
+	local arm_name="$1"
+	local arm_branch="$2"
+
+	log "Creating $arm_name branch: $arm_branch (from $BASE_BRANCH)"
+	if ! git -C "$REPO_ROOT" branch \
+			"$arm_branch" "$BASE_BRANCH" 2>>"$LOG_FILE"; then
+		log_error "failed to create $arm_name branch: $arm_branch"
+		return 1
+	fi
+	return 0
+}
+
+# setup_arm_worktree <arm_name> <arm_branch> <arm_wt_path>
+#
+# Creates a git worktree at arm_wt_path checked out on arm_branch.
+setup_arm_worktree() {
+	local arm_name="$1"
+	local arm_branch="$2"
+	local arm_wt="$3"
+
+	mkdir -p "$(dirname "$arm_wt")"
+	log "Creating $arm_name worktree at $arm_wt"
+	if ! git -C "$REPO_ROOT" worktree add \
+			"$arm_wt" "$arm_branch" 2>>"$LOG_FILE"; then
+		log_error "failed to create $arm_name worktree: $arm_wt"
+		return 1
+	fi
+	return 0
+}
+
+# =============================================================================
+# ARM LAUNCHER
+# =============================================================================
+
+# launch_arm <arm_name> <arm_wt> <arm_branch> <ctx_mode> <pid_varname>
+#
+# Runs batch-orchestrator.sh as a background child process of the
+# calling shell.  CWD is set to the arm worktree so all relative git
+# commands (git checkout, git pull, etc.) operate on the arm branch.
+# CONTEXT_MODE_ENABLED is set per arm.
+#
+# The background PID is stored in the variable named by pid_varname
+# (using printf -v so the caller can `wait` on it directly).
+#
+# Design note: this function is called as a plain invocation (not via
+# $(...)), so the background process launched with & is a direct child
+# of the main shell — `wait <pid>` in main() therefore works.
+launch_arm() {
+	local arm_name="$1"
+	local arm_wt="$2"
+	local arm_branch="$3"
+	local context_mode="$4"
+	local pid_varname="$5"
+	local arm_log="$AB_LOG_DIR/${arm_name}-run.log"
+
+	local -a agent_args=()
+	if [[ -n "$AGENT" ]]; then
+		agent_args=(--agent "$AGENT")
+	fi
+
+	log "Launching $arm_name arm" \
+		"(CONTEXT_MODE_ENABLED=$context_mode)"
+	log "$arm_name: issues=$ISSUES  branch=$arm_branch"
+
+	(
+		cd "$arm_wt" || exit 1
+		# Per-arm differentiator: batch-orchestrator.sh reads this via
+		# context_mode_claude_args() and adds --strict-mcp-config to its
+		# claude invocations when 0 (control) — suppressing the context-mode
+		# MCP plugin — and leaves it untouched when 1 (treatment) so the
+		# plugin loads.  Exporting it here is what makes the arms actually
+		# differ; without the consumer the experiment is a no-op (issue #542).
+		export CONTEXT_MODE_ENABLED="$context_mode"
+		bash "$SCRIPT_DIR/batch-orchestrator.sh" \
+			--issues "$ISSUES" \
+			--branch "$arm_branch" \
+			${agent_args[@]+"${agent_args[@]}"} \
+			>> "$arm_log" 2>&1
+	) &
+
+	# Store the subshell PID in the caller's variable.
+	# The subshell is a direct child of the main shell, so
+	# `wait "$pid_varname"` works in main().
+	printf -v "$pid_varname" '%s' "$!"
+}
+
+# =============================================================================
+# REPORTING HELPERS
+# =============================================================================
+
+# resolve_log_dir <worktree_path> <arm_name>
+#
+# Reads the arm's status.json to locate the batch log directory
+# used by batch-orchestrator.sh (the log_dir field).
+# Prints the absolute path to stdout; prints nothing on failure.
+resolve_log_dir() {
+	local wt_path="$1"
+	local arm_name="$2"
+	local status_file="$wt_path/status.json"
+
+	# batch-orchestrator.sh may write status.json into a LOG_BASE
+	# subdirectory rather than the worktree root. Search up to 3
+	# levels deep so the harness finds it without assuming a fixed
+	# layout, and emit a clear diagnostic showing both the expected
+	# path and where the file was actually found.
+	if [[ ! -f "$status_file" ]]; then
+		local found
+		found=$(find "$wt_path" -maxdepth 3 \
+			-name "status.json" -print -quit 2>/dev/null)
+		if [[ -n "$found" ]]; then
+			log_warn "$arm_name: status.json not at worktree" \
+				"root; using $found"
+			status_file="$found"
+		else
+			log_warn "$arm_name: status.json not found" \
+				"(checked $status_file and subdirs)"
+			return
+		fi
+	fi
+
+	local log_dir
+	log_dir=$(jq -r '.log_dir // empty' "$status_file" \
+		2>/dev/null) || log_dir=""
+
+	if [[ -z "$log_dir" ]]; then
+		log_warn "$arm_name: log_dir missing in status.json"
+		return
+	fi
+
+	# Relative log_dir is relative to the worktree root
+	if [[ "$log_dir" == /* ]]; then
+		printf '%s\n' "$log_dir"
+	else
+		printf '%s\n' "$wt_path/$log_dir"
+	fi
+}
+
+# invoke_report <control_log_dir> <treatment_log_dir>
+#
+# Calls ab-report.sh with both arm log directories. Writes results to
+# AB_LOG_DIR. Warns (non-fatal) when ab-report.sh is not yet present.
+invoke_report() {
+	local ctrl_log="$1"
+	local treat_log="$2"
+	local report_script="$SCRIPT_DIR/ab-report.sh"
+
+	if [[ ! -f "$report_script" ]]; then
+		log_warn "ab-report.sh not found — skipping report"
+		log_warn "Run manually when ab-report.sh is available:"
+		log_warn "  $report_script \\"
+		log_warn "    --control-log-dir \"$ctrl_log\" \\"
+		log_warn "    --treatment-log-dir \"$treat_log\" \\"
+		log_warn "    --output-dir \"$AB_LOG_DIR\""
+		return 0
+	fi
+
+	log "Invoking ab-report.sh"
+	local report_rc=0
+	bash "$report_script" \
+		--control-log-dir "$ctrl_log" \
+		--treatment-log-dir "$treat_log" \
+		--output-dir "$AB_LOG_DIR" \
+		>> "$LOG_FILE" 2>&1 \
+		|| report_rc=$?
+
+	if (( report_rc != 0 )); then
+		log_error "ab-report.sh failed (exit $report_rc)"
+		return 1
+	fi
+
+	log "Report written to $AB_LOG_DIR/report.md"
+	return 0
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+main() {
+	log "=========================================="
+	log "A/B Harness Starting"
+	log "=========================================="
+	log "Issues:            $ISSUES"
+	log "Base branch:       $BASE_BRANCH"
+	log "Agent:             ${AGENT:-default}"
+	log "Timestamp:         $AB_TIMESTAMP"
+	log "Control branch:    $CONTROL_BRANCH"
+	log "Treatment branch:  $TREATMENT_BRANCH"
+	log "Log dir:           $AB_LOG_DIR"
+	log "=========================================="
+
+	# Verify base branch exists before touching anything
+	if ! git -C "$REPO_ROOT" rev-parse \
+			--verify "$BASE_BRANCH" >/dev/null 2>&1; then
+		die "base branch does not exist: $BASE_BRANCH"
+	fi
+
+	# ------------------------------------------------------------------
+	# Create arm branches (no checkout — branch pointer only)
+	# ------------------------------------------------------------------
+	if ! setup_arm_branch "control" "$CONTROL_BRANCH"; then
+		die "aborting: control branch setup failed"
+	fi
+	CONTROL_BRANCH_CREATED=true
+
+	if ! setup_arm_branch "treatment" "$TREATMENT_BRANCH"; then
+		die "aborting: treatment branch setup failed"
+	fi
+	TREATMENT_BRANCH_CREATED=true
+
+	# ------------------------------------------------------------------
+	# Create arm worktrees (each checked out on its arm branch)
+	# ------------------------------------------------------------------
+	if ! setup_arm_worktree \
+			"control" "$CONTROL_BRANCH" "$CONTROL_WT"; then
+		die "aborting: control worktree setup failed"
+	fi
+	CONTROL_WT_CREATED=true
+
+	if ! setup_arm_worktree \
+			"treatment" "$TREATMENT_BRANCH" "$TREATMENT_WT"; then
+		die "aborting: treatment worktree setup failed"
+	fi
+	TREATMENT_WT_CREATED=true
+
+	# ------------------------------------------------------------------
+	# Launch both arms in parallel
+	# ------------------------------------------------------------------
+	launch_arm \
+		"control" "$CONTROL_WT" "$CONTROL_BRANCH" "0" CONTROL_PID
+	log "Control arm PID: $CONTROL_PID"
+
+	launch_arm \
+		"treatment" "$TREATMENT_WT" "$TREATMENT_BRANCH" "1" \
+		TREATMENT_PID
+	log "Treatment arm PID: $TREATMENT_PID"
+
+	log "Waiting for both arms to complete..."
+
+	# ------------------------------------------------------------------
+	# Wait for both arms; collect exit codes
+	# ------------------------------------------------------------------
+	local control_exit=0
+	local treatment_exit=0
+
+	wait "$CONTROL_PID" || control_exit=$?
+	log "Control arm finished (exit $control_exit)"
+
+	wait "$TREATMENT_PID" || treatment_exit=$?
+	log "Treatment arm finished (exit $treatment_exit)"
+
+	if (( control_exit != 0 )); then
+		log_warn "Control arm exited non-zero: $control_exit"
+	fi
+	if (( treatment_exit != 0 )); then
+		log_warn "Treatment arm exited non-zero: $treatment_exit"
+	fi
+
+	# ------------------------------------------------------------------
+	# Resolve arm log directories from each arm's status.json
+	# ------------------------------------------------------------------
+	local control_log_dir treatment_log_dir
+	control_log_dir=$(resolve_log_dir "$CONTROL_WT" "control")
+	treatment_log_dir=$(resolve_log_dir "$TREATMENT_WT" "treatment")
+
+	log "Control log dir:   ${control_log_dir:-unknown}"
+	log "Treatment log dir: ${treatment_log_dir:-unknown}"
+
+	# ------------------------------------------------------------------
+	# Generate comparison report (non-fatal if ab-report.sh missing)
+	# ------------------------------------------------------------------
+	local report_exit=0
+	invoke_report "$control_log_dir" "$treatment_log_dir" \
+		|| report_exit=$?
+
+	# ------------------------------------------------------------------
+	# Final summary
+	# ------------------------------------------------------------------
+	log "=========================================="
+	log "A/B Harness Complete"
+	log "=========================================="
+	log "Control:   exit=$control_exit" \
+		" dir=${control_log_dir:-unknown}"
+	log "Treatment: exit=$treatment_exit" \
+		" dir=${treatment_log_dir:-unknown}"
+	log "Harness log: $LOG_FILE"
+
+	if [[ -f "$AB_LOG_DIR/report.md" ]]; then
+		log "Report:  $AB_LOG_DIR/report.md"
+	fi
+	if [[ -f "$AB_LOG_DIR/ab-results.json" ]]; then
+		log "Results: $AB_LOG_DIR/ab-results.json"
+	fi
+
+	return $report_exit
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/ab-report.sh
+++ b/plugins/pipeline-core/scripts/ab-report.sh
@@ -1,0 +1,889 @@
+#!/usr/bin/env bash
+#
+# ab-report.sh
+# Compare two A/B arm run logs; emit markdown report + ab-results.json.
+#
+# Reads per-issue metrics.json (duration/iterations/escalations/state) from
+# each arm's implement-issue log directory and greps stage logs for Claude
+# CLI JSON result lines (total_cost_usd/num_turns). Computes per-issue and
+# aggregate deltas (treatment − control).
+#
+# Usage:
+#   ab-report.sh --control-log-dir <path> \
+#                --treatment-log-dir <path> \
+#                --output-dir <path>
+#
+# The batch-orchestrator log dir is the directory that contains
+# issue-N-status.json files (e.g. logs/batch-TIMESTAMP/ inside the arm
+# worktree, or the preserved-control/logs/batch-TIMESTAMP/ copy).
+#
+# Outputs:
+#   <output-dir>/report.md
+#   <output-dir>/ab-results.json
+#
+# Exit codes:
+#   0  Report generated successfully
+#   1  Fatal error (missing dependency, write failure)
+#   3  Configuration / argument error
+#
+
+set -uo pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+
+# =============================================================================
+# ERROR HELPERS
+# =============================================================================
+
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 1
+}
+
+die_usage() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 3
+}
+
+usage() {
+	cat <<EOF
+Usage: $SCRIPT_NAME [options]
+
+Compare two A/B arm run logs and generate a comparison report.
+
+Options:
+    --control-log-dir <path>    Batch-orchestrator log dir (control arm)
+    --treatment-log-dir <path>  Batch-orchestrator log dir (treatment arm)
+    --output-dir <path>         Write report.md and ab-results.json here
+    -h, --help                  Show this help
+
+Exit codes:
+    0  Report generated
+    1  Fatal error
+    3  Configuration / argument error
+EOF
+}
+
+# =============================================================================
+# ARGUMENT PARSING
+# =============================================================================
+
+CONTROL_LOG_DIR=""
+TREATMENT_LOG_DIR=""
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--control-log-dir)
+			[[ -n "${2:-}" ]] \
+				|| die_usage "--control-log-dir requires a value"
+			CONTROL_LOG_DIR="$2"
+			shift 2
+			;;
+		--treatment-log-dir)
+			[[ -n "${2:-}" ]] \
+				|| die_usage "--treatment-log-dir requires a value"
+			TREATMENT_LOG_DIR="$2"
+			shift 2
+			;;
+		--output-dir)
+			[[ -n "${2:-}" ]] \
+				|| die_usage "--output-dir requires a value"
+			OUTPUT_DIR="$2"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		--)
+			shift
+			break
+			;;
+		-*)
+			die_usage "unknown option: $1"
+			;;
+		*)
+			die_usage "unexpected argument: $1"
+			;;
+	esac
+done
+
+[[ -n "$CONTROL_LOG_DIR" ]] \
+	|| die_usage "--control-log-dir is required"
+[[ -n "$TREATMENT_LOG_DIR" ]] \
+	|| die_usage "--treatment-log-dir is required"
+[[ -n "$OUTPUT_DIR" ]] \
+	|| die_usage "--output-dir is required"
+
+[[ -d "$CONTROL_LOG_DIR" ]] \
+	|| die "control log dir not found: $CONTROL_LOG_DIR"
+[[ -d "$TREATMENT_LOG_DIR" ]] \
+	|| die "treatment log dir not found: $TREATMENT_LOG_DIR"
+
+mkdir -p "$OUTPUT_DIR" \
+	|| die "cannot create output dir: $OUTPUT_DIR"
+
+# =============================================================================
+# FLOAT FORMATTING (awk — avoids bc dependency)
+# =============================================================================
+
+# fmt_float <value> <decimals>
+# Format a number for display. Prints "n/a" when value is null or empty.
+fmt_float() {
+	local value="$1"
+	local decimals="${2:-2}"
+
+	if [[ -z "$value" || "$value" == "null" ]]; then
+		printf 'n/a'
+		return 0
+	fi
+
+	awk -v v="$value" -v d="$decimals" 'BEGIN { printf "%." d "f", v }'
+}
+
+# fmt_delta <value> <decimals>
+# Format a delta with explicit sign (+ or -). Prints "n/a" when null/empty.
+fmt_delta() {
+	local value="$1"
+	local decimals="${2:-0}"
+
+	if [[ -z "$value" || "$value" == "null" ]]; then
+		printf 'n/a'
+		return 0
+	fi
+
+	awk -v v="$value" -v d="$decimals" \
+		'BEGIN { printf "%+" "." d "f", v }'
+}
+
+# =============================================================================
+# DATA COLLECTION
+# =============================================================================
+
+# resolve_impl_log_dir <status_file> <arm_log_dir>
+#
+# Reads log_dir from an implement-issue status file and resolves it to an
+# accessible path. Falls back to searching under the sibling implement-issue
+# directory (handles preserved copies where the worktree is gone).
+#
+# Prints the resolved path to stdout; prints nothing on failure.
+resolve_impl_log_dir() {
+	local status_file="$1"
+	local arm_log_dir="$2"
+
+	local log_dir
+	log_dir=$(jq -r '.log_dir // empty' "$status_file" 2>/dev/null)
+	[[ -n "$log_dir" ]] || return 0
+
+	# Fast path: path exists (live worktree scenario)
+	if [[ -d "$log_dir" ]]; then
+		printf '%s' "$log_dir"
+		return 0
+	fi
+
+	# Slow path: worktree was cleaned up; search under sibling dir.
+	# arm_log_dir = .../logs/batch-TS/  so dirname = .../logs/
+	local issue_num
+	issue_num=$(jq -r '.issue // empty' "$status_file" 2>/dev/null)
+	[[ -n "$issue_num" ]] || return 0
+
+	local logs_parent impl_search found
+	logs_parent="$(dirname "$arm_log_dir")"
+	impl_search="$logs_parent/implement-issue"
+	[[ -d "$impl_search" ]] || return 0
+
+	found=$(find "$impl_search" -maxdepth 1 -type d \
+		-name "issue-${issue_num}-*" 2>/dev/null \
+		| sort | tail -1)
+	[[ -n "$found" ]] || return 0
+
+	printf '%s' "$found"
+}
+
+# collect_stage_costs <impl_log_dir>
+#
+# Greps stage log files for Claude CLI JSON result lines emitted by
+# --output-format json. Extracts total_cost_usd and num_turns and sums
+# them across all stages for the issue.
+#
+# Outputs JSON: {"cost_usd": N, "turns": N}
+collect_stage_costs() {
+	local impl_log_dir="$1"
+	local empty='{"cost_usd":0,"turns":0,"input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0}'
+
+	if [[ -z "$impl_log_dir" \
+			|| ! -d "$impl_log_dir/stages" ]]; then
+		printf '%s' "$empty"
+		return 0
+	fi
+
+	local stages_dir="$impl_log_dir/stages"
+	local result
+
+	# Collect result lines from stage logs.
+	# Requiring "total_cost_usd" in the grep pre-filter avoids passing
+	# non-result JSON objects (e.g. intermediate progress lines) to jq,
+	# guarding against lines that start with '{' but are not CLI results.
+	result=$(
+		for f in "$stages_dir"/*.log; do
+			[[ -f "$f" ]] || continue
+			grep '^{.*"total_cost_usd"' "$f" 2>/dev/null || true
+		done \
+		| jq -cs '
+			[.[] | select(.total_cost_usd != null)] |
+			{
+				cost_usd: (map(.total_cost_usd) | add // 0),
+				turns:    (map(.num_turns // 0)  | add // 0),
+				input_tokens: (
+					map(
+						(.usage.input_tokens
+						 // .input_tokens // 0)
+					) | add // 0
+				),
+				output_tokens: (
+					map(
+						(.usage.output_tokens
+						 // .output_tokens // 0)
+					) | add // 0
+				),
+				cache_creation_tokens: (
+					map(
+						(.usage.cache_creation_input_tokens
+						 // .usage.cache_creation_tokens
+						 // .cache_creation_input_tokens
+						 // .cache_creation_tokens // 0)
+					) | add // 0
+				),
+				cache_read_tokens: (
+					map(
+						(.usage.cache_read_input_tokens
+						 // .usage.cache_read_tokens
+						 // .cache_read_input_tokens
+						 // .cache_read_tokens // 0)
+					) | add // 0
+				)
+			}
+		' 2>/dev/null
+	)
+
+	if [[ -n "$result" ]]; then
+		printf '%s' "$result"
+	else
+		printf '%s' "$empty"
+	fi
+}
+
+# collect_arm_data <arm_log_dir>
+#
+# Discovers all issue-N-status.json files in the batch log dir, resolves
+# each issue's implement-issue log dir, reads metrics.json, and collects
+# stage costs.
+#
+# Prints a JSON array of per-issue objects to stdout.
+# All diagnostic output goes to stderr (stdout is the return channel).
+collect_arm_data() {
+	local arm_log_dir="$1"
+	local issues_json="[]"
+
+	local status_file
+	for status_file in "$arm_log_dir"/issue-*-status.json; do
+		[[ -f "$status_file" ]] || continue
+
+		# Extract issue number from: issue-<N>-status.json
+		local base="${status_file##*/}"
+		local issue_num="${base#issue-}"
+		issue_num="${issue_num%-status.json}"
+		[[ -n "$issue_num" ]] || continue
+
+		local impl_log_dir
+		impl_log_dir=$(resolve_impl_log_dir \
+			"$status_file" "$arm_log_dir")
+
+		local state="unknown"
+		local duration="null"
+		local quality_iters=0
+		local test_iters=0
+		local pr_iters=0
+		local escalation_count=0
+
+		if [[ -n "$impl_log_dir" \
+				&& -f "$impl_log_dir/metrics.json" ]]; then
+			local mf="$impl_log_dir/metrics.json"
+
+			# Extract all metrics.json fields in a single jq call
+			# with tab-separated output, then split into named
+			# variables (avoids forking jq once per field).
+			local metrics_tsv
+			metrics_tsv=$(jq -r '[
+				(.state // "unknown"),
+				(.total_duration_seconds // "null"),
+				(.iteration_summary.quality_iterations // 0),
+				(.iteration_summary.test_iterations // 0),
+				(.iteration_summary.pr_review_iterations // 0),
+				(.escalations | length)
+			] | @tsv' "$mf" 2>/dev/null || printf '')
+
+			if [[ -n "$metrics_tsv" ]]; then
+				IFS=$'\t' read -r state duration \
+					quality_iters test_iters \
+					pr_iters escalation_count \
+					<<< "$metrics_tsv"
+			fi
+		else
+			state=$(jq -r '.state // "unknown"' \
+				"$status_file" 2>/dev/null \
+				|| printf 'unknown')
+			printf 'WARN: no metrics.json for issue %s\n' \
+				"$issue_num" >&2
+		fi
+
+		local total_iters
+		total_iters=$(( quality_iters + test_iters + pr_iters ))
+
+		# Ensure duration is valid JSON (number or null literal)
+		local dur_json="null"
+		if [[ "$duration" != "null" && -n "$duration" ]]; then
+			dur_json="$duration"
+		fi
+
+		local costs_json
+		costs_json=$(collect_stage_costs "$impl_log_dir")
+
+		local updated
+		updated=$(jq \
+			--arg issue "$issue_num" \
+			--arg state "$state" \
+			--argjson duration "$dur_json" \
+			--argjson q "$quality_iters" \
+			--argjson t "$test_iters" \
+			--argjson p "$pr_iters" \
+			--argjson tot "$total_iters" \
+			--argjson esc "$escalation_count" \
+			--argjson costs "$costs_json" \
+			'. + [{
+				issue:    $issue,
+				state:    $state,
+				duration_seconds: $duration,
+				iterations: {
+					quality:   $q,
+					test:      $t,
+					pr_review: $p,
+					total:     $tot
+				},
+				escalations:           $esc,
+				cost_usd:              $costs.cost_usd,
+				turns:                 $costs.turns,
+				input_tokens:          $costs.input_tokens,
+				output_tokens:         $costs.output_tokens,
+				cache_creation_tokens: $costs.cache_creation_tokens,
+				cache_read_tokens:     $costs.cache_read_tokens
+			}]' <<< "$issues_json" 2>/dev/null)
+
+		if [[ -n "$updated" ]]; then
+			issues_json="$updated"
+		fi
+	done
+
+	printf '%s' "$issues_json"
+}
+
+# =============================================================================
+# AGGREGATION & DELTA COMPUTATION
+# =============================================================================
+
+# aggregate_arm <issues_json>
+# Computes totals across all issues for one arm.
+# Prints a JSON object to stdout.
+aggregate_arm() {
+	local issues_json="$1"
+
+	jq '{
+		issue_count:   length,
+		completed_count: (
+			[.[] | select(.state == "completed")] | length
+		),
+		total_duration_seconds: (
+			[.[].duration_seconds | select(. != null)]
+			| add // null
+		),
+		total_iterations:         ([.[].iterations.total]     | add // 0),
+		total_quality_iterations: ([.[].iterations.quality]   | add // 0),
+		total_test_iterations:    ([.[].iterations.test]      | add // 0),
+		total_pr_iterations:      ([.[].iterations.pr_review] | add // 0),
+		total_escalations:        ([.[].escalations]          | add // 0),
+		total_cost_usd:           ([.[].cost_usd]             | add // 0),
+		total_turns:              ([.[].turns]                | add // 0),
+		total_input_tokens: (
+			[.[].input_tokens]          | add // 0
+		),
+		total_output_tokens: (
+			[.[].output_tokens]         | add // 0
+		),
+		total_cache_creation_tokens: (
+			[.[].cache_creation_tokens] | add // 0
+		),
+		total_cache_read_tokens: (
+			[.[].cache_read_tokens]     | add // 0
+		)
+	}' <<< "$issues_json"
+}
+
+# compute_deltas <ctrl_issues_json> <treat_issues_json>
+# Joins both arms by issue number and computes treatment − control deltas.
+# Prints a JSON array to stdout.
+compute_deltas() {
+	local ctrl_json="$1"
+	local treat_json="$2"
+
+	jq -n \
+		--argjson ctrl "$ctrl_json" \
+		--argjson treat "$treat_json" \
+		'
+		($ctrl  | map({(.issue): .}) | add // {}) as $cm |
+		($treat | map({(.issue): .}) | add // {}) as $tm |
+		([$ctrl[].issue, $treat[].issue] | unique | sort) |
+		map(. as $iss |
+			$cm[$iss] as $c |
+			$tm[$iss] as $t |
+			{
+				issue:     $iss,
+				control:   $c,
+				treatment: $t,
+				delta: (
+					if ($c != null and $t != null) then {
+						duration_seconds: (
+							if ($t.duration_seconds != null
+								and $c.duration_seconds != null)
+							then ($t.duration_seconds
+								- $c.duration_seconds)
+							else null end
+						),
+						total_iterations: (
+							$t.iterations.total
+							- $c.iterations.total
+						),
+						escalations: (
+							$t.escalations - $c.escalations
+						),
+						cost_usd: ($t.cost_usd - $c.cost_usd),
+						turns:    ($t.turns    - $c.turns),
+						input_tokens: (
+							$t.input_tokens
+							- $c.input_tokens
+						),
+						output_tokens: (
+							$t.output_tokens
+							- $c.output_tokens
+						),
+						cache_creation_tokens: (
+							$t.cache_creation_tokens
+							- $c.cache_creation_tokens
+						),
+						cache_read_tokens: (
+							$t.cache_read_tokens
+							- $c.cache_read_tokens
+						),
+						state_changed: ($t.state != $c.state)
+					} else null end
+				)
+			}
+		)
+		'
+}
+
+# compute_agg_delta <ctrl_agg_json> <treat_agg_json>
+# Computes treatment − control aggregate deltas.
+# Prints a JSON object to stdout.
+compute_agg_delta() {
+	local c_agg="$1"
+	local t_agg="$2"
+
+	jq -n \
+		--argjson c "$c_agg" \
+		--argjson t "$t_agg" \
+		'{
+			issue_count: ($t.issue_count - $c.issue_count),
+			completed_count: (
+				$t.completed_count - $c.completed_count
+			),
+			total_duration_seconds: (
+				if ($t.total_duration_seconds != null
+					and $c.total_duration_seconds != null)
+				then ($t.total_duration_seconds
+					- $c.total_duration_seconds)
+				else null end
+			),
+			total_iterations: (
+				$t.total_iterations - $c.total_iterations
+			),
+			total_escalations: (
+				$t.total_escalations - $c.total_escalations
+			),
+			total_cost_usd: (
+				$t.total_cost_usd - $c.total_cost_usd
+			),
+			total_turns: ($t.total_turns - $c.total_turns),
+			total_input_tokens: (
+				$t.total_input_tokens
+				- $c.total_input_tokens
+			),
+			total_output_tokens: (
+				$t.total_output_tokens
+				- $c.total_output_tokens
+			),
+			total_cache_creation_tokens: (
+				$t.total_cache_creation_tokens
+				- $c.total_cache_creation_tokens
+			),
+			total_cache_read_tokens: (
+				$t.total_cache_read_tokens
+				- $c.total_cache_read_tokens
+			)
+		}'
+}
+
+# =============================================================================
+# REPORT GENERATION
+# =============================================================================
+
+# write_report <per_issue_json> <ctrl_agg> <treat_agg> <agg_delta>
+#              <ctrl_dir> <treat_dir> <report_file>
+write_report() {
+	local per_issue_json="$1"
+	local ctrl_agg="$2"
+	local treat_agg="$3"
+	local agg_delta="$4"
+	local ctrl_dir="$5"
+	local treat_dir="$6"
+	local report_file="$7"
+
+	{
+		printf '# A/B Test Report\n\n'
+		printf 'Generated: %s\n\n' "$(date -Iseconds)"
+
+		printf '| Arm | Log Directory |\n'
+		printf '|-----|---------------|\n'
+		printf '| control   | `%s` |\n' "$ctrl_dir"
+		printf '| treatment | `%s` |\n\n' "$treat_dir"
+
+		# ------------------------------------------------------------------
+		# Aggregate summary table
+		# ------------------------------------------------------------------
+		printf '## Aggregate Summary\n\n'
+		printf '| Metric | Control | Treatment | Delta |\n'
+		printf '|--------|---------|-----------|-------|\n'
+
+		local ca_dur ta_dur da_dur
+		local ca_iters ta_iters da_iters
+		local ca_esc ta_esc da_esc
+		local ca_cost ta_cost da_cost
+		local ca_turns ta_turns da_turns
+		local ca_comp ta_comp da_comp
+		local ca_inp ta_inp da_inp
+		local ca_out ta_out da_out
+		local ca_cc ta_cc da_cc
+		local ca_cr ta_cr da_cr
+
+		# Batch all field extractions for each arm into a single
+		# jq call per arm (control / treatment / delta), emitting
+		# tab-separated values split into named variables below.
+		local agg_filter='[
+			(.total_duration_seconds // "null"),
+			.total_iterations,
+			.total_escalations,
+			.total_cost_usd,
+			.total_turns,
+			.completed_count,
+			.total_input_tokens,
+			.total_output_tokens,
+			.total_cache_creation_tokens,
+			.total_cache_read_tokens
+		] | @tsv'
+
+		local ctrl_tsv treat_tsv delta_tsv
+		ctrl_tsv=$(jq -r "$agg_filter" <<< "$ctrl_agg" 2>/dev/null)
+		treat_tsv=$(jq -r "$agg_filter" <<< "$treat_agg" 2>/dev/null)
+		delta_tsv=$(jq -r "$agg_filter" <<< "$agg_delta" 2>/dev/null)
+
+		if [[ -n "$ctrl_tsv" ]]; then
+			IFS=$'\t' read -r ca_dur ca_iters ca_esc ca_cost \
+				ca_turns ca_comp ca_inp ca_out ca_cc ca_cr \
+				<<< "$ctrl_tsv"
+		fi
+		if [[ -n "$treat_tsv" ]]; then
+			IFS=$'\t' read -r ta_dur ta_iters ta_esc ta_cost \
+				ta_turns ta_comp ta_inp ta_out ta_cc ta_cr \
+				<<< "$treat_tsv"
+		fi
+		if [[ -n "$delta_tsv" ]]; then
+			IFS=$'\t' read -r da_dur da_iters da_esc da_cost \
+				da_turns da_comp da_inp da_out da_cc da_cr \
+				<<< "$delta_tsv"
+		fi
+
+		printf '| Duration (s)   | %s | %s | %s |\n' \
+			"$(fmt_float "$ca_dur" 1)" \
+			"$(fmt_float "$ta_dur" 1)" \
+			"$(fmt_delta "$da_dur" 1)"
+		printf '| Iterations     | %s | %s | %s |\n' \
+			"$ca_iters" "$ta_iters" \
+			"$(fmt_delta "$da_iters" 0)"
+		printf '| Escalations    | %s | %s | %s |\n' \
+			"$ca_esc" "$ta_esc" \
+			"$(fmt_delta "$da_esc" 0)"
+		printf '| Cost (USD)     | %s | %s | %s |\n' \
+			"$(fmt_float "$ca_cost" 4)" \
+			"$(fmt_float "$ta_cost" 4)" \
+			"$(fmt_delta "$da_cost" 4)"
+		printf '| Turns          | %s | %s | %s |\n' \
+			"$ca_turns" "$ta_turns" \
+			"$(fmt_delta "$da_turns" 0)"
+		printf '| Completed      | %s | %s | %s |\n' \
+			"$ca_comp" "$ta_comp" \
+			"$(fmt_delta "$da_comp" 0)"
+		printf '| Input tokens   | %s | %s | %s |\n' \
+			"$ca_inp" "$ta_inp" \
+			"$(fmt_delta "$da_inp" 0)"
+		printf '| Output tokens  | %s | %s | %s |\n' \
+			"$ca_out" "$ta_out" \
+			"$(fmt_delta "$da_out" 0)"
+		printf '| Cache-create   | %s | %s | %s |\n' \
+			"$ca_cc" "$ta_cc" \
+			"$(fmt_delta "$da_cc" 0)"
+		printf '| Cache-read     | %s | %s | %s |\n\n' \
+			"$ca_cr" "$ta_cr" \
+			"$(fmt_delta "$da_cr" 0)"
+
+		# ------------------------------------------------------------------
+		# Per-issue table
+		# ------------------------------------------------------------------
+		printf '## Per-Issue Comparison\n\n'
+		printf '| Issue | Arm | State | Duration (s)'
+		printf ' | Iters | Escl | Cost (USD) | Turns'
+		printf ' | Inp Tok | Out Tok | CCreate | CRead |\n'
+		printf '|-------|-----|-------|-------------'
+		printf '|-------|------|-----------|-------'
+		printf '|---------|---------|---------|-------|\n'
+
+		local entry iss_num c_entry t_entry d_entry
+		local c_state c_dur c_iters c_esc c_cost c_turns
+		local c_inp c_out c_cc c_cr
+		local t_state t_dur t_iters t_esc t_cost t_turns
+		local t_inp t_out t_cc t_cr
+		local d_dur d_iters d_esc d_cost d_turns
+		local d_inp d_out d_cc d_cr
+
+		while IFS= read -r entry; do
+			[[ -n "$entry" ]] || continue
+
+			iss_num=$(jq -r '.issue' <<< "$entry")
+			c_entry=$(jq -c '.control // {}' <<< "$entry")
+			t_entry=$(jq -c '.treatment // {}' <<< "$entry")
+			d_entry=$(jq -c '.delta // "null"' <<< "$entry")
+
+			c_state=$(jq -r '.state // "—"' <<< "$c_entry")
+			c_dur=$(jq -r '.duration_seconds // "null"' \
+				<<< "$c_entry")
+			c_iters=$(jq -r '.iterations.total // "—"' \
+				<<< "$c_entry")
+			c_esc=$(jq -r '.escalations // "—"' <<< "$c_entry")
+			c_cost=$(jq -r '.cost_usd // "null"' <<< "$c_entry")
+			c_turns=$(jq -r '.turns // "—"' <<< "$c_entry")
+			c_inp=$(jq -r '.input_tokens // "—"' \
+				<<< "$c_entry")
+			c_out=$(jq -r '.output_tokens // "—"' \
+				<<< "$c_entry")
+			c_cc=$(jq -r \
+				'.cache_creation_tokens // "—"' \
+				<<< "$c_entry")
+			c_cr=$(jq -r '.cache_read_tokens // "—"' \
+				<<< "$c_entry")
+
+			printf \
+				'| #%s | control | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+				"$iss_num" "$c_state" \
+				"$(fmt_float "$c_dur" 1)" \
+				"$c_iters" "$c_esc" \
+				"$(fmt_float "$c_cost" 4)" \
+				"$c_turns" \
+				"$c_inp" "$c_out" "$c_cc" "$c_cr"
+
+			t_state=$(jq -r '.state // "—"' <<< "$t_entry")
+			t_dur=$(jq -r '.duration_seconds // "null"' \
+				<<< "$t_entry")
+			t_iters=$(jq -r '.iterations.total // "—"' \
+				<<< "$t_entry")
+			t_esc=$(jq -r '.escalations // "—"' <<< "$t_entry")
+			t_cost=$(jq -r '.cost_usd // "null"' <<< "$t_entry")
+			t_turns=$(jq -r '.turns // "—"' <<< "$t_entry")
+			t_inp=$(jq -r '.input_tokens // "—"' \
+				<<< "$t_entry")
+			t_out=$(jq -r '.output_tokens // "—"' \
+				<<< "$t_entry")
+			t_cc=$(jq -r \
+				'.cache_creation_tokens // "—"' \
+				<<< "$t_entry")
+			t_cr=$(jq -r '.cache_read_tokens // "—"' \
+				<<< "$t_entry")
+
+			printf \
+				'| #%s | treatment | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+				"$iss_num" "$t_state" \
+				"$(fmt_float "$t_dur" 1)" \
+				"$t_iters" "$t_esc" \
+				"$(fmt_float "$t_cost" 4)" \
+				"$t_turns" \
+				"$t_inp" "$t_out" "$t_cc" "$t_cr"
+
+			if [[ "$d_entry" != '"null"' \
+					&& "$d_entry" != "null" ]]; then
+				d_dur=$(jq -r \
+					'.duration_seconds // "null"' \
+					<<< "$d_entry")
+				d_iters=$(jq -r \
+					'.total_iterations // "null"' \
+					<<< "$d_entry")
+				d_esc=$(jq -r \
+					'.escalations // "null"' \
+					<<< "$d_entry")
+				d_cost=$(jq -r \
+					'.cost_usd // "null"' <<< "$d_entry")
+				d_turns=$(jq -r \
+					'.turns // "null"' <<< "$d_entry")
+				d_inp=$(jq -r \
+					'.input_tokens // "null"' \
+					<<< "$d_entry")
+				d_out=$(jq -r \
+					'.output_tokens // "null"' \
+					<<< "$d_entry")
+				d_cc=$(jq -r \
+					'.cache_creation_tokens // "null"' \
+					<<< "$d_entry")
+				d_cr=$(jq -r \
+					'.cache_read_tokens // "null"' \
+					<<< "$d_entry")
+
+				printf \
+					'| | **delta** | | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+					"$(fmt_delta "$d_dur" 1)" \
+					"$(fmt_delta "$d_iters" 0)" \
+					"$(fmt_delta "$d_esc" 0)" \
+					"$(fmt_delta "$d_cost" 4)" \
+					"$(fmt_delta "$d_turns" 0)" \
+					"$(fmt_delta "$d_inp" 0)" \
+					"$(fmt_delta "$d_out" 0)" \
+					"$(fmt_delta "$d_cc" 0)" \
+					"$(fmt_delta "$d_cr" 0)"
+			fi
+
+		done < <(jq -c '.[]' <<< "$per_issue_json")
+
+	} > "$report_file" \
+		|| die "failed to write report: $report_file"
+}
+
+# write_results_json <per_issue_json> <ctrl_agg> <treat_agg> <agg_delta>
+#                    <ctrl_issues> <treat_issues>
+#                    <ctrl_dir> <treat_dir> <results_file>
+write_results_json() {
+	local per_issue_json="$1"
+	local ctrl_agg="$2"
+	local treat_agg="$3"
+	local agg_delta="$4"
+	local ctrl_issues="$5"
+	local treat_issues="$6"
+	local ctrl_dir="$7"
+	local treat_dir="$8"
+	local results_file="$9"
+
+	jq -n \
+		--arg schema_version "1" \
+		--arg generated_at "$(date -Iseconds)" \
+		--arg ctrl_dir "$ctrl_dir" \
+		--arg treat_dir "$treat_dir" \
+		--argjson ctrl_issues "$ctrl_issues" \
+		--argjson treat_issues "$treat_issues" \
+		--argjson ctrl_agg "$ctrl_agg" \
+		--argjson treat_agg "$treat_agg" \
+		--argjson agg_delta "$agg_delta" \
+		--argjson per_issue "$per_issue_json" \
+		'{
+			schema_version: $schema_version,
+			generated_at:   $generated_at,
+			arms: {
+				control: {
+					log_dir:   $ctrl_dir,
+					aggregate: $ctrl_agg,
+					issues:    $ctrl_issues
+				},
+				treatment: {
+					log_dir:   $treat_dir,
+					aggregate: $treat_agg,
+					issues:    $treat_issues
+				}
+			},
+			per_issue: $per_issue,
+			aggregate: {
+				control:   $ctrl_agg,
+				treatment: $treat_agg,
+				delta:     $agg_delta
+			}
+		}' > "$results_file" \
+		|| die "failed to write results JSON: $results_file"
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+main() {
+	command -v jq >/dev/null 2>&1 \
+		|| die "jq is required but not found in PATH"
+	command -v awk >/dev/null 2>&1 \
+		|| die "awk is required but not found in PATH"
+
+	printf 'Collecting control arm data from: %s\n' \
+		"$CONTROL_LOG_DIR" >&2
+	local ctrl_issues
+	ctrl_issues=$(collect_arm_data "$CONTROL_LOG_DIR")
+
+	printf 'Collecting treatment arm data from: %s\n' \
+		"$TREATMENT_LOG_DIR" >&2
+	local treat_issues
+	treat_issues=$(collect_arm_data "$TREATMENT_LOG_DIR")
+
+	printf 'Computing aggregates and deltas...\n' >&2
+
+	local ctrl_agg treat_agg
+	ctrl_agg=$(aggregate_arm "$ctrl_issues")
+	treat_agg=$(aggregate_arm "$treat_issues")
+
+	local agg_delta
+	agg_delta=$(compute_agg_delta "$ctrl_agg" "$treat_agg")
+
+	local per_issue
+	per_issue=$(compute_deltas "$ctrl_issues" "$treat_issues")
+
+	local report_file="$OUTPUT_DIR/report.md"
+	local results_file="$OUTPUT_DIR/ab-results.json"
+
+	printf 'Writing report to: %s\n' "$report_file" >&2
+	write_report \
+		"$per_issue" "$ctrl_agg" "$treat_agg" "$agg_delta" \
+		"$CONTROL_LOG_DIR" "$TREATMENT_LOG_DIR" \
+		"$report_file"
+
+	printf 'Writing results to: %s\n' "$results_file" >&2
+	write_results_json \
+		"$per_issue" "$ctrl_agg" "$treat_agg" "$agg_delta" \
+		"$ctrl_issues" "$treat_issues" \
+		"$CONTROL_LOG_DIR" "$TREATMENT_LOG_DIR" \
+		"$results_file"
+
+	printf 'Done.\n' >&2
+	printf '  Report:  %s\n' "$report_file" >&2
+	printf '  Results: %s\n' "$results_file" >&2
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/apply-local.sh
+++ b/plugins/pipeline-core/scripts/apply-local.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# apply-local.sh — Copy local customizations over generic pipeline defaults
+#
+# Usage: .claude/scripts/apply-local.sh [--dry-run]
+#
+# Copies files from .claude/local/ over their counterparts in .claude/
+# This allows local customizations to survive upstream pipeline syncs:
+#   1. Pull upstream changes (updates generic defaults)
+#   2. Run apply-local.sh (re-applies your customizations on top)
+#
+# The .claude/local/ directory mirrors the .claude/ structure:
+#   .claude/local/agents/backend-developer.md  →  .claude/agents/backend-developer.md
+#   .claude/local/skills/my-skill/SKILL.md     →  .claude/skills/my-skill/SKILL.md
+#   .claude/local/config/platform.sh           →  .claude/config/platform.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOCAL_DIR="${CLAUDE_DIR}/local"
+DRY_RUN=false
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=true
+fi
+
+if [[ ! -d "$LOCAL_DIR" ]]; then
+    echo "No .claude/local/ directory found. Nothing to apply."
+    echo "Run /adapting-claude-pipeline to create local customizations."
+    exit 0
+fi
+
+copied=0
+
+while IFS= read -r -d '' local_file; do
+    rel_path="${local_file#"${LOCAL_DIR}/"}"
+    target="${CLAUDE_DIR}/${rel_path}"
+
+    if $DRY_RUN; then
+        echo "[dry-run] Would copy: local/${rel_path} → ${rel_path}"
+    else
+        mkdir -p "$(dirname "$target")"
+        cp "$local_file" "$target"
+        echo "Applied: local/${rel_path} → ${rel_path}"
+    fi
+    ((copied++))
+done < <(find "$LOCAL_DIR" -type f -print0)
+
+if $DRY_RUN; then
+    echo ""
+    echo "Dry run complete. ${copied} file(s) would be applied."
+else
+    echo ""
+    echo "Applied ${copied} local customization(s)."
+fi

--- a/plugins/pipeline-core/scripts/batch-orchestrator.sh
+++ b/plugins/pipeline-core/scripts/batch-orchestrator.sh
@@ -1,0 +1,2093 @@
+#!/usr/bin/env bash
+#
+# batch-orchestrator.sh
+# Orchestrates batch processing of GitHub issues using Claude Agent SDK
+#
+# Usage:
+#   ./batch-orchestrator.sh --manifest <path>
+#   ./batch-orchestrator.sh --issues "123,124,125" --branch "test"
+#   ./batch-orchestrator.sh --manifest <path> --agent react-frontend-developer
+#
+# Agent Selection:
+#   --agent <name>  Specify agent for implement-issue (e.g., react-frontend-developer,
+#                   fastify-backend-developer). Process-pr always uses code-reviewer.
+#
+# Outputs:
+#   - status.json: Real-time progress (read by handle-issues skill)
+#   - logs/batch-<timestamp>/: Per-issue logs and final summary
+#
+# Exit codes:
+#   0  - All issues processed successfully
+#   1  - Some issues failed (check status.json)
+#   2  - Circuit breaker triggered.  Two independent breakers share this code
+#        and set a distinct batch state before exiting:
+#          * consecutive failures    -> state "circuit_breaker"
+#          * per-batch token/cost cap -> state "budget_exceeded" (issue #583,
+#            terminal: the batch is never resumed or retried on a budget halt)
+#   3  - Configuration/argument error
+#
+
+set -uo pipefail  # Note: not -e, we handle errors explicitly
+
+# =============================================================================
+# PORTABLE TIMEOUT (macOS does not ship GNU timeout)
+# =============================================================================
+
+if ! command -v timeout &>/dev/null; then
+    timeout() {
+        local duration="$1"; shift
+        perl -e '
+            use POSIX ":sys_wait_h";
+            alarm shift @ARGV;
+            $SIG{ALRM} = sub { kill 15, $pid; waitpid($pid, 0); exit 124 };
+            $pid = fork // die "fork: $!";
+            if ($pid == 0) { exec @ARGV; die "exec: $!" }
+            waitpid($pid, 0);
+            exit ($? >> 8);
+        ' "$duration" "$@"
+    }
+fi
+
+# =============================================================================
+# PORTABLE SETSID (macOS / older systems may not ship setsid)
+# =============================================================================
+
+if ! command -v setsid &>/dev/null; then
+    setsid() {
+        # Call setsid(2) via perl then exec the target command so that the
+        # caller's $! resolves to the exec'd process (pid == pgid == sid).
+        exec perl -MPOSIX -e 'POSIX::setsid(); exec @ARGV' -- "$@"
+    }
+fi
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMA_DIR="$SCRIPT_DIR/schemas"
+source "$SCRIPT_DIR/../config/platform.sh"
+source "$SCRIPT_DIR/issue-body-lib.sh"
+# claude-usage.sh provides is_model_exhausted / model_reset_at for the
+# pre-flight log line. Sourcing is no-op when CLAUDE_USAGE_SESSION_KEY is
+# unset (graceful fallback — see claude-usage.sh).
+source "$SCRIPT_DIR/claude-usage.sh"
+PLATFORM_DIR="$SCRIPT_DIR/platform"
+LOG_BASE="logs/batch-$(date +%Y%m%d-%H%M%S)"
+STATUS_FILE="status.json"
+LOCK_FILE="logs/.batch-orchestrator.lock"
+
+# pgid of the currently active per-issue orchestrator process group.
+# Set by process_issue() before blocking on wait; cleared on exit.
+# The batch-level TERM/EXIT cleanup trap uses this to kill the subtree.
+ACTIVE_ORCH_PGID=""
+
+# Skip reason set by validate_issue_for_processing(); read by process_issue()
+# to log and record why an issue was skipped in status.json.
+_SKIP_REASON=""
+
+# Epic-scope signal set by validate_issue_for_processing() when an issue is
+# flagged as epic-scope (see EPIC_SCOPE_MAX_TASKS). Epic issues concentrate
+# spend, so they are routed to split-first (skipped from a wholesale run)
+# rather than implemented in a single expensive pass. Empty when not epic.
+_EPIC_SCOPE=""
+
+# Epic-scope task-count threshold: an issue whose body carries more than this
+# many task/AC checkboxes is treated as epic-scope regardless of labels. Set
+# generously so ordinary multi-task issues are not flagged. Env-configurable.
+EPIC_SCOPE_MAX_TASKS="${EPIC_SCOPE_MAX_TASKS:-20}"
+
+# Per-batch cumulative token/cost budget ceiling (issue #583).  A second
+# circuit breaker alongside MAX_CONSECUTIVE_FAILURES: after every processed
+# issue the running batch tally is compared against these ceilings, and a hard
+# breach halts the loop with batch state `budget_exceeded` (exit code 2),
+# mirroring the consecutive-failure breaker.  Defaults are NON-BREAKING: 0 (or
+# empty) = disabled, so existing batches are unaffected until an operator opts
+# in.  A soft breach at BATCH_BUDGET_SOFT_PCT% of a ceiling warns once first.
+# Env-overridable for tuning and tests.
+MAX_BATCH_TOKENS="${MAX_BATCH_TOKENS:-0}"
+MAX_BATCH_COST_USD="${MAX_BATCH_COST_USD:-0}"
+BATCH_BUDGET_SOFT_PCT="${BATCH_BUDGET_SOFT_PCT:-80}"
+
+# Cumulative batch spend tally.  Summed after each process_issue from the same
+# per-issue cost_summary the batch already records (see process_issue).  Read
+# by check_batch_budget().  _BATCH_BUDGET_SOFT_WARNED latches the one-shot warn.
+_BATCH_TOKENS_USED=0
+_BATCH_COST_USED=0
+_BATCH_BUDGET_SOFT_WARNED=0
+
+# Timeouts and limits
+readonly ISSUE_TIMEOUT=10800  # 180 minutes per issue
+readonly MAX_CONSECUTIVE_FAILURES=3
+readonly RATE_LIMIT_BUFFER=60  # Extra seconds to wait after rate limit reset
+readonly RATE_LIMIT_DEFAULT_WAIT=3600  # Default 1 hour if we can't determine wait time
+# Maximum depth for auto-implementing follow-up issues.
+# Depth 1 = direct follow-ups of the primary batch issues.
+# Depth 2 = follow-ups of follow-ups.  Values >= 2 are surfaced as
+# warnings but NOT auto-implemented to prevent unbounded recursion.
+readonly MAX_FOLLOWUP_DEPTH=1
+
+# =============================================================================
+# ARGUMENT PARSING
+# =============================================================================
+
+MANIFEST=""
+ISSUES=""
+BRANCH=""
+AGENT=""
+ENRICH_FOLLOWUPS=false
+ENRICH_ALL_NEEDS_EXPLORE=false
+IMPLEMENT_FOLLOWUPS=false
+
+usage() {
+    echo "Usage: $0 --manifest <path>"
+    echo "       $0 --issues \"123,124,125\" --branch \"test\""
+    echo "       $0 --manifest <path> --agent react-frontend-developer"
+    echo ""
+    echo "Options:"
+    echo "  --manifest <path>   Path to manifest.json with issues and branch"
+    echo "  --issues <list>     Comma-separated list of issue numbers"
+    echo "  --branch <name>     Base branch for PRs"
+    echo "  --agent <name>      Agent for implement-issue stage (optional)"
+    echo "  --enrich-followups  After batch, enrich needs-explore issues created"
+    echo "                      during this run (calls /enrich-issue on each)"
+    echo "  --enrich-all-needs-explore"
+    echo "                      After batch, enrich ALL open needs-explore issues"
+    echo "                      regardless of creation time (implies --enrich-followups)"
+    echo "  --no-enrich-followups"
+    echo "                      Disable auto-enrichment of needs-explore follow-up"
+    echo "                      issues (overrides the default-on behaviour)"
+    echo "  --implement-followups"
+    echo "                      After batch, auto-implement follow-up issues created"
+    echo "                      during this run as a second wave (implies"
+    echo "                      --enrich-followups so needs-explore issues are"
+    echo "                      enriched before implementation)"
+    echo "  --no-implement-followups"
+    echo "                      Disable auto-implementation of follow-up issues"
+    echo "                      (overrides --implement-followups)"
+    echo ""
+    echo "Available agents:"
+    echo "  react-frontend-developer        React, Next.js, shadcn/ui, Tailwind"
+    echo "  fastify-backend-developer        TypeScript, Fastify, routes, services"
+    echo "  (none specified)                Default claude behavior"
+    echo ""
+    echo "Note: process-pr stage always uses code-reviewer agent"
+    exit 3
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --manifest)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --manifest requires a value" >&2; exit 3; }
+            MANIFEST="$2"
+            shift 2
+            ;;
+        --issues)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --issues requires a value" >&2; exit 3; }
+            ISSUES="$2"
+            shift 2
+            ;;
+        --branch)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --branch requires a value" >&2; exit 3; }
+            BRANCH="$2"
+            shift 2
+            ;;
+        --agent)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --agent requires a value" >&2; exit 3; }
+            AGENT="$2"
+            shift 2
+            ;;
+        --enrich-followups)
+            ENRICH_FOLLOWUPS=true
+            shift
+            ;;
+        --no-enrich-followups)
+            ENRICH_FOLLOWUPS=false
+            shift
+            ;;
+        --enrich-all-needs-explore)
+            ENRICH_FOLLOWUPS=true
+            ENRICH_ALL_NEEDS_EXPLORE=true
+            shift
+            ;;
+        --implement-followups)
+            IMPLEMENT_FOLLOWUPS=true
+            ENRICH_FOLLOWUPS=true
+            shift
+            ;;
+        --no-implement-followups)
+            IMPLEMENT_FOLLOWUPS=false
+            shift
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Load from manifest if provided
+if [[ -n "$MANIFEST" ]]; then
+    if [[ ! -f "$MANIFEST" ]]; then
+        echo "ERROR: Manifest file not found: $MANIFEST"
+        exit 3
+    fi
+    ISSUES=$(jq -r '.issues | join(",")' "$MANIFEST")
+    BRANCH=$(jq -r '.base_branch' "$MANIFEST")
+    # Load agent from manifest if not specified on command line
+    if [[ -z "$AGENT" ]]; then
+        AGENT=$(jq -r '.agent // empty' "$MANIFEST")
+    fi
+fi
+
+if [[ -z "$ISSUES" || -z "$BRANCH" ]]; then
+    echo "ERROR: Must provide --manifest or both --issues and --branch"
+    usage
+fi
+
+# Convert comma-separated to array
+IFS=',' read -ra ISSUE_ARRAY <<< "$ISSUES"
+
+# Load schemas as single-line JSON for CLI
+# Note: implement-issue now uses its own orchestrator script with separate schemas
+if [[ ! -f "$SCHEMA_DIR/process-pr.json" ]]; then
+    echo "ERROR: Schema not found: $SCHEMA_DIR/process-pr.json"
+    exit 3
+fi
+
+PROCESS_SCHEMA=$(jq -c . "$SCHEMA_DIR/process-pr.json")
+
+# =============================================================================
+# LOCKING
+# =============================================================================
+
+acquire_lock() {
+    mkdir -p "$(dirname "$LOCK_FILE")"
+
+    if [[ -f "$LOCK_FILE" ]]; then
+        local lock_pid
+        lock_pid=$(cat "$LOCK_FILE" 2>/dev/null)
+        if [[ -n "$lock_pid" ]] && kill -0 "$lock_pid" 2>/dev/null; then
+            echo "ERROR: Another batch is running (PID: $lock_pid)"
+            echo "Lock file: $LOCK_FILE"
+            echo "If stale, remove manually: rm $LOCK_FILE"
+            exit 3
+        fi
+        echo "Removing stale lock file (PID $lock_pid not running)"
+        rm -f "$LOCK_FILE"
+    fi
+
+    echo $$ > "$LOCK_FILE"
+}
+
+release_lock() {
+    if [[ -f "$LOCK_FILE" ]] && [[ "$(cat "$LOCK_FILE" 2>/dev/null)" == "$$" ]]; then
+        rm -f "$LOCK_FILE"
+    fi
+}
+
+# cleanup — kill the active per-issue orchestrator process group (if any) and
+# release the lock file.  Called from both the TERM and EXIT traps so that a
+# single signal to the batch always terminates the full orchestrator subtree.
+cleanup() {
+    [[ -n "$ACTIVE_ORCH_PGID" ]] && kill -- -"$ACTIVE_ORCH_PGID" 2>/dev/null
+    release_lock
+}
+
+trap 'cleanup; exit 143' TERM
+trap cleanup EXIT
+acquire_lock
+
+# =============================================================================
+# LOGGING
+# =============================================================================
+
+mkdir -p "$LOG_BASE"
+LOG_FILE="$LOG_BASE/orchestrator.log"
+
+log() {
+    local msg="[$(date -Iseconds)] $*"
+    printf '%s\n' "$msg" >> "$LOG_FILE"
+    printf '%s\n' "$msg" >&2
+}
+
+log_error() {
+    local msg="[$(date -Iseconds)] ERROR: $*"
+    printf '%s\n' "$msg" >> "$LOG_FILE"
+    printf '%s\n' "$msg" >&2
+}
+
+log_warn() {
+    local msg="[$(date -Iseconds)] WARN: $*"
+    printf '%s\n' "$msg" >> "$LOG_FILE"
+    printf '%s\n' "$msg" >&2
+}
+
+# =============================================================================
+# STRUCTURED EVENT EMISSION
+# =============================================================================
+#
+# emit_event <event_type> [key=value ...]
+#
+# Builds a JSON envelope with ts/run_id/event/stage and forwards it to
+# event-emit.sh, which validates against schemas/pipeline-event.json and
+# appends one JSONL line to $LOG_BASE/events.jsonl under flock.
+#
+# Design notes:
+#   - Parallel to existing text logs: every text-log call site that maps to one
+#     of the 8 event types (stage_start, stage_end, escalation, retry,
+#     model_call, rate_limit_hit, schema_validation_fail, status_change) gets
+#     a parallel emit_event call.  Text logs are retained verbatim for human
+#     debugging — see issue #180.
+#   - Safe-by-default: silently no-ops when event-emit.sh is missing or
+#     LOG_BASE is unset (e.g. during early init or when the helper has not yet
+#     landed in this branch).  A schema-invalid emit exits non-zero from
+#     event-emit.sh but never crashes the orchestrator (stderr-redirected,
+#     `|| true`).
+#   - run_id is derived from the LOG_BASE basename which already encodes
+#     issue+timestamp (e.g. "issue-180-20260502-183541").
+emit_event() {
+    local event_type="$1"
+    shift
+
+    # Parallel-task safety: if the helper hasn't been added yet (sub-issue
+    # tasks land out of order), skip silently rather than break the pipeline.
+    local emit_script="$SCRIPT_DIR/event-emit.sh"
+    if [[ ! -x "$emit_script" ]]; then
+        return 0
+    fi
+
+    # Skip if LOG_BASE isn't established yet (very early init paths).
+    if [[ -z "${LOG_BASE:-}" ]]; then
+        return 0
+    fi
+
+    local run_id="${LOG_BASE##*/}"
+
+    local -a jq_args=(
+        --arg ts "$(date -Iseconds)"
+        --arg run_id "$run_id"
+        --arg event "$event_type"
+    )
+    local filter='{ts: $ts, run_id: $run_id, event: $event}'
+
+    local kv key value safe_key json_value
+    for kv in "$@"; do
+        # Support `key:=value` for JSON-typed values (numbers, booleans, null)
+        # in addition to `key=value` for strings. Required because the schema
+        # types fields like attempt/max_attempts/stage_attempt as integer.
+        if [[ "$kv" == *":="* ]]; then
+            key="${kv%%:=*}"
+            value="${kv#*:=}"
+            json_value=true
+        else
+            key="${kv%%=*}"
+            value="${kv#*=}"
+            json_value=false
+        fi
+        # Defensive: only allow alphanumeric/underscore in keys to keep the
+        # generated jq filter safe.
+        safe_key="${key//[^A-Za-z0-9_]/}"
+        if [[ -z "$safe_key" ]]; then
+            continue
+        fi
+        if $json_value; then
+            jq_args+=(--argjson "$safe_key" "$value")
+        else
+            jq_args+=(--arg "$safe_key" "$value")
+        fi
+        filter+=" | .${safe_key} = \$${safe_key}"
+    done
+
+    local event_json
+    event_json=$(jq -nc "${jq_args[@]}" "$filter" 2>/dev/null) || return 0
+
+    LOG_DIR="$LOG_BASE" "$emit_script" "$event_json" >/dev/null 2>&1 || true
+}
+
+# =============================================================================
+# STATUS FILE MANAGEMENT
+# =============================================================================
+
+init_status() {
+    # Resume-awareness: when a status.json from a prior launch of this batch
+    # exists, preserve per-issue terminal state (completed/already_implemented)
+    # instead of resetting every issue to pending. Without this the
+    # idempotency skip in the primary loop is dead code — each relaunch
+    # would reset status to pending and re-run already-finished issues.
+    local prior_status="{}"
+    if [[ -f "$STATUS_FILE" ]]; then
+        # Build a {number: status} map of issues whose prior status was
+        # terminal. Non-terminal (pending/failed/in_progress) issues are
+        # intentionally omitted so they re-run on resume.
+        prior_status=$(jq -c '
+            [.issues[]?
+             | select(.status == "completed"
+                      or .status == "already_implemented")]
+            | map({(.number): .status})
+            | add // {}' "$STATUS_FILE" 2>/dev/null) || prior_status="{}"
+        if [[ -z "$prior_status" ]]; then
+            prior_status="{}"
+        fi
+    fi
+
+    local preserved_count=0
+    local issues_json="[]"
+    for issue in "${ISSUE_ARRAY[@]}"; do
+        local issue_status="pending"
+        local prior
+        prior=$(printf '%s' "$prior_status" \
+            | jq -r --arg num "$issue" '.[$num] // empty')
+        if [[ -n "$prior" ]]; then
+            issue_status="$prior"
+            preserved_count=$((preserved_count + 1))
+        fi
+        issues_json=$(printf '%s' "$issues_json" \
+            | jq --arg num "$issue" --arg status "$issue_status" '. + [{
+            "number": $num,
+            "status": $status,
+            "stage": null,
+            "pr": null,
+            "session_id": null,
+            "error": null,
+            "follow_ups": [],
+            "deploy_verify_failed": false,
+            "started_at": null,
+            "stage_started_at": null,
+            "completed_at": null,
+            "cost_usd": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0
+        }]')
+    done
+
+    local completed_count
+    completed_count=$(printf '%s' "$issues_json" \
+        | jq '[.[] | select(.status == "completed"
+                            or .status == "already_implemented")] | length')
+
+    jq -n \
+        --arg state "running" \
+        --arg branch "$BRANCH" \
+        --argjson total "${#ISSUE_ARRAY[@]}" \
+        --argjson completed "$completed_count" \
+        --argjson issues "$issues_json" \
+        --arg log_dir "$LOG_BASE" \
+        '{
+            state: $state,
+            base_branch: $branch,
+            current_issue: null,
+            progress: {
+                total: $total,
+                completed: $completed,
+                failed: 0,
+                skipped: 0,
+                merge_blocked: 0,
+                pending: ($total - $completed),
+                in_progress: 0
+            },
+            issues: $issues,
+            cost_summary: {
+                total_cost_usd: ($issues | map(.cost_usd // 0) | add // 0),
+                total_input_tokens:
+                    ($issues | map(.input_tokens // 0) | add // 0),
+                total_output_tokens:
+                    ($issues | map(.output_tokens // 0) | add // 0),
+                total_cache_read_tokens:
+                    ($issues | map(.cache_read_tokens // 0) | add // 0),
+                total_cache_creation_tokens:
+                    ($issues | map(.cache_creation_tokens // 0) | add // 0)
+            },
+            rate_limit: {
+                waiting: false,
+                resume_at: null,
+                session_id: null
+            },
+            last_update: (now | todate),
+            log_dir: $log_dir
+        }' > "$STATUS_FILE"
+
+    if ((preserved_count > 0)); then
+        log "Resuming batch: preserved $preserved_count completed issue(s)"
+    fi
+    log "Initialized status file: $STATUS_FILE"
+}
+
+update_issue_field() {
+    local issue_num="$1"
+    local field="$2"
+    local value="$3"
+    local is_json="${4:-false}"
+
+    if [[ "$is_json" == "true" ]]; then
+        jq --arg num "$issue_num" \
+           --arg field "$field" \
+           --argjson val "$value" \
+           '(.issues[] | select(.number == $num))[$field] = $val |
+            .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    else
+        jq --arg num "$issue_num" \
+           --arg field "$field" \
+           --arg val "$value" \
+           '(.issues[] | select(.number == $num))[$field] = $val |
+            .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    fi
+}
+
+update_progress() {
+    jq '.progress.completed =
+            ([.issues[] | select(.status == "completed"
+                or .status == "already_done")] | length) |
+        .progress.failed =
+            ([.issues[] | select(.status == "failed")] | length) |
+        .progress.skipped =
+            ([.issues[] | select(.status == "skipped")] | length) |
+        .progress.merge_blocked =
+            ([.issues[] | select(.status == "merge_blocked")] | length) |
+        .progress.in_progress =
+            ([.issues[] | select(.status == "in_progress")] | length) |
+        .progress.pending =
+            ([.issues[] | select(.status == "pending")] | length) |
+        .cost_summary.total_cost_usd =
+            ([.issues[] | (.cost_usd // 0)] | add // 0) |
+        .cost_summary.total_input_tokens =
+            ([.issues[] | (.input_tokens // 0)] | add // 0) |
+        .cost_summary.total_output_tokens =
+            ([.issues[] | (.output_tokens // 0)] | add // 0) |
+        .cost_summary.total_cache_read_tokens =
+            ([.issues[] | (.cache_read_tokens // 0)] | add // 0) |
+        .cost_summary.total_cache_creation_tokens =
+            ([.issues[] | (.cache_creation_tokens // 0)] | add // 0) |
+        .last_update = (now | todate)' \
+        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+}
+
+set_current_issue() {
+    local issue_num="$1"
+    jq --arg num "$issue_num" '.current_issue = $num | .last_update = (now | todate)' \
+        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+}
+
+set_rate_limit() {
+    local waiting="$1"
+    local resume_at="${2:-null}"
+    local session_id="${3:-null}"
+
+    if [[ "$resume_at" == "null" || -z "$resume_at" ]]; then
+        resume_at="null"
+    else
+        resume_at="\"$resume_at\""
+    fi
+
+    if [[ "$session_id" == "null" || -z "$session_id" ]]; then
+        session_id="null"
+    else
+        session_id="\"$session_id\""
+    fi
+
+    jq --argjson waiting "$waiting" \
+       --argjson resume "$resume_at" \
+       --argjson session "$session_id" \
+       '.rate_limit = {waiting: $waiting, resume_at: $resume, session_id: $session} |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+}
+
+set_state() {
+    local state="$1"
+    jq --arg state "$state" '.state = $state | .last_update = (now | todate)' \
+        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+}
+
+# Check the cumulative per-batch token/cost budget ceiling (issue #583).
+#
+# Uses the running tally accumulated in _BATCH_TOKENS_USED / _BATCH_COST_USED
+# after each process_issue (summed from every issue's cost_summary — the same
+# per-issue accounting the batch already records).  Returns:
+#   0 — within budget, OR only a soft breach (one-shot warning emitted, batch
+#       continues)
+#   1 — HARD breach: the caller halts the loop with state budget_exceeded
+#
+# Disabled (always returns 0) when both ceilings are unset/0, so existing
+# batches are unaffected.  Mirrors the consecutive-failure circuit breaker.
+check_batch_budget() {
+    local max_tokens="${MAX_BATCH_TOKENS:-0}"
+    local max_cost="${MAX_BATCH_COST_USD:-0}"
+    local soft_pct="${BATCH_BUDGET_SOFT_PCT:-80}"
+    local used_tokens="${_BATCH_TOKENS_USED:-0}"
+    local used_cost="${_BATCH_COST_USED:-0}"
+
+    # Disabled unless at least one ceiling is a positive value.
+    if awk -v t="$max_tokens" -v c="$max_cost" \
+        'BEGIN { exit !((t+0) <= 0 && (c+0) <= 0) }'; then
+        return 0
+    fi
+
+    local verdict
+    verdict=$(awk -v ut="$used_tokens" -v uc="$used_cost" \
+        -v mt="$max_tokens" -v mc="$max_cost" -v sp="$soft_pct" '
+        BEGIN {
+            hard = 0; soft = 0;
+            if (mt + 0 > 0) {
+                if (ut + 0 >= mt + 0) hard = 1;
+                else if (ut + 0 >= (mt + 0) * (sp + 0) / 100) soft = 1;
+            }
+            if (mc + 0 > 0) {
+                if (uc + 0 >= mc + 0) hard = 1;
+                else if (uc + 0 >= (mc + 0) * (sp + 0) / 100) soft = 1;
+            }
+            if (hard) print "hard";
+            else if (soft) print "soft";
+            else print "ok";
+        }')
+
+    case "$verdict" in
+        hard)
+            log_error "BATCH BUDGET CEILING:" \
+                "tokens=${used_tokens}/${max_tokens}" \
+                "cost=\$${used_cost}/\$${max_cost} —" \
+                "stopping batch (budget_exceeded)."
+            return 1
+            ;;
+        soft)
+            if (( ${_BATCH_BUDGET_SOFT_WARNED:-0} == 0 )); then
+                _BATCH_BUDGET_SOFT_WARNED=1
+                log_warn "Batch budget soft threshold reached (${soft_pct}%):" \
+                    "tokens=${used_tokens}/${max_tokens}" \
+                    "cost=\$${used_cost}/\$${max_cost}."
+            fi
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+# =============================================================================
+# RATE LIMIT DETECTION
+# =============================================================================
+
+detect_rate_limit() {
+    local output="$1"
+    local exit_code="${2:-0}"
+
+    # Check structured output first (most reliable)
+    local status
+    status=$(printf '%s' "$output" | jq -r '.structured_output.status // empty' 2>/dev/null)
+
+    # If structured output shows success, definitively NOT rate limited
+    if [[ "$status" == "success" || "$status" == "merged" || "$status" == "changes_requested" ]]; then
+        return 1
+    fi
+
+    # If structured output explicitly says rate_limit
+    if [[ "$status" == "rate_limit" ]]; then
+        return 0
+    fi
+
+    # Only check text patterns if structured output is empty/error (fallback detection)
+    # Check result text for rate limit indicators
+    local result
+    result=$(printf '%s' "$output" | jq -r '.result // empty' 2>/dev/null)
+    if echo "$result" | grep -qiE 'rate.limit|429|too many requests|quota.exceeded|secondary rate'; then
+        return 0
+    fi
+
+    # Check raw output only if JSON parsing failed (no valid structured_output)
+    # Use word boundaries to avoid matching field names like "rate_limit" in JSON
+    if [[ -z "$status" ]]; then
+        if echo "$output" | grep -qiE '\brate limit\b|HTTP 429|\btoo many requests\b|quota exceeded'; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+extract_wait_time() {
+    local output="$1"
+    local result
+    result=$(printf '%s' "$output" | jq -r '.result // empty' 2>/dev/null)
+
+    # Combine result and raw output for searching
+    local search_text="$result $output"
+
+    # Try to find retry-after seconds
+    local retry_after
+    retry_after=$(echo "$search_text" | grep -oiE 'retry.after[^0-9]*([0-9]+)' | grep -oE '[0-9]+' | head -1)
+    if [[ -n "$retry_after" ]] && (( retry_after > 0 )); then
+        echo "$retry_after"
+        return
+    fi
+
+    # Try to find "wait X minutes/hours"
+    local wait_mins
+    wait_mins=$(echo "$search_text" | grep -oiE 'wait[^0-9]*([0-9]+)[^0-9]*min' | grep -oE '[0-9]+' | head -1)
+    if [[ -n "$wait_mins" ]] && (( wait_mins > 0 )); then
+        echo $((wait_mins * 60))
+        return
+    fi
+
+    local wait_hours
+    wait_hours=$(echo "$search_text" | grep -oiE 'wait[^0-9]*([0-9]+)[^0-9]*hour' | grep -oE '[0-9]+' | head -1)
+    if [[ -n "$wait_hours" ]] && (( wait_hours > 0 )); then
+        echo $((wait_hours * 3600))
+        return
+    fi
+
+    # Default to configured wait time
+    echo "$RATE_LIMIT_DEFAULT_WAIT"
+}
+
+# =============================================================================
+# COMPOSITION ROUTING
+# =============================================================================
+#
+# dispatch_composition routes a claude invocation to one of two subprocess
+# paths:
+#
+#   1. isolated  (isolated=true)  — worktree-isolated subprocess with
+#      --dangerously-skip-permissions.  Used for implementation tasks that
+#      need to modify files in a fresh git worktree.
+#
+#   2. standard  (isolated=false) — plain subprocess WITHOUT
+#      --dangerously-skip-permissions.  Used for decision/review tasks like
+#      process-pr that orchestrate via interactive tools.
+#
+# ARCHITECTURAL CONSTRAINT: bash cannot invoke the Skill tool.
+# The Skill tool is a Claude Code API feature available only inside a Claude
+# session; it cannot be called from a bash subprocess.  Both paths therefore
+# call `claude -p` as a child process — the distinction is only in which
+# permission flags are forwarded.  Any "skill-tool path" naming in prior
+# versions of this file was aspirational and has been removed to avoid
+# confusion.
+#
+# Usage:
+#   dispatch_composition "<prompt>" [isolated] [extra claude args...]
+#
+# Arguments:
+#   prompt   — slash-command prompt (e.g. "/process-pr 1 2 main")
+#   isolated — "true" for isolated subprocess, "false"/omitted for standard
+#   ...      — additional flags forwarded to the claude invocation
+#
+# Kill-switch: COMPOSITION_BACKEND env var overrides auto-routing.
+#   subprocess — always use isolated subprocess path
+#   skill      — always use standard (non-sandboxed) subprocess path
+#                NOTE: "skill" is a legacy name; it does NOT invoke the Skill
+#                tool.  It selects the standard subprocess without
+#                --dangerously-skip-permissions.
+#   (unset)    — auto-route based on the isolated argument
+
+dispatch_composition() {
+	local prompt="$1"
+	local isolated="${2:-false}"
+	local -a extra_args=()
+	if (( $# > 2 )); then
+		shift 2
+		extra_args=("$@")
+	fi
+
+	local backend
+	if [[ -n "${COMPOSITION_BACKEND:-}" ]]; then
+		case "$COMPOSITION_BACKEND" in
+			subprocess|skill)
+				backend="$COMPOSITION_BACKEND"
+				;;
+			*)
+				printf 'ERROR: unknown COMPOSITION_BACKEND value: %s\n' \
+					"$COMPOSITION_BACKEND" >&2
+				return 1
+				;;
+		esac
+	elif [[ "$isolated" == "true" ]]; then
+		backend="subprocess"
+	else
+		backend="skill"
+	fi
+
+	case "$backend" in
+		subprocess)
+			run_composition_subprocess "$prompt" "${extra_args[@]+"${extra_args[@]}"}"
+			;;
+		# "skill" is the legacy kill-switch value; routes to the standard
+		# (non-sandboxed) subprocess path.  See ARCHITECTURAL CONSTRAINT note
+		# above.
+		skill)
+			run_composition_standard "$prompt" "${extra_args[@]+"${extra_args[@]}"}"
+			;;
+	esac
+}
+
+# context_mode_claude_args — print the claude(1) MCP flags for this arm.
+#
+# The ab-harness exports CONTEXT_MODE_ENABLED per arm (0 = control,
+# 1 = treatment) so the two arms differ ONLY in whether the context-mode
+# MCP plugin is active.  This translates that env var into claude flags;
+# without it both arms invoke claude identically and the A/B experiment is a
+# no-op — the original bug in issue #542.
+#
+#   CONTEXT_MODE_ENABLED=1   treatment: print nothing — the context-mode MCP
+#                            plugin loads normally from the user's Claude
+#                            config, so the arm runs WITH it enabled.
+#   CONTEXT_MODE_ENABLED=0   control: print --strict-mcp-config so claude
+#   (or unset)               ignores all externally configured MCP servers,
+#                            suppressing the context-mode plugin so the arm
+#                            runs WITHOUT it.
+#
+# Prints one flag per line (nothing for treatment); callers read the output
+# into an array and splice it into the claude argv.  Pure: stdout only, no
+# logging, so command substitution stays clean.
+context_mode_claude_args() {
+	if [[ "${CONTEXT_MODE_ENABLED:-0}" == "1" ]]; then
+		return 0
+	fi
+	printf '%s\n' "--strict-mcp-config"
+}
+
+# run_composition_subprocess — invoke a skill as a worktree-isolated subprocess.
+# Used for skills that require git worktree isolation (e.g. implement-issue).
+run_composition_subprocess() {
+	local prompt="$1"
+	shift
+	log "Composition dispatch → subprocess: $prompt"
+	local -a ctx_args=()
+	local _flag
+	while IFS= read -r _flag; do
+		[[ -n "$_flag" ]] && ctx_args+=("$_flag")
+	done < <(context_mode_claude_args)
+	timeout "$ISSUE_TIMEOUT" env -u CLAUDECODE claude -p "$prompt" \
+		--dangerously-skip-permissions \
+		--output-format json \
+		${ctx_args[@]+"${ctx_args[@]}"} \
+		"$@" \
+		2>&1
+}
+
+# run_composition_standard — invoke claude as a standard (non-sandboxed) subprocess.
+# Used for decision/review skills that do not require worktree isolation
+# (e.g. process-pr, plan, review).
+#
+# ARCHITECTURAL CONSTRAINT: bash cannot invoke the Skill tool.
+# This function is the successor to the former run_composition_skill(); it was
+# renamed because the old name implied a Skill-tool invocation, which bash
+# subprocesses cannot perform.  The implementation is a plain `claude -p`
+# call — identical to run_composition_subprocess() except that it omits
+# --dangerously-skip-permissions, allowing the spawned session to use
+# interactive tools and AskUserQuestion.
+#
+# Output format is not forced here — callers that need structured JSON must
+# pass --output-format json (and --json-schema) explicitly.
+run_composition_standard() {
+	local prompt="$1"
+	shift
+	log "Composition dispatch → standard: $prompt"
+	local -a ctx_args=()
+	local _flag
+	while IFS= read -r _flag; do
+		[[ -n "$_flag" ]] && ctx_args+=("$_flag")
+	done < <(context_mode_claude_args)
+	timeout "$ISSUE_TIMEOUT" env -u CLAUDECODE claude -p "$prompt" \
+		${ctx_args[@]+"${ctx_args[@]}"} \
+		"$@" \
+		2>&1
+}
+
+# =============================================================================
+# ISSUE PROCESSING
+# =============================================================================
+
+# revalidate_issue_after_enrich <issue_num>
+#
+# Re-fetch the issue body after an inline /enrich-issue run and re-check it
+# against assert_issue_valid. Enrichment can return rc=0 while still leaving a
+# body that fails structural validation; without this gate the orchestrator
+# would proceed to spin up implement-issue on an unparseable issue.
+#
+# Returns:
+#   0 — body now passes assert_issue_valid (proceed)
+#   1 — body was successfully re-fetched but is still invalid (skip)
+#
+# A gh re-fetch failure (network/auth error) is treated as non-fatal: the
+# function returns 0 so the orchestrator's own validation acts as the safety
+# net — mirroring validate_issue_for_processing's gh-failure policy.
+revalidate_issue_after_enrich() {
+	local issue_num="$1"
+
+	local issue_json
+	issue_json=$(gh issue view "$issue_num" --json body \
+		2>/dev/null) || return 0
+	[[ -z "$issue_json" ]] && return 0
+
+	local body
+	body=$(printf '%s' "$issue_json" \
+		| jq -r '.body // ""' 2>/dev/null) || return 0
+
+	assert_issue_valid "$body" 2>/dev/null
+}
+
+# validate_issue_for_processing <issue_num>
+#
+# Preflight check: verify the issue has a parseable "## Implementation Tasks"
+# section and no blocking "needs-explore" label before spinning up the
+# implement-issue orchestrator.
+#
+# Returns:
+#   0 — issue is valid (or was enriched inline); proceed with processing
+#   1 — issue must be skipped; sets _SKIP_REASON with a human-readable reason
+#
+# When ENRICH_FOLLOWUPS=true and a skip condition is detected, the function
+# calls /enrich-issue <num> inline instead of returning 1. If enrichment
+# fails, it falls back to returning 1 (skip).
+#
+# A gh failure (network/auth error) is treated as non-fatal: the function
+# returns 0 so the orchestrator's own issue-validation logic acts as the
+# safety net.
+
+validate_issue_for_processing() {
+	local issue_num="$1"
+	_SKIP_REASON=""
+
+	local issue_json
+	issue_json=$(gh issue view "$issue_num" --json body,labels \
+		2>/dev/null) || return 0
+	[[ -z "$issue_json" ]] && return 0
+
+	# -----------------------------------------------------------------
+	# Check 1: blocking needs-explore label
+	# -----------------------------------------------------------------
+	local has_needs_explore
+	has_needs_explore=$(printf '%s' "$issue_json" \
+		| jq -r '[.labels[].name] | any(. == "needs-explore")' \
+		2>/dev/null) || has_needs_explore="false"
+
+	if [[ "$has_needs_explore" == "true" ]]; then
+		if [[ "$ENRICH_FOLLOWUPS" == true ]]; then
+			log "Preflight #$issue_num: needs-explore label" \
+				"— enriching inline"
+			local enrich_out enrich_rc
+			enrich_out=$(dispatch_composition \
+				"/enrich-issue $issue_num" false 2>&1)
+			enrich_rc=$?
+			if (( enrich_rc != 0 )); then
+				log_warn \
+					"Preflight #$issue_num: enrich-issue" \
+					"failed (rc=$enrich_rc) — skipping"
+				[[ -n "$enrich_out" ]] && \
+					log_warn \
+						"Preflight #$issue_num:" \
+						"enrich output: $enrich_out"
+				_SKIP_REASON="needs-explore label (enrich-issue failed)"
+				return 1
+			fi
+			if ! revalidate_issue_after_enrich "$issue_num"; then
+				log_warn \
+					"Preflight #$issue_num: enriched but" \
+					"body still invalid — skipping"
+				_SKIP_REASON="needs-explore label (still invalid after enrich)"
+				return 1
+			fi
+			log "Preflight #$issue_num: enriched inline — proceeding"
+			return 0
+		fi
+		_SKIP_REASON="needs-explore label"
+		return 1
+	fi
+
+	# -----------------------------------------------------------------
+	# Check 1b: epic-scope flag — route oversized issues to split-first
+	#
+	# Epic-scope issues concentrate spend (claude-spend: 48 epic-scope runs
+	# used 35% of tokens). Detect them at preflight — via an `epic`/
+	# `epic-scope` label or an oversized body (more than EPIC_SCOPE_MAX_TASKS
+	# task/AC checkboxes) — set _EPIC_SCOPE, and route to split-first by
+	# skipping the wholesale run so the issue is broken into sub-issues first.
+	# -----------------------------------------------------------------
+	_EPIC_SCOPE=""
+	local has_epic_label epic_body epic_task_count
+	has_epic_label=$(printf '%s' "$issue_json" \
+		| jq -r '[.labels[].name] | any(. == "epic" or . == "epic-scope")' \
+		2>/dev/null) || has_epic_label="false"
+	epic_body=$(printf '%s' "$issue_json" \
+		| jq -r '.body // ""' 2>/dev/null) || epic_body=""
+	epic_task_count=$(printf '%s' "$epic_body" \
+		| grep -cE '^[[:space:]]*[-*] \[[ xX]\]' 2>/dev/null) \
+		|| epic_task_count=0
+
+	if [[ "$has_epic_label" == "true" ]] \
+		|| (( epic_task_count > EPIC_SCOPE_MAX_TASKS )); then
+		if [[ "$has_epic_label" == "true" ]]; then
+			_EPIC_SCOPE="epic label"
+		else
+			_EPIC_SCOPE="oversized body ($epic_task_count checkboxes > $EPIC_SCOPE_MAX_TASKS)"
+		fi
+		log_warn "Preflight #$issue_num: epic-scope ($_EPIC_SCOPE)" \
+			"— routing to split-first"
+		_SKIP_REASON="epic-scope — split into sub-issues first ($_EPIC_SCOPE)"
+		return 1
+	fi
+
+	# -----------------------------------------------------------------
+	# Check 2: missing or unparseable ## Implementation Tasks section
+	# -----------------------------------------------------------------
+	local body
+	body=$(printf '%s' "$issue_json" \
+		| jq -r '.body // ""' 2>/dev/null) || body=""
+
+	if ! printf '%s' "$body" | grep -q '## Implementation Tasks'; then
+		if [[ "$ENRICH_FOLLOWUPS" == true ]]; then
+			log "Preflight #$issue_num: missing ## Implementation Tasks" \
+				"— enriching inline"
+			local enrich_out enrich_rc
+			enrich_out=$(dispatch_composition \
+				"/enrich-issue $issue_num" false 2>&1)
+			enrich_rc=$?
+			if (( enrich_rc != 0 )); then
+				log_warn \
+					"Preflight #$issue_num: enrich-issue" \
+					"failed (rc=$enrich_rc) — skipping"
+				[[ -n "$enrich_out" ]] && \
+					log_warn \
+						"Preflight #$issue_num:" \
+						"enrich output: $enrich_out"
+				_SKIP_REASON="missing ## Implementation Tasks (enrich-issue failed)"
+				return 1
+			fi
+			if ! revalidate_issue_after_enrich "$issue_num"; then
+				log_warn \
+					"Preflight #$issue_num: enriched but" \
+					"body still invalid — skipping"
+				_SKIP_REASON="missing ## Implementation Tasks (still invalid after enrich)"
+				return 1
+			fi
+			log "Preflight #$issue_num: enriched inline — proceeding"
+			return 0
+		fi
+		_SKIP_REASON="missing ## Implementation Tasks"
+		return 1
+	fi
+
+	# -----------------------------------------------------------------
+	# Check 3: structural validation for pipeline-autocreated bodies
+	# and any body that already carries ## Implementation Tasks.
+	# Non-pipeline issues without that section are not subject to
+	# assert_issue_valid — they may use prose task formats.
+	# -----------------------------------------------------------------
+	if printf '%s' "$body" \
+		| grep -qE '<!-- pipeline-autocreated -->|## Implementation Tasks'; then
+		local valid_errs valid_rc
+		valid_errs=$(assert_issue_valid "$body" 2>&1 >/dev/null)
+		valid_rc=$?
+		if (( valid_rc != 0 )); then
+			while IFS= read -r diag_line; do
+				[[ -n "$diag_line" ]] && \
+					log_warn "Preflight #$issue_num: $diag_line"
+			done <<< "$valid_errs"
+			if [[ "$ENRICH_FOLLOWUPS" == true ]] \
+				&& printf '%s' "$body" \
+					| grep -q '<!-- pipeline-autocreated -->'; then
+				log "Preflight #$issue_num: body failed structural" \
+					"validation — enriching inline"
+				local enrich_out enrich_rc
+				enrich_out=$(dispatch_composition \
+					"/enrich-issue $issue_num" false 2>&1)
+				enrich_rc=$?
+				if (( enrich_rc != 0 )); then
+					log_warn \
+						"Preflight #$issue_num: enrich-issue" \
+						"failed (rc=$enrich_rc) — skipping"
+					[[ -n "$enrich_out" ]] && \
+						log_warn \
+							"Preflight #$issue_num:" \
+							"enrich output: $enrich_out"
+					_SKIP_REASON="body failed structural validation (enrich-issue failed)"
+					return 1
+				fi
+				if ! revalidate_issue_after_enrich "$issue_num"; then
+					log_warn \
+						"Preflight #$issue_num: enriched but" \
+						"body still invalid — skipping"
+					_SKIP_REASON="body failed structural validation (still invalid after enrich)"
+					return 1
+				fi
+				log "Preflight #$issue_num: enriched inline — proceeding"
+				return 0
+			fi
+			_SKIP_REASON="body failed structural validation"
+			return 1
+		fi
+	fi
+
+	return 0
+}
+
+process_issue() {
+    local issue_num="$1"
+    local issue_log="$LOG_BASE/issue-$issue_num.log"
+
+    log "=========================================="
+    log "Starting issue #$issue_num"
+    log "=========================================="
+    emit_event "issue_start" "issue_num=$issue_num"
+
+    # ---------------------------------------------------------------
+    # Preflight: validate issue has parseable tasks and no blocking
+    # labels before spinning up the implement-issue orchestrator.
+    # A validation failure is non-fatal (returns 0 to the caller) so
+    # it does NOT increment consecutive_failures or trigger the
+    # circuit breaker. When ENRICH_FOLLOWUPS=true the issue is
+    # enriched inline rather than skipped.
+    # ---------------------------------------------------------------
+    if ! validate_issue_for_processing "$issue_num"; then
+        log_warn \
+            "Skipping issue #$issue_num:" \
+            "${_SKIP_REASON:-preflight validation failed}"
+        update_issue_field "$issue_num" "status" "skipped"
+        update_issue_field \
+            "$issue_num" "error" \
+            "${_SKIP_REASON:-preflight validation failed}"
+        update_progress
+        return 0
+    fi
+
+    set_current_issue "$issue_num"
+    update_issue_field "$issue_num" "status" "in_progress"
+    update_issue_field "$issue_num" "started_at" "$(date -Iseconds)"
+    update_issue_field "$issue_num" "stage" "implement-issue"
+    update_issue_field "$issue_num" "stage_started_at" "$(date -Iseconds)"
+    update_progress
+
+    # Set up feature branch for this issue
+    local feature_branch="feature/issue-$issue_num"
+    log "Setting up feature branch: $feature_branch"
+    git checkout "$BRANCH" 2>/dev/null
+    git pull --ff-only 2>/dev/null || true
+    if git show-ref --verify --quiet "refs/heads/$feature_branch" 2>/dev/null; then
+        git checkout "$feature_branch" 2>/dev/null
+    else
+        git checkout -b "$feature_branch" "$BRANCH" 2>/dev/null
+    fi
+
+    # -------------------------------------------------------------------------
+    # IMPLEMENT-ISSUE (via orchestrator script)
+    # -------------------------------------------------------------------------
+    local issue_status_file="$LOG_BASE/issue-$issue_num-status.json"
+
+    local -a agent_args=()
+    if [[ -n "$AGENT" ]]; then
+        agent_args=(--agent "$AGENT")
+    fi
+
+    log "Running: implement-issue-orchestrator.sh --issue $issue_num --branch $BRANCH ${agent_args[@]+"${agent_args[@]}"}"
+
+    local impl_exit=0
+    local orch_pgid=""
+
+    # Named pipe: lets tee fan orchestrator output to log and stdout
+    # while keeping the orchestrator in its own tracked process group.
+    local orch_out_fifo="$LOG_BASE/issue-$issue_num-out.fifo"
+    rm -f "$orch_out_fifo"
+    mkfifo "$orch_out_fifo" || {
+        log_error "mkfifo failed: $orch_out_fifo — cannot track pgid"
+        return 1
+    }
+
+    printf '%s\n' "=== implement-issue output ===" >> "$issue_log"
+
+    # tee reads from the fifo: writes to log file and stdout for live view.
+    tee -a "$issue_log" < "$orch_out_fifo" &
+    local tee_pid=$!
+
+    # Launch orchestrator in its own process group via setsid so the batch
+    # can terminate the entire subtree with one signal.
+    # After setsid the new process is its own session leader: pid == pgid.
+    setsid "$SCRIPT_DIR/implement-issue-orchestrator.sh" \
+        --issue "$issue_num" \
+        --branch "$BRANCH" \
+        ${agent_args[@]+"${agent_args[@]}"} \
+        --status-file "$issue_status_file" \
+        > "$orch_out_fifo" 2>&1 &
+    local orch_pid=$!
+    orch_pgid=$orch_pid  # setsid: pid == pgid for the new session leader
+    ACTIVE_ORCH_PGID=$orch_pgid  # expose to batch-level TERM/EXIT trap (#394)
+
+    # The fifo name is no longer needed; both ends hold open file descriptors.
+    rm -f "$orch_out_fifo"
+
+    log "Orchestrator PID=$orch_pid PGID=$orch_pgid (issue #$issue_num)"
+
+    wait "$orch_pid"
+    impl_exit=$?
+    wait "$tee_pid"  # Flush tee before reading status file
+
+    ACTIVE_ORCH_PGID=""  # Clear: orchestrator has exited
+    printf '%s\n' "=== exit code: $impl_exit ===" >> "$issue_log"
+
+    # Parse result from status file
+    local impl_status="error"
+    local pr_number=""
+    local impl_error=""
+
+    if [[ -f "$issue_status_file" ]]; then
+        local state
+        state=$(jq -r '.state' "$issue_status_file")
+
+        # Map script states to expected values
+        case "$state" in
+            completed)
+                impl_status="success"
+                # Extract PR number from stages.pr or from the status file
+                pr_number=$(jq -r '.stages.pr.pr_number // empty' "$issue_status_file" 2>/dev/null)
+                ;;
+            already_implemented)
+                impl_status="already_implemented"
+                ;;
+            merge_blocked)
+                impl_status="merge_blocked"
+                pr_number=$(jq -r '.stages.pr.pr_number // empty' "$issue_status_file" 2>/dev/null)
+                log "PR #${pr_number:-?} left open — merge blocked by quality gate"
+                ;;
+            completed_partial)
+                # Issue #577: partial delivery (not all tasks completed, or the
+                # PR review never approved).  Handle it like merge_blocked —
+                # leave the PR open and record it — rather than letting it fall
+                # to the *) error arm, where the PR-recovery logic below would
+                # wrongly flip it to success because a PR number exists.
+                impl_status="merge_blocked"
+                pr_number=$(jq -r '.stages.pr.pr_number // empty' "$issue_status_file" 2>/dev/null)
+                log "PR #${pr_number:-?} left open — partial delivery (not all tasks completed / review unresolved)"
+                ;;
+            budget_exceeded)
+                # Issue #583: the per-run token/cost ceiling halted the
+                # orchestrator cleanly before completion.  Treat it as terminal
+                # like merge_blocked — leave any PR open, record it, and do NOT
+                # let the recovery arm below flip it to success on a stray PR
+                # number.  This is a spend-halt, never an escalate/retry.
+                impl_status="budget_exceeded"
+                pr_number=$(jq -r '.stages.pr.pr_number // empty' "$issue_status_file" 2>/dev/null)
+                log "Issue #$issue_num halted — per-run budget ceiling exceeded (budget_exceeded)"
+                ;;
+            error|max_iterations_quality|max_iterations_pr_review)
+                impl_status="error"
+                impl_error="Script exited with state: $state"
+                ;;
+            interrupted_during_*)
+                local interrupted_stage="${state#interrupted_during_}"
+                impl_status="error"
+                impl_error="Orchestrator interrupted during: $interrupted_stage"
+                log_warn "orchestrator interrupted during $interrupted_stage"
+                ;;
+            *)
+                impl_status="error"
+                impl_error="Unknown state: $state"
+                ;;
+        esac
+
+        # Recovery: if the orchestrator exited with a non-completed state but
+        # stages.pr.pr_number was already written (PR created before crash),
+        # treat it as recoverable success. Handles the case where the script is
+        # killed or crashes after PR creation but before set_final_state("completed").
+        if [[ "$impl_status" == "error" ]]; then
+            local recovered_pr stuck_stage
+            recovered_pr=$(jq -r '.stages.pr.pr_number // empty' "$issue_status_file" 2>/dev/null)
+            # Name the stage the orchestrator was on when it exited so a masked
+            # hang is visibly diagnosed instead of silently absorbed.
+            stuck_stage=$(jq -r '.current_stage // "unknown"' "$issue_status_file" 2>/dev/null)
+            [[ -n "$stuck_stage" ]] || stuck_stage="unknown"
+            if [[ -n "$recovered_pr" && "$recovered_pr" =~ ^[0-9]+$ ]]; then
+                log_warn "Orchestrator exited with state='$state' (stuck at: $stuck_stage) but PR #$recovered_pr exists — recovering as success"
+                impl_status="success"
+                pr_number="$recovered_pr"
+                impl_error=""
+            fi
+        fi
+    else
+        impl_error="Status file not created"
+    fi
+
+    log "implement-issue status: $impl_status, PR: ${pr_number:-none}"
+
+    # Cost accounting: the sub-orchestrator aggregates the cost of every
+    # CLI call it makes into a run-level cost_summary on its own status
+    # file. Record it now — before any early return below — so partial
+    # runs (skipped/merge_blocked/failed) still surface their spend in
+    # the batch cost_summary rollup. `// 0` degrades to zero when the
+    # field is absent rather than corrupting status.json.
+    local impl_cost_usd="0"
+    local impl_input_tokens="0" impl_output_tokens="0"
+    local impl_cache_read_tokens="0" impl_cache_creation_tokens="0"
+    if [[ -f "$issue_status_file" ]]; then
+        impl_cost_usd=$(jq -r '.cost_summary.total_cost_usd // 0' \
+            "$issue_status_file" 2>/dev/null) || impl_cost_usd="0"
+        impl_input_tokens=$(jq -r '.cost_summary.total_input_tokens // 0' \
+            "$issue_status_file" 2>/dev/null) || impl_input_tokens="0"
+        impl_output_tokens=$(jq -r '.cost_summary.total_output_tokens // 0' \
+            "$issue_status_file" 2>/dev/null) || impl_output_tokens="0"
+        impl_cache_read_tokens=$(jq -r \
+            '.cost_summary.total_cache_read_tokens // 0' \
+            "$issue_status_file" 2>/dev/null) || impl_cache_read_tokens="0"
+        impl_cache_creation_tokens=$(jq -r \
+            '.cost_summary.total_cache_creation_tokens // 0' \
+            "$issue_status_file" 2>/dev/null) || impl_cache_creation_tokens="0"
+    fi
+    update_issue_field "$issue_num" "cost_usd" "$impl_cost_usd" "true"
+    update_issue_field "$issue_num" "input_tokens" \
+        "$impl_input_tokens" "true"
+    update_issue_field "$issue_num" "output_tokens" \
+        "$impl_output_tokens" "true"
+    update_issue_field "$issue_num" "cache_read_tokens" \
+        "$impl_cache_read_tokens" "true"
+    update_issue_field "$issue_num" "cache_creation_tokens" \
+        "$impl_cache_creation_tokens" "true"
+
+    # Feed the cumulative per-batch spend tally (issue #583) from the same
+    # per-issue cost_summary read above.  Runs before every early return so
+    # partial/failed/skipped issues still count toward the batch ceiling. The
+    # tally is checked by check_batch_budget() in the main loop after this
+    # function returns.  Tokens are integer; cost is a float summed via awk.
+    local impl_tokens="0"
+    if [[ -f "$issue_status_file" ]]; then
+        impl_tokens=$(jq -r '(.cost_summary.total_input_tokens // 0) + (.cost_summary.total_output_tokens // 0) + (.cost_summary.total_cache_read_tokens // 0) + (.cost_summary.total_cache_creation_tokens // 0)' \
+            "$issue_status_file" 2>/dev/null) || impl_tokens="0"
+    fi
+    [[ -n "$impl_tokens" ]] || impl_tokens=0
+    _BATCH_TOKENS_USED=$(( ${_BATCH_TOKENS_USED:-0} + impl_tokens ))
+    _BATCH_COST_USED=$(awk -v a="${_BATCH_COST_USED:-0}" -v b="${impl_cost_usd:-0}" \
+        'BEGIN { printf "%.6f", (a + 0) + (b + 0) }')
+
+    # Log location of metrics.json emitted by the orchestrator's EXIT trap
+    if [[ -f "$issue_status_file" ]]; then
+        local issue_log_dir
+        issue_log_dir=$(jq -r '.log_dir // empty' "$issue_status_file" 2>/dev/null)
+        if [[ -n "$issue_log_dir" && -f "$issue_log_dir/metrics.json" ]]; then
+            log "Metrics available: $issue_log_dir/metrics.json"
+        fi
+    fi
+
+    # Propagate non-blocking deploy-verify failure flag from per-issue
+    # status file to batch status.json. The deploy-verify stage is
+    # intentionally non-blocking: a failed deploy command does NOT fail
+    # the issue, but the failure must surface in the batch post-run
+    # summary so operators can investigate the deployment.
+    # implement-issue-orchestrator.sh appends entries of the form
+    # "deploy_verify:<reason>:..." to the .degraded_stages array when a
+    # deploy-verify step fails (set by DEGRADED_STAGES in the orchestrator).
+    if [[ -f "$issue_status_file" ]]; then
+        local dv_cmd_failed
+        dv_cmd_failed=$(jq -r \
+            '[.degraded_stages[]? | select(startswith("deploy_verify:"))] | length > 0' \
+            "$issue_status_file" 2>/dev/null) || dv_cmd_failed=false
+        if [[ "$dv_cmd_failed" == "true" ]]; then
+            log_warn \
+                "Issue #$issue_num: deploy-verify command failed" \
+                "(non-blocking — see issue comment for details)"
+            update_issue_field \
+                "$issue_num" "deploy_verify_failed" "true" "true"
+        fi
+    fi
+
+    if [[ "$impl_status" == "already_implemented" ]]; then
+        log "Issue #$issue_num was already implemented in a prior run — skipping PR creation."
+        update_issue_field "$issue_num" "status" "already_done"
+        update_progress
+        git checkout "$BRANCH" 2>/dev/null || true
+        return 0
+    fi
+
+    if [[ "$impl_status" == "merge_blocked" ]]; then
+        log "Issue #$issue_num PR #${pr_number:-?} left open — merge blocked by quality gate."
+        update_issue_field "$issue_num" "status" "merge_blocked"
+        if [[ -n "$pr_number" ]]; then
+            update_issue_field "$issue_num" "pr" "$pr_number" "true"
+        fi
+        update_progress
+        git checkout "$BRANCH" 2>/dev/null || true
+        return 0
+    fi
+
+    if [[ "$impl_status" == "budget_exceeded" ]]; then
+        # Issue #583: per-run budget ceiling halted this issue.  Record it as a
+        # terminal spend-halt (not a failure) and leave any PR open, mirroring
+        # merge_blocked.  Returning 0 keeps it out of consecutive_failures — the
+        # per-BATCH ceiling (check_batch_budget) is what stops the whole batch;
+        # a single over-budget issue does not, since the next issue starts fresh
+        # against its own per-run ceiling.
+        log "Issue #$issue_num PR #${pr_number:-?} left open — per-run budget ceiling exceeded."
+        update_issue_field "$issue_num" "status" "budget_exceeded"
+        if [[ -n "$pr_number" ]]; then
+            update_issue_field "$issue_num" "pr" "$pr_number" "true"
+        fi
+        update_progress
+        git checkout "$BRANCH" 2>/dev/null || true
+        return 0
+    fi
+
+    if [[ "$impl_status" != "success" ]]; then
+        log_error "implement-issue failed for #$issue_num: ${impl_error:-unknown error}"
+        update_issue_field "$issue_num" "status" "failed"
+        update_issue_field "$issue_num" "error" "${impl_error:-implement-issue failed with status: $impl_status}"
+        update_progress
+        git checkout "$BRANCH" 2>/dev/null || true
+        return 1
+    fi
+
+    if [[ -z "$pr_number" ]]; then
+        log_error "implement-issue succeeded but no PR number found for #$issue_num"
+        update_issue_field "$issue_num" "status" "failed"
+        update_issue_field "$issue_num" "error" "No PR number in status file or output"
+        update_progress
+        git checkout "$BRANCH" 2>/dev/null || true
+        return 1
+    fi
+    log "implement-issue complete. PR #$pr_number created"
+    update_issue_field "$issue_num" "pr" "$pr_number" "true"
+    update_issue_field "$issue_num" "stage" "process-pr"
+
+    # -------------------------------------------------------------------------
+    # PROCESS-PR (always uses code-reviewer agent)
+    # -------------------------------------------------------------------------
+    log "Running: claude -p \"/process-pr $pr_number $issue_num $BRANCH\" --agent code-reviewer --json-schema ..."
+
+    local proc_exit=0
+
+    printf '%s\n' "=== process-pr output ===" >> "$issue_log"
+    dispatch_composition "/process-pr $pr_number $issue_num $BRANCH" "false" \
+        --agent code-reviewer \
+        --output-format json \
+        --json-schema "$PROCESS_SCHEMA" \
+        | tee -a "$issue_log"
+    proc_exit=${PIPESTATUS[0]}
+    printf '%s\n' "=== exit code: $proc_exit ===" >> "$issue_log"
+
+    # Update session ID from last JSON line in log
+    local session_id
+    session_id=$(grep -E '^\{' "$issue_log" | tail -1 | jq -r '.session_id // empty' 2>/dev/null)
+    if [[ -n "$session_id" ]]; then
+        update_issue_field "$issue_num" "session_id" "$session_id"
+    fi
+
+    # Check for rate limit
+    local proc_last_json
+    proc_last_json=$(grep -E '^\{' "$issue_log" | tail -1)
+    if detect_rate_limit "$proc_last_json" "$proc_exit"; then
+        local wait_time
+        wait_time=$(extract_wait_time "$proc_last_json")
+        wait_time=$((wait_time + RATE_LIMIT_BUFFER))
+        local resume_at
+        resume_at=$(date -Iseconds -d "+${wait_time} seconds" 2>/dev/null || date -v+${wait_time}S -Iseconds 2>/dev/null)
+
+        log "Rate limit hit during process-pr. Waiting ${wait_time}s"
+        emit_event "rate_limit_hit" "stage=process-pr" "retry_after_seconds:=$wait_time"
+        set_rate_limit "true" "$resume_at" "$session_id"
+
+        sleep "$wait_time"
+
+        set_rate_limit "false" "" ""
+
+        # Resume — retry-with-backoff: parent already slept for the rate-limit
+        # window; restart fresh rather than resuming with "please continue"
+        # (the --resume subprocess is replaced by a clean retry here).
+        printf '%s\n' "=== process-pr resume output ===" >> "$issue_log"
+        dispatch_composition "/process-pr $pr_number $issue_num $BRANCH" "false" \
+            --agent code-reviewer \
+            --output-format json \
+            --json-schema "$PROCESS_SCHEMA" \
+            | tee -a "$issue_log"
+        proc_exit=${PIPESTATUS[0]}
+        proc_last_json=$(grep -E '^\{' "$issue_log" | tail -1)
+    fi
+
+    # Check for timeout
+    if (( proc_exit == 124 )); then
+        log_error "Issue #$issue_num timed out during process-pr (${ISSUE_TIMEOUT}s)"
+        update_issue_field "$issue_num" "status" "failed"
+        update_issue_field "$issue_num" "error" "Timeout after ${ISSUE_TIMEOUT}s during process-pr"
+        update_progress
+        git checkout "$BRANCH" 2>/dev/null || true
+        return 1
+    fi
+
+    # Parse structured output
+    local proc_status
+    local follow_ups
+    local proc_error
+
+    proc_status=$(printf '%s' "$proc_last_json" | jq -r '.structured_output.status // "error"' 2>/dev/null)
+    follow_ups=$(printf '%s' "$proc_last_json" | jq -c '.structured_output.follow_up_issues // []' 2>/dev/null)
+    proc_error=$(printf '%s' "$proc_last_json" | jq -r '.structured_output.error // empty' 2>/dev/null)
+
+    log "process-pr status: $proc_status"
+
+    case "$proc_status" in
+        merged)
+            log "Issue #$issue_num completed. PR #$pr_number merged."
+            update_issue_field "$issue_num" "status" "completed"
+            update_issue_field "$issue_num" "completed_at" "$(date -Iseconds)"
+            update_issue_field "$issue_num" "follow_ups" "$follow_ups" "true"
+            # Push feature branch and return to base
+            git push -u origin "$feature_branch" 2>/dev/null || true
+            git checkout "$BRANCH" 2>/dev/null || true
+            ;;
+        changes_requested)
+            # process-pr handles re-implementation internally by calling implement-issue again
+            # If we get here with changes_requested, it means the re-implementation cycle completed
+            log "Issue #$issue_num: changes were requested and addressed"
+            update_issue_field "$issue_num" "status" "completed"
+            update_issue_field "$issue_num" "completed_at" "$(date -Iseconds)"
+            ;;
+        error|rate_limit|*)
+            log_error "process-pr failed for #$issue_num: ${proc_error:-status was $proc_status}"
+            update_issue_field "$issue_num" "status" "failed"
+            update_issue_field "$issue_num" "error" "${proc_error:-process-pr failed with status: $proc_status}"
+            update_progress
+            git checkout "$BRANCH" 2>/dev/null || true
+            return 1
+            ;;
+    esac
+
+    update_progress
+    return 0
+}
+
+# =============================================================================
+# POST-BATCH SWEEP: enrich needs-explore follow-up issues
+# =============================================================================
+#
+# sweep_enrich_followups — called after the primary issue loop when
+# --enrich-followups is set.  Queries gh for every open issue tagged
+# needs-explore that was created since BATCH_START_TIME, then invokes
+# /enrich-issue N on each one via dispatch_composition.
+#
+# Design notes:
+#   - Scoped to this batch run via BATCH_START_TIME — avoids touching
+#     follow-ups from prior batches.
+#   - Failures are logged as warnings only; they do NOT increment
+#     consecutive_failures and do NOT trigger the circuit breaker.
+#   - Uses dispatch_composition (non-isolated path) so the enrich-issue
+#     skill can use interactive tools (gh, MCP, etc.) without a worktree.
+
+sweep_enrich_followups() {
+	log "========================================"
+	log "Post-batch sweep: needs-explore issues"
+	log "========================================"
+	log "Batch start time: $BATCH_START_TIME"
+
+	local found_issues
+	if [[ "$ENRICH_ALL_NEEDS_EXPLORE" == true ]]; then
+		log "Sweep: --enrich-all-needs-explore set — including ALL open needs-explore issues"
+		found_issues=$(gh issue list \
+			--label needs-explore \
+			--state open \
+			--limit 1000 \
+			--json number,createdAt \
+			2>/dev/null \
+			| jq -r '.[].number' \
+			2>/dev/null) || found_issues=""
+	else
+		found_issues=$(gh issue list \
+			--label needs-explore \
+			--state open \
+			--limit 1000 \
+			--json number,createdAt \
+			2>/dev/null \
+			| jq -r --arg since "$BATCH_START_TIME" \
+			'[.[] | select(.createdAt >= $since)] | .[].number' \
+			2>/dev/null) || found_issues=""
+	fi
+
+	if [[ -z "$found_issues" ]]; then
+		log "Sweep: no needs-explore issues found since $BATCH_START_TIME"
+		return 0
+	fi
+
+	local issue_num
+	while IFS= read -r issue_num; do
+		[[ -z "$issue_num" ]] && continue
+		log "Sweep: enriching issue #$issue_num"
+		local enrich_output enrich_rc
+		enrich_output=$(dispatch_composition \
+			"/enrich-issue $issue_num" false 2>&1)
+		enrich_rc=$?
+		if (( enrich_rc != 0 )); then
+			log_warn \
+				"Sweep: enrich-issue #$issue_num failed (rc=$enrich_rc)" \
+				"— skipping, batch unaffected"
+			[[ -n "$enrich_output" ]] && \
+				log_warn "Sweep: enrich-issue #$issue_num output: $enrich_output"
+		else
+			log "Sweep: enriched issue #$issue_num successfully"
+		fi
+	done <<< "$found_issues"
+
+	log "Sweep: done"
+}
+
+# =============================================================================
+# POST-BATCH SWEEP: implement follow-up issues (second wave)
+# =============================================================================
+#
+# sweep_implement_followups — called after the primary issue loop (and after
+# sweep_enrich_followups when ENRICH_FOLLOWUPS=true) when --implement-followups
+# is set.  Collects follow_up issue numbers recorded in status.json during
+# the primary batch, deduplicates them against the original ISSUE_ARRAY, and
+# runs each remaining follow-up through process_issue().
+#
+# Design notes:
+#   - Only depth-1 follow-ups (direct follow-ups of primary-batch issues) are
+#     auto-implemented.  MAX_FOLLOWUP_DEPTH=1 enforces this — depth-2 issues
+#     (follow-ups of follow-ups) are surfaced as warnings only.
+#   - needs-explore follow-ups are skipped unless ENRICH_FOLLOWUPS=true.
+#     --implement-followups implies ENRICH_FOLLOWUPS=true so that
+#     sweep_enrich_followups enriches those issues before this sweep runs.
+#   - Failures for individual follow-ups are logged as warnings only; they
+#     do NOT increment consecutive_failures and do NOT trigger the circuit
+#     breaker — the primary batch result is already finalised.
+#   - The ISSUE_ARRAY check prevents re-processing issues that were already
+#     handled in the primary loop.
+
+sweep_implement_followups() {
+	log "========================================"
+	log "Post-batch sweep: implement follow-up issues"
+	log "========================================"
+	log "Max follow-up depth: $MAX_FOLLOWUP_DEPTH"
+
+	# Collect all follow-up issue numbers across every completed primary issue.
+	# follow_ups is a JSON array of issue-number strings set by process_issue()
+	# in the merged) case arm via update_issue_field.
+	local all_followups
+	all_followups=$(jq -r \
+		'[.issues[].follow_ups[]? | strings] | unique | .[]' \
+		"$STATUS_FILE" 2>/dev/null) || all_followups=""
+
+	if [[ -z "$all_followups" ]]; then
+		log "Sweep: no follow-up issues found in status.json"
+		return 0
+	fi
+
+	# Dedup against the original manifest (ISSUE_ARRAY).  Any follow-up that
+	# was already in the primary batch does not need to be re-processed.
+	local -a new_followups=()
+	local issue_num
+	while IFS= read -r issue_num; do
+		[[ -z "$issue_num" ]] && continue
+
+		local orig already_in_manifest=false
+		for orig in "${ISSUE_ARRAY[@]}"; do
+			if [[ "$orig" == "$issue_num" ]]; then
+				already_in_manifest=true
+				break
+			fi
+		done
+		if $already_in_manifest; then
+			log "Sweep: #$issue_num already in original manifest — skipping"
+			continue
+		fi
+
+		new_followups+=("$issue_num")
+	done <<< "$all_followups"
+
+	if [[ ${#new_followups[@]} -eq 0 ]]; then
+		log "Sweep: all follow-ups were already in the original manifest"
+		return 0
+	fi
+
+	log "Sweep: ${#new_followups[@]} follow-up issue(s) to implement"
+
+	# Depth guard: this sweep handles depth-1 follow-ups.  Any follow-ups
+	# created by this wave would be at depth 2 — beyond MAX_FOLLOWUP_DEPTH —
+	# and must NOT be auto-implemented.  Surface them as warnings instead.
+	# (Checked again at the end of the sweep, after process_issue() runs.)
+
+	# Register a placeholder row in status.json for each new follow-up so
+	# that update_issue_field calls inside process_issue have a matching
+	# target.  Without this, every jq select(.number == $num) matches
+	# nothing: all field writes silently no-op, and the depth-2 follow_ups
+	# query below yields empty because process_issue never records follow_ups
+	# for unregistered issues.
+	for issue_num in "${new_followups[@]}"; do
+		local exists
+		exists=$(jq -r --arg num "$issue_num" \
+			'.issues[] | select(.number == $num) | .number' \
+			"$STATUS_FILE" 2>/dev/null) || exists=""
+		if [[ -z "$exists" ]]; then
+			# Register the placeholder AND bump progress totals so the
+			# wave-2 issue is reflected in .progress.  total/pending are
+			# not recomputed by update_progress (which only derives
+			# completed/failed/skipped/etc. from .issues[]), so they must
+			# be incremented here to keep the snapshot consistent.
+			jq --arg num "$issue_num" \
+				'.issues += [{
+					"number": $num,
+					"status": "pending",
+					"stage": null,
+					"pr": null,
+					"session_id": null,
+					"error": null,
+					"follow_ups": [],
+					"deploy_verify_failed": false,
+					"started_at": null,
+					"stage_started_at": null,
+					"completed_at": null,
+					"cost_usd": 0
+				}]
+				| .progress.total = (.progress.total + 1)
+				| .progress.pending = (.progress.pending + 1)
+				| .last_update = (now | todate)' \
+				"$STATUS_FILE" > "${STATUS_FILE}.tmp" \
+				&& mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+			log "Sweep: registered follow-up #$issue_num in status.json"
+		fi
+	done
+
+	for issue_num in "${new_followups[@]}"; do
+		# When ENRICH_FOLLOWUPS is false, skip any follow-up that still
+		# carries the needs-explore label — it was never enriched and
+		# would likely fail the implement stage.
+		# When ENRICH_FOLLOWUPS is true (implied by --implement-followups),
+		# this check is bypassed entirely: every follow-up is passed to
+		# process_issue regardless of its current labels.
+		if [[ "$ENRICH_FOLLOWUPS" != true ]]; then
+			local labels
+			labels=$(timeout 30 gh issue view "$issue_num" --json labels \
+				--jq '[.labels[].name] | join(",")' \
+				2>/dev/null) || labels=""
+			if [[ "$labels" == *"needs-explore"* ]]; then
+				log "Sweep: #$issue_num has needs-explore label" \
+					"and ENRICH_FOLLOWUPS is not set — skipping"
+				continue
+			fi
+		fi
+
+		log "Sweep: implementing follow-up #$issue_num"
+		if process_issue "$issue_num"; then
+			log "Sweep: follow-up #$issue_num processed successfully"
+		else
+			log_warn \
+				"Sweep: follow-up #$issue_num failed" \
+				"— skipping, batch unaffected"
+		fi
+	done
+
+	# Surface any depth-2 follow-ups (follow-ups of this sweep's issues) so
+	# operators can triage them.  MAX_FOLLOWUP_DEPTH=1 means we do not
+	# auto-implement beyond depth 1; anything deeper must be handled manually
+	# or by re-running with an explicit --issues list.
+	local depth2_raw=()
+	local d2_issue orig2 already_known
+	while IFS= read -r d2_issue; do
+		[[ -z "$d2_issue" ]] && continue
+		already_known=false
+		for orig2 in "${ISSUE_ARRAY[@]}" "${new_followups[@]}"; do
+			if [[ "$orig2" == "$d2_issue" ]]; then
+				already_known=true
+				break
+			fi
+		done
+		$already_known || depth2_raw+=("$d2_issue")
+	done < <(jq -r \
+		'[.issues[].follow_ups[]? | strings] | unique | .[]' \
+		"$STATUS_FILE" 2>/dev/null || true)
+
+	if (( ${#depth2_raw[@]} > 0 )); then
+		log_warn "========================================"
+		log_warn "Depth-$(( MAX_FOLLOWUP_DEPTH + 1 )) follow-ups detected" \
+			"(MAX_FOLLOWUP_DEPTH=$MAX_FOLLOWUP_DEPTH — NOT auto-implemented):"
+		local d2
+		for d2 in "${depth2_raw[@]}"; do
+			log_warn "  #$d2"
+		done
+		log_warn "Run with --issues on these numbers to implement them."
+		log_warn "========================================"
+	fi
+
+	log "Sweep: done"
+}
+
+# =============================================================================
+# MAIN LOOP
+# =============================================================================
+
+log "=========================================="
+log "Batch Orchestrator Starting"
+log "=========================================="
+log "Issues: ${ISSUE_ARRAY[*]}"
+log "Branch: $BRANCH"
+log "Implement agent: ${AGENT:-default}"
+log "Process-PR agent: code-reviewer"
+log "Log dir: $LOG_BASE"
+log "Timeout per issue: ${ISSUE_TIMEOUT}s"
+log "Max consecutive failures: $MAX_CONSECUTIVE_FAILURES"
+log "Enrich follow-ups: $ENRICH_FOLLOWUPS"
+log "Implement follow-ups: $IMPLEMENT_FOLLOWUPS"
+emit_event "batch_start" "total_issues:=${#ISSUE_ARRAY[@]}" "branch=$BRANCH"
+
+# Capture batch start time for scoping the post-batch follow-up sweep.
+# Must be set before the primary issue loop so any needs-explore issues
+# created during this run are in scope for sweep_enrich_followups.
+# Use UTC with the trailing 'Z' to match the format gh emits for
+# `createdAt` — this lets jq compare the two values lexicographically
+# without timezone-offset skew (a local "+10:00" timestamp would never
+# compare correctly against a UTC "Z" timestamp from gh).
+BATCH_START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+init_status
+
+# Pre-flight usage check. When the user has configured CLAUDE_USAGE_SESSION_KEY,
+# log current per-model utilization + reset times so operators can see at a
+# glance whether the batch will hit a wall. Per-stage escalation in the
+# subprocess (implement-issue-orchestrator.sh) handles actual routing — this
+# is an observability gate, not a control point.
+if [[ -n "${CLAUDE_USAGE_SESSION_KEY:-}${CLAUDE_USAGE_SESSION_KEY_FILE:-}" ]] \
+        && declare -F is_model_exhausted >/dev/null 2>&1; then
+    for _m in sonnet opus; do
+        _pct=$(usage_for_model "$_m" 2>/dev/null || echo "0")
+        _reset=$(model_reset_at "$_m" 2>/dev/null || echo "unknown")
+        if is_model_exhausted "$_m" 2>/dev/null; then
+            log "Pre-flight: $_m exhausted (utilization ${_pct}%, resets $_reset) — subprocess will escalate"
+        else
+            log "Pre-flight: $_m available (utilization ${_pct}%, resets $_reset)"
+        fi
+    done
+else
+    log_warn "Pre-flight: CLAUDE_USAGE_SESSION_KEY unset — no usage check"
+    log_warn "Pre-flight: export CLAUDE_USAGE_SESSION_KEY=<session-cookie>"
+    log_warn "Pre-flight: export CLAUDE_USAGE_ORG_ID=<org-id> to enable"
+fi
+
+consecutive_failures=0
+exit_code=0
+
+for issue in "${ISSUE_ARRAY[@]}"; do
+    # Check idempotency - skip if already completed in a previous run
+    current_status=$(jq -r --arg num "$issue" '.issues[] | select(.number == $num) | .status' "$STATUS_FILE")
+
+    if [[ "$current_status" == "completed" ]]; then
+        log "Skipping issue #$issue (already completed)"
+        continue
+    fi
+
+    # ---------------------------------------------------------------
+    # Up-front skip gate: closed issue OR merged PR (via gh).
+    # Complements the status.json idempotency check above by querying
+    # live platform state before spinning up the orchestrator.
+    # Only active when GIT_HOST=github.  A gh failure (network error,
+    # unauthenticated) is non-fatal: the empty result falls through so
+    # the orchestrator's already_implemented detection remains the
+    # safety net.
+    # ---------------------------------------------------------------
+    if [[ "${GIT_HOST:-github}" == "github" ]]; then
+        _upfront_issue_state=""
+        _upfront_issue_state=$(gh issue view "$issue" --json state \
+            --jq '.state' 2>/dev/null) || true
+        if [[ "$_upfront_issue_state" == "CLOSED" ]]; then
+            log "Skipping issue #$issue (already closed on GitHub)"
+            update_issue_field "$issue" "status" "completed"
+            update_progress
+            continue
+        fi
+
+        _merged_pr=""
+        _merged_pr=$(gh pr list --state merged \
+            --head "feature/issue-$issue" \
+            --json number --jq '.[0].number // empty' \
+            2>/dev/null) || true
+        if [[ -n "$_merged_pr" ]]; then
+            log "Skipping issue #$issue (PR #$_merged_pr already merged)"
+            update_issue_field "$issue" "status" "completed"
+            update_issue_field "$issue" "pr" "$_merged_pr" "true"
+            update_progress
+            continue
+        fi
+    fi
+
+    if process_issue "$issue"; then
+        consecutive_failures=0
+        log "Issue #$issue processed successfully"
+        emit_event "issue_end" "issue_num=$issue" "outcome=success"
+    else
+        consecutive_failures=$((consecutive_failures + 1))
+        exit_code=1
+        log "Issue #$issue failed. Consecutive failures: $consecutive_failures / $MAX_CONSECUTIVE_FAILURES"
+        emit_event "issue_end" "issue_num=$issue" "outcome=failed"
+
+        if (( consecutive_failures >= MAX_CONSECUTIVE_FAILURES )); then
+            log_error "CIRCUIT BREAKER: $MAX_CONSECUTIVE_FAILURES consecutive failures. Stopping batch."
+            set_state "circuit_breaker"
+            emit_event "batch_paused" "consecutive_failures:=$consecutive_failures" "max_failures:=$MAX_CONSECUTIVE_FAILURES"
+            exit_code=2
+            break
+        fi
+    fi
+
+    # Per-batch token/cost budget breaker (issue #583).  Checked after every
+    # processed issue — success or failure — mirroring the consecutive-failure
+    # circuit breaker above.  A HARD breach halts the batch with the terminal
+    # budget_exceeded state (exit code 2); the batch is never resumed on a
+    # budget halt.  Disabled by default, so no behaviour change until an
+    # operator sets MAX_BATCH_TOKENS / MAX_BATCH_COST_USD.
+    if ! check_batch_budget; then
+        log_error "BATCH BUDGET BREAKER: cumulative token/cost ceiling exceeded. Stopping batch."
+        set_state "budget_exceeded"
+        emit_event "budget_exceeded" \
+            "scope=batch" \
+            "used_tokens:=${_BATCH_TOKENS_USED:-0}" \
+            "max_tokens:=${MAX_BATCH_TOKENS:-0}" \
+            "used_cost_usd:=${_BATCH_COST_USED:-0}" \
+            "max_cost_usd:=${MAX_BATCH_COST_USD:-0}"
+        exit_code=2
+        break
+    fi
+done
+
+# Post-batch sweep: enrich any needs-explore follow-up issues that were
+# created during this run.  Runs even when the circuit breaker fired so
+# that follow-ups from the issues that DID complete get enriched.
+# Failures inside sweep_enrich_followups are warnings only — they never
+# change exit_code or the batch state.
+if [[ "$ENRICH_FOLLOWUPS" == true ]]; then
+	sweep_enrich_followups
+fi
+
+# Post-batch sweep: implement follow-up issues created during this run as a
+# second wave.  Runs after sweep_enrich_followups (above) so that any
+# needs-explore follow-ups are enriched before being implemented.
+# Failures inside sweep_implement_followups are warnings only — they never
+# change exit_code or the batch state.
+if [[ "$IMPLEMENT_FOLLOWUPS" == true ]]; then
+	sweep_implement_followups
+fi
+
+# Final state
+final_failed=$(jq '.progress.failed' "$STATUS_FILE")
+if (( exit_code == 2 )); then
+    # Circuit breaker already set state
+    :
+elif (( final_failed > 0 )); then
+    set_state "completed_with_errors"
+else
+    set_state "completed"
+fi
+
+log "=========================================="
+log "Batch Complete"
+log "=========================================="
+log "Final state: $(jq -r '.state' "$STATUS_FILE")"
+log "Progress: $(jq -c '.progress' "$STATUS_FILE")"
+
+# Surface non-blocking deploy-verify failures so they are not silently
+# missed across a multi-issue batch. The failures are recorded per-issue
+# (deploy_verify_failed: true) by process_issue() when the implement-issue
+# orchestrator sets stages.deploy_verify.deploy_cmd_failed = true.
+_dv_failed_count=$(jq \
+    '[.issues[] | select(.deploy_verify_failed == true)] | length' \
+    "$STATUS_FILE" 2>/dev/null) || _dv_failed_count=0
+if ((_dv_failed_count > 0)); then
+    log_warn "=========================================="
+    log_warn "DEPLOY-VERIFY FAILURES: $_dv_failed_count issue(s)"
+    log_warn "(non-blocking — issue comment has details)"
+    log_warn "=========================================="
+    while IFS= read -r _dv_entry; do
+        log_warn "  $_dv_entry"
+    done < <(jq -r \
+        '.issues[]
+         | select(.deploy_verify_failed == true)
+         | "Issue #\(.number) PR \(.pr // "N/A"): deploy command failed"' \
+        "$STATUS_FILE" 2>/dev/null)
+fi
+
+# Surface preflight-skipped issues so operators can see which issues
+# were skipped and why (missing tasks or needs-explore label).
+# Skipped issues are non-fatal and excluded from consecutive_failures,
+# but they must be visible in the post-run summary for triage.
+_skipped_count=$(jq \
+    '[.issues[] | select(.status == "skipped")] | length' \
+    "$STATUS_FILE" 2>/dev/null) || _skipped_count=0
+if ((_skipped_count > 0)); then
+    log_warn "=========================================="
+    log_warn "PREFLIGHT SKIPPED: $_skipped_count issue(s)"
+    log_warn "(missing ## Implementation Tasks or needs-explore label)"
+    log_warn "=========================================="
+    while IFS= read -r _skip_entry; do
+        log_warn "  $_skip_entry"
+    done < <(jq -r \
+        '.issues[]
+         | select(.status == "skipped")
+         | "Issue #\(.number): \(.error // "unknown reason")"' \
+        "$STATUS_FILE" 2>/dev/null)
+fi
+
+_batch_outcome=$(jq -r '.state' "$STATUS_FILE" 2>/dev/null)
+[[ -z "$_batch_outcome" || "$_batch_outcome" == "null" ]] && _batch_outcome="failed"
+emit_event "batch_end" "outcome=$_batch_outcome"
+
+# -----------------------------------------------------------------------------
+# COST/TOKEN TREND GUARD (advisory, non-blocking — issue #585)
+#
+# Evaluate this batch's MT/issue against a rolling baseline of recent batch
+# summaries. The guard reads the batch cost_summary token totals (rolled up
+# from #580's per-issue cost_summary) and NO-OPs cleanly when cost_summary is
+# absent or carries only total_cost_usd (no token totals). Its
+# verdict is attached to summary.json as cost_rollup / trend_warning and, when
+# a drift is detected, surfaced on the event stream as cost_trend_warning.
+# Every failure mode degrades to a benign noop verdict so the guard can never
+# block or fail the batch.
+# -----------------------------------------------------------------------------
+_trend_verdict='{"status":"noop","warning":false}'
+_trend_guard="$SCRIPT_DIR/cost-trend-guard.sh"
+if [[ -x "$_trend_guard" ]]; then
+    _trend_out=$("$_trend_guard" \
+        --current "$STATUS_FILE" \
+        --history-dir "$(dirname "$LOG_BASE")" 2>/dev/null) || _trend_out=""
+    if [[ -n "$_trend_out" ]] && printf '%s' "$_trend_out" | jq empty 2>/dev/null; then
+        _trend_verdict="$_trend_out"
+    fi
+fi
+
+_trend_warn=$(printf '%s' "$_trend_verdict" | jq -r '.warning // false' 2>/dev/null)
+if [[ "$_trend_warn" == "true" ]]; then
+    _trend_msg=$(printf '%s' "$_trend_verdict" | jq -r '.message // "cost trend regression detected"')
+    log_warn "Cost trend guard: $_trend_msg"
+    emit_event "cost_trend_warning" \
+        "latest_mt_per_issue:=$(printf '%s' "$_trend_verdict" | jq -c '.latest_mt_per_issue // 0')" \
+        "baseline_mt_per_issue:=$(printf '%s' "$_trend_verdict" | jq -c '.baseline_mt_per_issue // 0')" \
+        "factor:=$(printf '%s' "$_trend_verdict" | jq -c '.factor // 0')" \
+        "window:=$(printf '%s' "$_trend_verdict" | jq -c '.window // 0')"
+fi
+
+# Write summary — include deploy_verify_failed and skipped counts in
+# .progress so consumers can query them without iterating .issues[]. The
+# cost_rollup / trend_warning fields carry the advisory trend guard verdict.
+jq --argjson trend "$_trend_verdict" '{
+    state: .state,
+    base_branch: .base_branch,
+    progress: (.progress + {
+        deploy_verify_failed:
+            ([.issues[] | select(.deploy_verify_failed == true)] | length),
+        skipped:
+            ([.issues[] | select(.status == "skipped")] | length)
+    }),
+    issues: [.issues[] | {
+        number, status, pr, follow_ups, error, deploy_verify_failed
+    }],
+    cost_summary: (.cost_summary // null),
+    cost_rollup: {
+        latest_mt_per_issue: ($trend.latest_mt_per_issue // null),
+        baseline_mt_per_issue: ($trend.baseline_mt_per_issue // null),
+        window: ($trend.window // null),
+        factor: ($trend.factor // null)
+    },
+    trend_warning: ($trend.warning // false),
+    log_dir: .log_dir,
+    completed_at: (now | todate)
+}' "$STATUS_FILE" > "$LOG_BASE/summary.json"
+
+log "Summary written to $LOG_BASE/summary.json"
+
+exit $exit_code

--- a/plugins/pipeline-core/scripts/batch-runner.sh
+++ b/plugins/pipeline-core/scripts/batch-runner.sh
@@ -1,0 +1,335 @@
+#!/bin/bash
+# DEPRECATED: Use batch-orchestrator.sh instead. This script has known issues (set -e, OWNER/REPO literal).
+#
+# batch-runner.sh
+# Executes implement-issue and process-pr for a single issue
+# Returns JSON to stdout for handle-issues to parse
+#
+# Usage: ./batch-runner.sh <issue_number> <base_branch>
+#
+# Output JSON format:
+# {
+#   "stage": "implement-issue|process-pr",
+#   "status": "success|rate_limit|error",
+#   "issue": 123,
+#   "pr": 456,
+#   "session_id": "...",
+#   "retry_after": 3600,
+#   "reset_at": "2026-01-29T15:30:00Z",
+#   "error": "...",
+#   "follow_up_issues": [789, 790]
+# }
+#
+# Exit codes:
+#   0  - Success (all stages completed)
+#   10 - Rate limit (recoverable, wait and retry)
+#   20 - Parse error (PR number extraction failed)
+#   30 - Logic error (stage failed, may be recoverable)
+#   40 - Fatal error (stop batch, needs human)
+
+set -euo pipefail
+
+ISSUE_NUMBER="${1:?Usage: batch-runner.sh <issue_number> <base_branch>}"
+BASE_BRANCH="${2:?Usage: batch-runner.sh <issue_number> <base_branch>}"
+
+# Exit codes for different failure types
+EXIT_SUCCESS=0
+EXIT_RATE_LIMIT=10
+EXIT_PARSE_ERROR=20
+EXIT_LOGIC_ERROR=30
+EXIT_FATAL=40
+
+LOG_DIR="logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/batch-runner-$(date +%Y%m%d-%H%M%S)-issue-$ISSUE_NUMBER.log"
+
+# Lock file to prevent parallel execution
+LOCK_FILE="$LOG_DIR/.handle-issues.lock"
+
+# Acquire lock (fail if already held)
+acquire_lock() {
+    if [ -f "$LOCK_FILE" ]; then
+        local lock_pid
+        lock_pid=$(cat "$LOCK_FILE" 2>/dev/null)
+
+        # Check if lock holder is still running
+        if [ -n "$lock_pid" ] && kill -0 "$lock_pid" 2>/dev/null; then
+            echo "ERROR: Another handle-issues batch is running (PID: $lock_pid)"
+            echo "Lock file: $LOCK_FILE"
+            echo "If this is stale, remove it manually: rm $LOCK_FILE"
+            exit $EXIT_FATAL
+        else
+            echo "[$(date)] Removing stale lock file (PID $lock_pid not running)" >> "$LOG_FILE"
+            rm -f "$LOCK_FILE"
+        fi
+    fi
+
+    # Create lock with our PID
+    echo $$ > "$LOCK_FILE"
+    echo "[$(date)] Acquired lock (PID: $$)" >> "$LOG_FILE"
+}
+
+# Release lock on exit
+release_lock() {
+    if [ -f "$LOCK_FILE" ] && [ "$(cat "$LOCK_FILE" 2>/dev/null)" = "$$" ]; then
+        rm -f "$LOCK_FILE"
+        echo "[$(date)] Released lock" >> "$LOG_FILE"
+    fi
+}
+
+# Set up trap to release lock on exit
+trap release_lock EXIT
+
+# Acquire lock before proceeding
+acquire_lock
+
+# Helper: output JSON result
+output_json() {
+    local stage="$1"
+    local status="$2"
+    local extra="${3:-}"
+
+    cat <<EOF
+{
+  "stage": "$stage",
+  "status": "$status",
+  "issue": $ISSUE_NUMBER,
+  "base_branch": "$BASE_BRANCH"$extra
+}
+EOF
+}
+
+# Helper: check for rate limit in output
+check_rate_limit() {
+    local output="$1"
+
+    # Expanded patterns for reliable rate limit detection
+    # Covers: GitHub 403, secondary rate limits, Anthropic API limits
+    if echo "$output" | grep -qiE \
+        "rate.limit|429|403.*forbidden|secondary.*rate|API rate limit|too many requests|quota.exceeded|retry.after"; then
+        # Log which pattern matched for debugging
+        local matched_pattern
+        matched_pattern=$(echo "$output" | grep -oiE \
+            "rate.limit|429|403.*forbidden|secondary.*rate|API rate limit|too many requests|quota.exceeded|retry.after" | head -1)
+        echo "[$(date)] Rate limit detected via pattern: $matched_pattern" >> "$LOG_FILE"
+        return 0  # Rate limited
+    fi
+    return 1  # Not rate limited
+}
+
+# Helper: extract rate limit info
+extract_rate_limit_info() {
+    local output="$1"
+    local retry_after=""
+    local reset_at=""
+
+    # Try to extract retry-after (seconds)
+    retry_after=$(echo "$output" | grep -oi "retry.after[^0-9]*\([0-9]*\)" | grep -o "[0-9]*" | head -1 || echo "")
+
+    # Try to extract reset time (RFC3339 or human readable)
+    reset_at=$(echo "$output" | grep -oE "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}" | head -1 || echo "")
+
+    # If no RFC3339, try human readable like "10am"
+    if [ -z "$reset_at" ]; then
+        reset_at=$(echo "$output" | grep -oi "reset at [^.]*" | head -1 || echo "")
+    fi
+
+    echo "$retry_after|$reset_at"
+}
+
+# =============================================================================
+# STAGE 1: implement-issue
+# =============================================================================
+
+echo "[$(date)] Starting implement-issue for #$ISSUE_NUMBER on $BASE_BRANCH" >> "$LOG_FILE"
+
+# Run implement-issue in headless mode, capture output and session ID
+IMPLEMENT_OUTPUT=$(mktemp)
+IMPLEMENT_SESSION_ID=""
+
+# Execute claude with implement-issue skill
+# Correct syntax: claude -p "prompt" --flags
+if claude -p "/implement-issue $ISSUE_NUMBER $BASE_BRANCH" \
+    --dangerously-skip-permissions \
+    --output-format json \
+    > "$IMPLEMENT_OUTPUT" 2>&1; then
+
+    IMPLEMENT_STATUS="success"
+else
+    IMPLEMENT_EXIT_CODE=$?
+
+    # Check if rate limited
+    if check_rate_limit "$(cat "$IMPLEMENT_OUTPUT")"; then
+        IMPLEMENT_STATUS="rate_limit"
+        RATE_INFO=$(extract_rate_limit_info "$(cat "$IMPLEMENT_OUTPUT")")
+        RETRY_AFTER=$(echo "$RATE_INFO" | cut -d'|' -f1)
+        RESET_AT=$(echo "$RATE_INFO" | cut -d'|' -f2)
+
+        # Try to get session ID from JSON output
+        IMPLEMENT_SESSION_ID=$(jq -r '.session_id // empty' "$IMPLEMENT_OUTPUT" 2>&1)
+        JQ_EXIT=$?
+        if [ $JQ_EXIT -ne 0 ]; then
+            echo "[$(date)] WARNING: Failed to parse session_id from implement-issue output (jq exit: $JQ_EXIT): $IMPLEMENT_SESSION_ID" >> "$LOG_FILE"
+            IMPLEMENT_SESSION_ID=""
+        fi
+
+        echo "[$(date)] Rate limited during implement-issue. Retry after: $RETRY_AFTER, Reset at: $RESET_AT" >> "$LOG_FILE"
+
+        output_json "implement-issue" "rate_limit" ",
+  \"session_id\": \"$IMPLEMENT_SESSION_ID\",
+  \"retry_after\": ${RETRY_AFTER:-null},
+  \"reset_at\": \"${RESET_AT:-}\",
+  \"error\": \"Rate limit exceeded\""
+
+        rm -f "$IMPLEMENT_OUTPUT"
+        exit $EXIT_RATE_LIMIT
+    else
+        IMPLEMENT_STATUS="error"
+        # Capture full error but limit to 2000 chars for JSON safety
+        ERROR_MSG=$(cat "$IMPLEMENT_OUTPUT" | tr '\n' ' ' | sed 's/"/\\"/g' | cut -c1-2000)
+        if [ ${#ERROR_MSG} -eq 2000 ]; then
+            ERROR_MSG="${ERROR_MSG}... [truncated, see log file]"
+        fi
+        IMPLEMENT_SESSION_ID=$(jq -r '.session_id // empty' "$IMPLEMENT_OUTPUT" 2>&1)
+        JQ_EXIT=$?
+        if [ $JQ_EXIT -ne 0 ]; then
+            echo "[$(date)] WARNING: Failed to parse session_id from implement-issue output (jq exit: $JQ_EXIT): $IMPLEMENT_SESSION_ID" >> "$LOG_FILE"
+            IMPLEMENT_SESSION_ID=""
+        fi
+
+        echo "[$(date)] Error during implement-issue: $ERROR_MSG" >> "$LOG_FILE"
+
+        output_json "implement-issue" "error" ",
+  \"session_id\": \"$IMPLEMENT_SESSION_ID\",
+  \"error\": \"$ERROR_MSG\""
+
+        rm -f "$IMPLEMENT_OUTPUT"
+        exit $EXIT_LOGIC_ERROR
+    fi
+fi
+
+# Extract PR number from successful implement-issue output
+PR_NUMBER=$(grep -oE "github\.com/[^/]+/[^/]+/pull/([0-9]+)" "$IMPLEMENT_OUTPUT" | grep -oE "[0-9]+$" | head -1 || echo "")
+
+# Fallback: If regex parsing fails, query GitHub directly
+if [ -z "$PR_NUMBER" ]; then
+    echo "[$(date)] PR number not found in output, trying GitHub fallback query..." >> "$LOG_FILE"
+
+    # Search for open PRs with exact issue number in title (word boundary via regex)
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    PR_NUMBER=$("$SCRIPT_DIR/platform/find-mr.sh" --branch "$(git branch --show-current)" 2>/dev/null || echo "")
+
+    if [ -n "$PR_NUMBER" ]; then
+        echo "[$(date)] Found PR #$PR_NUMBER via GitHub fallback query" >> "$LOG_FILE"
+    fi
+fi
+
+if [ -z "$PR_NUMBER" ]; then
+    echo "[$(date)] implement-issue completed but no PR number found (regex and fallback failed)" >> "$LOG_FILE"
+    output_json "implement-issue" "error" ",
+  \"error\": \"No PR number found in output\""
+    rm -f "$IMPLEMENT_OUTPUT"
+    exit $EXIT_PARSE_ERROR
+fi
+
+echo "[$(date)] implement-issue completed. PR #$PR_NUMBER created" >> "$LOG_FILE"
+cat "$IMPLEMENT_OUTPUT" >> "$LOG_FILE"
+rm -f "$IMPLEMENT_OUTPUT"
+
+# =============================================================================
+# STAGE 2: process-pr
+# =============================================================================
+
+echo "[$(date)] Starting process-pr for PR #$PR_NUMBER, Issue #$ISSUE_NUMBER" >> "$LOG_FILE"
+
+PROCESS_OUTPUT=$(mktemp)
+PROCESS_SESSION_ID=""
+
+if claude -p "/process-pr $PR_NUMBER $ISSUE_NUMBER $BASE_BRANCH" \
+    --dangerously-skip-permissions \
+    --output-format json \
+    > "$PROCESS_OUTPUT" 2>&1; then
+
+    PROCESS_STATUS="success"
+
+    # Check if it was approved or changes requested
+    if grep -qi "changes.requested\|re-implementing" "$PROCESS_OUTPUT"; then
+        PROCESS_STATUS="changes_requested"
+    elif grep -qi "approved\|merged" "$PROCESS_OUTPUT"; then
+        PROCESS_STATUS="approved"
+    fi
+else
+    PROCESS_EXIT_CODE=$?
+
+    # Check if rate limited
+    if check_rate_limit "$(cat "$PROCESS_OUTPUT")"; then
+        PROCESS_STATUS="rate_limit"
+        RATE_INFO=$(extract_rate_limit_info "$(cat "$PROCESS_OUTPUT")")
+        RETRY_AFTER=$(echo "$RATE_INFO" | cut -d'|' -f1)
+        RESET_AT=$(echo "$RATE_INFO" | cut -d'|' -f2)
+
+        PROCESS_SESSION_ID=$(jq -r '.session_id // empty' "$PROCESS_OUTPUT" 2>&1)
+        JQ_EXIT=$?
+        if [ $JQ_EXIT -ne 0 ]; then
+            echo "[$(date)] WARNING: Failed to parse session_id from process-pr output (jq exit: $JQ_EXIT): $PROCESS_SESSION_ID" >> "$LOG_FILE"
+            PROCESS_SESSION_ID=""
+        fi
+
+        echo "[$(date)] Rate limited during process-pr. Retry after: $RETRY_AFTER, Reset at: $RESET_AT" >> "$LOG_FILE"
+
+        output_json "process-pr" "rate_limit" ",
+  \"pr\": $PR_NUMBER,
+  \"session_id\": \"$PROCESS_SESSION_ID\",
+  \"retry_after\": ${RETRY_AFTER:-null},
+  \"reset_at\": \"${RESET_AT:-}\",
+  \"error\": \"Rate limit exceeded\""
+
+        rm -f "$PROCESS_OUTPUT"
+        exit $EXIT_RATE_LIMIT
+    else
+        PROCESS_STATUS="error"
+        # Capture full error but limit to 2000 chars for JSON safety
+        ERROR_MSG=$(cat "$PROCESS_OUTPUT" | tr '\n' ' ' | sed 's/"/\\"/g' | cut -c1-2000)
+        if [ ${#ERROR_MSG} -eq 2000 ]; then
+            ERROR_MSG="${ERROR_MSG}... [truncated, see log file]"
+        fi
+        PROCESS_SESSION_ID=$(jq -r '.session_id // empty' "$PROCESS_OUTPUT" 2>&1)
+        JQ_EXIT=$?
+        if [ $JQ_EXIT -ne 0 ]; then
+            echo "[$(date)] WARNING: Failed to parse session_id from process-pr output (jq exit: $JQ_EXIT): $PROCESS_SESSION_ID" >> "$LOG_FILE"
+            PROCESS_SESSION_ID=""
+        fi
+
+        echo "[$(date)] Error during process-pr: $ERROR_MSG" >> "$LOG_FILE"
+
+        output_json "process-pr" "error" ",
+  \"pr\": $PR_NUMBER,
+  \"session_id\": \"$PROCESS_SESSION_ID\",
+  \"error\": \"$ERROR_MSG\""
+
+        rm -f "$PROCESS_OUTPUT"
+        exit $EXIT_LOGIC_ERROR
+    fi
+fi
+
+# Extract follow-up issues if any
+FOLLOW_UP_ISSUES=$(grep -oE "Created follow-up issue #[0-9]+" "$PROCESS_OUTPUT" | grep -oE "[0-9]+" | tr '\n' ',' | sed 's/,$//' || echo "")
+
+echo "[$(date)] process-pr completed with status: $PROCESS_STATUS" >> "$LOG_FILE"
+cat "$PROCESS_OUTPUT" >> "$LOG_FILE"
+rm -f "$PROCESS_OUTPUT"
+
+# =============================================================================
+# OUTPUT FINAL RESULT
+# =============================================================================
+
+FOLLOW_UP_JSON="[]"
+if [ -n "$FOLLOW_UP_ISSUES" ]; then
+    FOLLOW_UP_JSON="[$FOLLOW_UP_ISSUES]"
+fi
+
+output_json "process-pr" "$PROCESS_STATUS" ",
+  \"pr\": $PR_NUMBER,
+  \"follow_up_issues\": $FOLLOW_UP_JSON"
+
+echo "[$(date)] batch-runner completed for issue #$ISSUE_NUMBER" >> "$LOG_FILE"

--- a/plugins/pipeline-core/scripts/canary-measure.sh
+++ b/plugins/pipeline-core/scripts/canary-measure.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+#
+# canary-measure.sh
+# Aggregate wall-clock and token usage per issue across a canary run.
+#
+# Used to gate AC5 of issue #179: tokens-per-issue regression ≤ 10%,
+# wall-clock-per-issue regression ≤ 25%. The script reads metrics.json files
+# emitted by implement-issue-orchestrator and matches them against transcript
+# JSONL files in ~/.claude/projects/ to compute per-issue token totals.
+#
+# Usage (measurement mode):
+#   canary-measure.sh --logs-dir <dir> [--transcripts-dir <dir>]
+#                     [--label <name>] [--format json|markdown]
+#                     [--limit N]
+#
+# Usage (delta mode):
+#   canary-measure.sh --compute-deltas --before <json> --after <json>
+#                     [--format json|markdown]
+#
+# Defaults:
+#   --transcripts-dir  ~/.claude/projects
+#   --format           json
+#
+# Issue→transcript matching:
+#   A transcript JSONL record is attributed to issue N if its `cwd` field
+#   equals the issue's log directory or any descendant path (e.g. worktrees/).
+#
+# Exit codes:
+#   0 - success
+#   1 - validation failure (missing args, bad inputs)
+#
+
+set -euo pipefail
+
+# =============================================================================
+# DEFAULTS / ARGUMENT PARSING
+# =============================================================================
+
+LOGS_DIR=""
+TRANSCRIPTS_DIR="${HOME}/.claude/projects"
+LABEL=""
+FORMAT="json"
+LIMIT=0
+COMPUTE_DELTAS=0
+BEFORE=""
+AFTER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --logs-dir)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            LOGS_DIR="$2"; shift 2;;
+        --transcripts-dir)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            TRANSCRIPTS_DIR="$2"; shift 2;;
+        --label)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            LABEL="$2"; shift 2;;
+        --format)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            FORMAT="$2"; shift 2;;
+        --limit)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            LIMIT="$2"; shift 2;;
+        --compute-deltas)
+            COMPUTE_DELTAS=1; shift;;
+        --before)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            BEFORE="$2"; shift 2;;
+        --after)
+            [[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+            AFTER="$2"; shift 2;;
+        -h|--help)
+            sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+        *)
+            printf 'ERROR: unknown option: %s\n' "$1" >&2; exit 1;;
+    esac
+done
+
+case "$FORMAT" in
+    json|markdown) ;;
+    *) printf 'ERROR: --format must be json or markdown\n' >&2; exit 1;;
+esac
+
+# =============================================================================
+# DELTA MODE
+# =============================================================================
+
+if [[ "$COMPUTE_DELTAS" -eq 1 ]]; then
+    [[ -f "$BEFORE" ]] || { printf 'ERROR: --before file not found: %s\n' "$BEFORE" >&2; exit 1; }
+    [[ -f "$AFTER"  ]] || { printf 'ERROR: --after file not found: %s\n'  "$AFTER"  >&2; exit 1; }
+
+    deltas=$(jq -n \
+        --slurpfile b "$BEFORE" \
+        --slurpfile a "$AFTER" \
+        '
+        def pct(before; after):
+            if before == 0 or before == null then null
+            else (((after - before) * 100) / before) | floor end;
+
+        ($b[0].summary // {}) as $bs
+        | ($a[0].summary // {}) as $as
+        | {
+            before_label: ($b[0].label // null),
+            after_label:  ($a[0].label // null),
+            before_summary: $bs,
+            after_summary:  $as,
+            deltas: {
+                wall_clock_total_pct:  pct($bs.wall_clock_total;  $as.wall_clock_total),
+                wall_clock_median_pct: pct($bs.wall_clock_median; $as.wall_clock_median),
+                tokens_total_pct:      pct($bs.tokens_total;      $as.tokens_total),
+                tokens_median_pct:     pct($bs.tokens_median;     $as.tokens_median)
+            },
+            gates: {
+                tokens_pct_limit:     10,
+                wall_clock_pct_limit: 25,
+                tokens_within_limit:
+                    ((pct($bs.tokens_median; $as.tokens_median) // 0) <= 10),
+                wall_clock_within_limit:
+                    ((pct($bs.wall_clock_median; $as.wall_clock_median) // 0) <= 25)
+            }
+        }
+        ')
+
+    if [[ "$FORMAT" = "json" ]]; then
+        printf '%s\n' "$deltas"
+    else
+        printf '## Canary deltas: %s → %s\n\n' \
+            "$(printf '%s' "$deltas" | jq -r '.before_label // "before"')" \
+            "$(printf '%s' "$deltas" | jq -r '.after_label  // "after"')"
+        printf '| Metric | Before | After | Δ%% | Gate |\n'
+        printf '|---|---:|---:|---:|:---:|\n'
+        printf '%s\n' "$deltas" | jq -r '
+            "| Wall-clock total (s)  | \(.before_summary.wall_clock_total)  | \(.after_summary.wall_clock_total)  | \(.deltas.wall_clock_total_pct  // "n/a") | — |",
+            "| Wall-clock median (s) | \(.before_summary.wall_clock_median) | \(.after_summary.wall_clock_median) | \(.deltas.wall_clock_median_pct // "n/a") | \(if .gates.wall_clock_within_limit then "PASS" else "FAIL" end) |",
+            "| Tokens total          | \(.before_summary.tokens_total)      | \(.after_summary.tokens_total)      | \(.deltas.tokens_total_pct      // "n/a") | — |",
+            "| Tokens median         | \(.before_summary.tokens_median)     | \(.after_summary.tokens_median)     | \(.deltas.tokens_median_pct     // "n/a") | \(if .gates.tokens_within_limit then "PASS" else "FAIL" end) |"
+        '
+    fi
+    exit 0
+fi
+
+# =============================================================================
+# MEASUREMENT MODE
+# =============================================================================
+
+[[ -n "$LOGS_DIR" ]] || { printf 'ERROR: --logs-dir is required\n' >&2; exit 1; }
+[[ -d "$LOGS_DIR" ]] || { printf 'ERROR: --logs-dir not found: %s\n' "$LOGS_DIR" >&2; exit 1; }
+
+# Discover metrics.json files (bash 3.2 compatible — no mapfile)
+METRICS_FILES=()
+while IFS= read -r _f; do
+    [[ -n "$_f" ]] && METRICS_FILES+=("$_f")
+done < <(find "$LOGS_DIR" -mindepth 2 -maxdepth 3 -name metrics.json -type f 2>/dev/null | sort)
+
+if [[ "$LIMIT" -gt 0 && "${#METRICS_FILES[@]}" -gt "$LIMIT" ]]; then
+    _start=$(( ${#METRICS_FILES[@]} - LIMIT ))
+    METRICS_FILES=("${METRICS_FILES[@]:$_start}")
+fi
+
+if [[ "${#METRICS_FILES[@]}" -eq 0 ]]; then
+    printf 'ERROR: no metrics.json files found under %s\n' "$LOGS_DIR" >&2
+    exit 1
+fi
+
+# Sum tokens from transcripts whose cwd matches the issue's log directory
+# (or any descendant path, e.g. worktrees/task-N).
+#
+# Transcripts in ~/.claude/projects/ are organized by directory whose name is
+# the cwd with `/` replaced by `-` (e.g. /a/b/c → -a-b-c). To avoid loading all
+# 10k+ transcript files, we pre-filter by parent-dir name; if that yields
+# nothing (e.g. test fixtures with arbitrary names), we fall back to scanning
+# all transcripts under TRANSCRIPTS_DIR. We always verify the cwd field inside
+# each record matches log_dir (or a descendant).
+sum_tokens_for_issue() {
+    local log_dir="$1"
+    local empty='{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"sessions":0}'
+
+    if [[ ! -d "$TRANSCRIPTS_DIR" ]]; then
+        printf '%s' "$empty"; return
+    fi
+
+    # Mangled directory prefix used by ~/.claude/projects/.
+    local prefix="${log_dir//\//-}"
+
+    local files=()
+    while IFS= read -r _f; do
+        [[ -n "$_f" ]] && files+=("$_f")
+    done < <(find "$TRANSCRIPTS_DIR" -name '*.jsonl' -type f \
+                  -path "*${prefix}*" 2>/dev/null)
+
+    # Fallback: small test fixtures often don't follow the mangled-name scheme.
+    # If the prefix filter found nothing, scan all and rely on cwd verification.
+    if [[ "${#files[@]}" -eq 0 ]]; then
+        while IFS= read -r _f; do
+            [[ -n "$_f" ]] && files+=("$_f")
+        done < <(find "$TRANSCRIPTS_DIR" -name '*.jsonl' -type f 2>/dev/null)
+    fi
+
+    if [[ "${#files[@]}" -eq 0 ]]; then
+        printf '%s' "$empty"; return
+    fi
+
+    # Stream-process per file, verifying cwd in each record. Avoids loading
+    # everything into a single jq slurp.
+    local sessions=0
+    local seen_session
+    local stream_output
+    stream_output=$(for f in "${files[@]}"; do
+        jq -c --arg root "$log_dir" '
+            select(.cwd != null and .message.usage != null
+                   and (.cwd == $root or (.cwd | startswith($root + "/"))))
+            | .message.usage
+            | {input_tokens: (.input_tokens // 0),
+               output_tokens: (.output_tokens // 0),
+               cache_creation_input_tokens: (.cache_creation_input_tokens // 0),
+               cache_read_input_tokens: (.cache_read_input_tokens // 0)}' \
+            "$f" 2>/dev/null \
+        && { seen_session=1; printf '%s\n' "__SESSION__"; }
+    done)
+
+    sessions=$(printf '%s\n' "$stream_output" | grep -c '^__SESSION__$' || true)
+    local records
+    records=$(printf '%s\n' "$stream_output" | grep -v '^__SESSION__$')
+
+    if [[ -z "$records" ]]; then
+        printf '{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"sessions":%d}' "$sessions"
+        return
+    fi
+
+    local agg
+    agg=$(printf '%s\n' "$records" | jq -s --argjson n "$sessions" '
+        {
+            input_tokens:               (map(.input_tokens               // 0) | add // 0),
+            output_tokens:              (map(.output_tokens              // 0) | add // 0),
+            cache_creation_input_tokens:(map(.cache_creation_input_tokens // 0) | add // 0),
+            cache_read_input_tokens:    (map(.cache_read_input_tokens     // 0) | add // 0),
+            sessions: $n
+        }')
+    if [[ -n "$agg" ]]; then
+        printf '%s' "$agg"
+    else
+        printf '%s' "$empty"
+    fi
+}
+
+# Build per-issue rows
+ISSUE_ROWS=()
+for mf in "${METRICS_FILES[@]}"; do
+    log_dir="$(dirname "$mf")"
+    issue=$(jq -r '.issue // empty' "$mf")
+    duration=$(jq -r '.total_duration_seconds // 0' "$mf")
+    started=$(jq -r '.started_at // empty' "$mf")
+    completed=$(jq -r '.completed_at // empty' "$mf")
+    state=$(jq -r '.state // empty' "$mf")
+
+    [[ -n "$issue" ]] || continue
+
+    tokens_json=$(sum_tokens_for_issue "$log_dir")
+
+    row=$(jq -n \
+        --arg issue "$issue" \
+        --arg log_dir "$log_dir" \
+        --arg started "$started" \
+        --arg completed "$completed" \
+        --arg state "$state" \
+        --argjson duration "$duration" \
+        --argjson tok "$tokens_json" \
+        '{
+            issue: $issue,
+            log_dir: $log_dir,
+            state: $state,
+            started_at: $started,
+            completed_at: $completed,
+            wall_clock_seconds: $duration,
+            input_tokens:                $tok.input_tokens,
+            output_tokens:               $tok.output_tokens,
+            cache_creation_input_tokens: $tok.cache_creation_input_tokens,
+            cache_read_input_tokens:     $tok.cache_read_input_tokens,
+            transcript_sessions:         $tok.sessions,
+            total_tokens: ($tok.input_tokens + $tok.output_tokens
+                          + $tok.cache_creation_input_tokens
+                          + $tok.cache_read_input_tokens)
+         }')
+    ISSUE_ROWS+=("$row")
+done
+
+# Aggregate summary
+ALL_ROWS_JSON=$(printf '%s\n' "${ISSUE_ROWS[@]}" | jq -s '.')
+
+SUMMARY=$(printf '%s' "$ALL_ROWS_JSON" | jq '
+    def median: sort | if length == 0 then 0
+        elif length % 2 == 1 then .[length/2|floor]
+        else ((.[length/2 - 1] + .[length/2]) / 2 | floor) end;
+
+    {
+        count: length,
+        wall_clock_total:  ([.[].wall_clock_seconds] | add // 0),
+        wall_clock_median: ([.[].wall_clock_seconds] | median),
+        tokens_total:      ([.[].total_tokens]       | add // 0),
+        tokens_median:     ([.[].total_tokens]       | median),
+        input_tokens_total:  ([.[].input_tokens]                | add // 0),
+        output_tokens_total: ([.[].output_tokens]               | add // 0),
+        cache_creation_total:([.[].cache_creation_input_tokens] | add // 0),
+        cache_read_total:    ([.[].cache_read_input_tokens]     | add // 0)
+    }
+')
+
+REPORT=$(jq -n \
+    --arg label "$LABEL" \
+    --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg logs_dir "$LOGS_DIR" \
+    --arg transcripts_dir "$TRANSCRIPTS_DIR" \
+    --argjson issues "$ALL_ROWS_JSON" \
+    --argjson summary "$SUMMARY" \
+    '{
+        label: (if $label == "" then null else $label end),
+        generated_at: $generated_at,
+        logs_dir: $logs_dir,
+        transcripts_dir: $transcripts_dir,
+        summary: $summary,
+        issues: $issues
+     }')
+
+if [[ "$FORMAT" = "json" ]]; then
+    printf '%s\n' "$REPORT"
+    exit 0
+fi
+
+# Markdown output
+{
+    label_disp=$(printf '%s' "$REPORT" | jq -r '.label // "unlabeled"')
+    printf '## Canary measurement: %s\n\n' "$label_disp"
+    printf 'Generated: %s\n' "$(printf '%s' "$REPORT" | jq -r '.generated_at')"
+    printf 'Logs dir: `%s`\n' "$(printf '%s' "$REPORT" | jq -r '.logs_dir')"
+    printf 'Issues: %s\n\n' "$(printf '%s' "$REPORT" | jq -r '.summary.count')"
+
+    printf '### Per-issue\n\n'
+    printf '| Issue | State | Wall-clock (s) | Total tokens | Input | Output | Cache create | Cache read | Sessions |\n'
+    printf '|---|---|---:|---:|---:|---:|---:|---:|---:|\n'
+    printf '%s' "$REPORT" | jq -r '.issues[] |
+        "| \(.issue) | \(.state // "?") | \(.wall_clock_seconds) | \(.total_tokens) | \(.input_tokens) | \(.output_tokens) | \(.cache_creation_input_tokens) | \(.cache_read_input_tokens) | \(.transcript_sessions) |"'
+
+    printf '\n### Summary\n\n'
+    printf '| Metric | Value |\n|---|---:|\n'
+    printf '%s' "$REPORT" | jq -r '.summary |
+        "| Issues counted | \(.count) |",
+        "| Wall-clock total (s) | \(.wall_clock_total) |",
+        "| Median wall-clock (s) | \(.wall_clock_median) |",
+        "| Tokens total | \(.tokens_total) |",
+        "| Median tokens | \(.tokens_median) |",
+        "| Input tokens total | \(.input_tokens_total) |",
+        "| Output tokens total | \(.output_tokens_total) |",
+        "| Cache-creation tokens | \(.cache_creation_total) |",
+        "| Cache-read tokens | \(.cache_read_total) |"'
+}

--- a/plugins/pipeline-core/scripts/capture-usage-fixture.sh
+++ b/plugins/pipeline-core/scripts/capture-usage-fixture.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# capture-usage-fixture.sh — Capture a real claude.ai usage API response
+#
+# Hits the (private) usage endpoint that Sneaky Penguin and similar menu-bar
+# apps poll, saves the JSON to the test fixtures directory, and prints the
+# bucket field names so we can map them to the menu-bar's display labels
+# (Session 5h / All-models Weekly / Sonnet / Extra Usage).
+#
+# Why: the proactive-usage-polling design needs the real field names from
+# this endpoint before we can implement usage_for_model(). Don't guess.
+#
+# Required input (env var, prompt, or file):
+#   CLAUDE_USAGE_SESSION_KEY        sessionKey cookie from claude.ai
+#   CLAUDE_USAGE_SESSION_KEY_FILE   alternative: path to file containing key (0600)
+#   CLAUDE_USAGE_ORG_ID             organization UUID
+#
+# Output:
+#   .claude/scripts/implement-issue-test/fixtures/usage-response.json
+#
+# Usage:
+#   .claude/scripts/capture-usage-fixture.sh                     # interactive prompts
+#   CLAUDE_USAGE_SESSION_KEY=sk-ant-... CLAUDE_USAGE_ORG_ID=uuid \
+#     .claude/scripts/capture-usage-fixture.sh                   # fully scripted
+#
+# Security notes:
+#   - The sessionKey is a long-lived bearer-equivalent for your claude.ai
+#     account. This script reads it once into a local variable and passes it
+#     to curl via -H (header — not visible in /proc/PID/cmdline) instead of
+#     -b (cookie file path or inline). The key value is never echoed, never
+#     logged, never written to status.json, never appears in the saved
+#     fixture (the response itself contains usage data only).
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="$SCRIPT_DIR/implement-issue-test/fixtures/usage-response.json"
+
+err() { printf 'error: %s\n' "$*" >&2; }
+
+command -v curl >/dev/null 2>&1 || { err "curl required"; exit 2; }
+command -v jq >/dev/null 2>&1 || { err "jq required"; exit 2; }
+
+# Source the runtime module so we share its env-var > file resolution
+# (_session_key_value) — keeps both paths in sync if it ever grows.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/claude-usage.sh"
+
+# --- session key (env var > file > prompt) ---------------------------------
+
+session_key=""
+if ! session_key=$(_session_key_value 2>/dev/null) || [[ -z "$session_key" ]]; then
+    printf 'Paste sessionKey (input hidden, starts with sk-ant-sid01-): ' >&2
+    # -s suppresses echo; -r preserves backslashes in the value.
+    IFS= read -rs session_key
+    printf '\n' >&2
+fi
+
+if [[ -z "$session_key" ]]; then
+    err "no sessionKey provided"
+    exit 2
+fi
+
+# Cheap sanity check — don't log the value, just confirm shape.
+if [[ ! "$session_key" =~ ^sk-ant- ]]; then
+    err "sessionKey doesn't start with 'sk-ant-' — wrong cookie?"
+    err "(get it from claude.ai DevTools → Application → Cookies → sessionKey)"
+    exit 2
+fi
+
+# --- org id (env var > prompt) ---------------------------------------------
+
+org_id="${CLAUDE_USAGE_ORG_ID:-}"
+if [[ -z "$org_id" ]]; then
+    printf 'Organization UUID: ' >&2
+    IFS= read -r org_id
+fi
+
+if [[ -z "$org_id" ]]; then
+    err "no org_id provided"
+    err "(find it in DevTools → Network tab on claude.ai — any /api/organizations/{uuid}/ request)"
+    exit 2
+fi
+
+# --- fetch -----------------------------------------------------------------
+
+url="https://claude.ai/api/organizations/${org_id}/usage"
+printf 'Fetching: %s\n' "$url" >&2
+
+http_status=0
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+http_status=$(curl -sS \
+    --connect-timeout 5 \
+    --max-time 15 \
+    -o "$body_file" \
+    -w '%{http_code}' \
+    -H "Cookie: sessionKey=${session_key}" \
+    -H "Accept: application/json" \
+    "$url" 2>&1) || {
+    err "curl failed: $http_status"
+    exit 1
+}
+
+if [[ "$http_status" != "200" ]]; then
+    err "HTTP $http_status from $url"
+    err "first 200 bytes of response body:"
+    head -c 200 "$body_file" >&2
+    printf '\n' >&2
+    exit 1
+fi
+
+if ! jq empty "$body_file" 2>/dev/null; then
+    err "response is not valid JSON"
+    err "first 200 bytes:"
+    head -c 200 "$body_file" >&2
+    printf '\n' >&2
+    exit 1
+fi
+
+# --- save fixture ----------------------------------------------------------
+
+mkdir -p "$(dirname "$FIXTURE")"
+jq . "$body_file" > "$FIXTURE"
+printf 'Saved fixture: %s (%d bytes)\n' "$FIXTURE" "$(wc -c < "$FIXTURE" | tr -d ' ')" >&2
+
+# --- summarize field structure --------------------------------------------
+
+printf '\n' >&2
+printf 'Top-level field names:\n' >&2
+jq -r 'keys[]' "$FIXTURE" | sed 's/^/  /' >&2
+
+printf '\nBucket-shaped fields (objects with a numeric utilization or limit):\n' >&2
+jq -r '
+  paths(type == "object" and (
+    has("utilization_pct") or has("usage") or has("limit") or
+    has("remaining") or has("resets_at") or has("reset_at")
+  )) | join(".")
+' "$FIXTURE" 2>/dev/null | sed 's/^/  /' >&2 || true
+
+printf '\nReset timestamps found:\n' >&2
+jq -r '
+  paths(type == "string") as $p |
+  getpath($p) as $v |
+  select($p[-1] | test("reset"; "i")) |
+  "  \($p | join(\".\")) = \($v)"
+' "$FIXTURE" 2>/dev/null >&2 || true
+
+printf '\n' >&2
+printf 'Next: paste this fixture (or just the field names) so the design can\n' >&2
+printf 'map each bucket to a model in the v3 polling proposal.\n' >&2

--- a/plugins/pipeline-core/scripts/claude-usage.sh
+++ b/plugins/pipeline-core/scripts/claude-usage.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+#
+# claude-usage.sh — Proactive usage polling for the Claude.ai usage API
+#
+# Queries the (private) endpoint that Sneaky Penguin and similar menu-bar apps
+# poll. Lets the orchestrator skip a model whose per-model bucket is exhausted
+# by escalating via _next_model_up — without sleeping for the rate-limit reset.
+#
+# This module is sourced by orchestrator scripts. It exposes:
+#   fetch_usage              — populate / refresh the cache (30s TTL)
+#   usage_for_model MODEL    — utilization 0..100 with bucket fallback
+#   model_reset_at MODEL     — ISO8601 timestamp or "unknown"
+#   is_model_exhausted MODEL — 0/1, applies all guards in order
+#
+# Hybrid fallback: if CLAUDE_USAGE_SESSION_KEY is unset OR any fetch fails,
+# is_model_exhausted returns false for everything. Caller behaves as today.
+#
+# Security: sessionKey is treated as a bearer-equivalent secret. Read once
+# into a local variable, passed to curl via -H Cookie:, never echoed, never
+# logged, never written to status.json or any artifact.
+#
+
+# Guard against double-sourcing — orchestrator and batch-orchestrator may
+# both source this. Function definitions are idempotent but the cache-path
+# computation is wasteful to repeat.
+if [[ -n "${_CLAUDE_USAGE_SOURCED:-}" ]]; then
+    return 0 2>/dev/null || true
+fi
+_CLAUDE_USAGE_SOURCED=1
+
+# Cache file under XDG_CACHE_HOME so it's user-scoped (one source of truth
+# across all worktrees / projects) and never accidentally committed.
+_CLAUDE_USAGE_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-pipeline"
+_CLAUDE_USAGE_CACHE_FILE="$_CLAUDE_USAGE_CACHE_DIR/usage.json"
+_CLAUDE_USAGE_SYNTH_FILE="$_CLAUDE_USAGE_CACHE_DIR/synthetic_exhaustion.json"
+
+# Defaults (overridable via env). See SKILL.md for semantics.
+: "${CLAUDE_USAGE_CACHE_TTL:=30}"
+: "${CLAUDE_USAGE_SESSION_THRESHOLD:=95}"
+: "${CLAUDE_USAGE_MODEL_THRESHOLD:=95}"
+: "${CLAUDE_USAGE_WEEKLY_THRESHOLD:=98}"
+: "${CLAUDE_USAGE_EXTRA_THRESHOLD:=90}"
+
+# --- internal helpers ------------------------------------------------------
+
+_usage_log() {
+    # Stage-runner ships a `log` function; if not present, fall back to stderr.
+    # All claude-usage messages go to stderr — never stdout (we return values
+    # there).
+    if declare -F log >/dev/null 2>&1; then
+        log "$@"
+    else
+        printf '[%s] %s\n' "$(date -Iseconds 2>/dev/null || date)" "$*" >&2
+    fi
+}
+
+_usage_warn() { _usage_log "WARN claude-usage: $*"; }
+_usage_error() { _usage_log "ERROR claude-usage: $*"; }
+
+_cache_age_seconds() {
+    [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || { printf '999999\n'; return; }
+    local mtime now
+    mtime=$(stat -f %m "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null \
+         || stat -c %Y "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    printf '%s\n' $((now - mtime))
+}
+
+_session_key_value() {
+    # Resolution order: env var > file (with newline strip).
+    if [[ -n "${CLAUDE_USAGE_SESSION_KEY:-}" ]]; then
+        printf '%s' "$CLAUDE_USAGE_SESSION_KEY"
+        return 0
+    fi
+    if [[ -n "${CLAUDE_USAGE_SESSION_KEY_FILE:-}" && -r "${CLAUDE_USAGE_SESSION_KEY_FILE}" ]]; then
+        tr -d '[:space:]' < "$CLAUDE_USAGE_SESSION_KEY_FILE"
+        return 0
+    fi
+    return 1
+}
+
+# --- fetch_usage -----------------------------------------------------------
+# Returns 0 on success (cache populated and valid), non-zero on any failure.
+# Side effect: writes cache file. Failures are logged but never raise.
+
+fetch_usage() {
+    if [[ "${CLAUDE_USAGE_DISABLE:-0}" == "1" ]]; then
+        return 1
+    fi
+
+    # Cache hit?
+    local age
+    age=$(_cache_age_seconds)
+    if (( age <= CLAUDE_USAGE_CACHE_TTL )) && [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]]; then
+        return 0
+    fi
+
+    local session_key
+    if ! session_key=$(_session_key_value); then
+        # Unconfigured — silent no-op so non-users see no churn.
+        return 1
+    fi
+
+    if [[ -z "${CLAUDE_USAGE_ORG_ID:-}" ]]; then
+        _usage_warn "CLAUDE_USAGE_SESSION_KEY set but CLAUDE_USAGE_ORG_ID is not — skipping fetch"
+        return 1
+    fi
+
+    mkdir -p "$_CLAUDE_USAGE_CACHE_DIR"
+
+    # Track whether the cache was previously valid — drives WARN vs ERROR
+    # severity on failure (regression-after-success is louder than first-fail).
+    local had_valid_cache=0
+    if [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] && jq empty "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null; then
+        had_valid_cache=1
+    fi
+
+    local body_file http_status
+    body_file=$(mktemp)
+    # Trap-free cleanup: the function caller may also have traps; we just
+    # rm at end of function.
+
+    # NOTE: the sessionKey is interpolated into a HEADER VALUE (-H), not into
+    # a positional arg. /proc/PID/cmdline shows positional args; headers are
+    # not visible to ps. Read-once into local variable; never logged.
+    http_status=$(curl -sS \
+        --connect-timeout 3 \
+        --max-time 5 \
+        -o "$body_file" \
+        -w '%{http_code}' \
+        -H "Cookie: sessionKey=${session_key}" \
+        -H "Accept: application/json" \
+        "https://claude.ai/api/organizations/${CLAUDE_USAGE_ORG_ID}/usage" 2>/dev/null) \
+        || http_status="000"
+
+    # Clear local references to the secret immediately after the curl call.
+    session_key=""
+
+    if [[ "$http_status" != "200" ]]; then
+        _log_fetch_failure "$had_valid_cache" "fetch failed (HTTP $http_status)" "endpoint regression?"
+        rm -f "$body_file"
+        return 1
+    fi
+
+    if ! jq empty "$body_file" 2>/dev/null; then
+        _log_fetch_failure "$had_valid_cache" "response is not valid JSON" "endpoint shape changed?"
+        rm -f "$body_file"
+        return 1
+    fi
+
+    # Atomic install (tmp + mv). Pretty-printed for ad-hoc inspection.
+    jq . "$body_file" > "${_CLAUDE_USAGE_CACHE_FILE}.tmp" && \
+        mv "${_CLAUDE_USAGE_CACHE_FILE}.tmp" "$_CLAUDE_USAGE_CACHE_FILE"
+
+    rm -f "$body_file"
+    return 0
+}
+
+# Cache-was-valid escalates WARN to ERROR — a regression-after-success is
+# louder than first-time failure (which usually means unconfigured / new user).
+_log_fetch_failure() {
+    local had_valid="$1" msg="$2" regression_suffix="$3"
+    if (( had_valid )); then
+        _usage_error "$msg after prior success — $regression_suffix"
+    else
+        _usage_warn "$msg"
+    fi
+}
+
+# --- bucket-mapped accessors ----------------------------------------------
+
+_per_model_field() {
+    case "$1" in
+        sonnet) printf 'seven_day_sonnet' ;;
+        opus)   printf 'seven_day_opus' ;;
+        *)      printf '' ;;
+    esac
+}
+
+# Models known to share the seven_day all-models bucket when no per-model
+# field exists. Haiku is here; truly unknown models are NOT — for those we
+# return 0 so the gating logic can't accidentally throttle a model the
+# script doesn't recognize.
+_is_known_model() {
+    case "$1" in
+        sonnet|opus|haiku) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Pick PER_MODEL_FIELD.PROP if non-null, else seven_day.PROP, else DEFAULT.
+# One jq invocation, returns the resolved value via stdout.
+_bucket_pick() {
+    local field="$1" prop="$2" default="$3"
+    jq -r --arg f "$field" --arg p "$prop" --arg d "$default" '
+        def pick(p): . as $o | if $o[p] == null or $o[p] == "" then null else $o[p] end;
+        (if $f != "" then (.[$f] // {}) | pick($p) else null end) //
+        ((.seven_day // {}) | pick($p)) //
+        $d
+    ' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null
+}
+
+# usage_for_model MODEL → integer 0..100 (or 0 on unknown / no data)
+usage_for_model() {
+    local model="$1"
+    _is_known_model "$model" || { printf '0\n'; return 0; }
+
+    fetch_usage || { printf '0\n'; return 0; }
+    [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || { printf '0\n'; return 0; }
+
+    local val
+    val=$(_bucket_pick "$(_per_model_field "$model")" utilization 0)
+    printf '%.0f\n' "${val:-0}"
+}
+
+# model_reset_at MODEL → ISO8601 string or "unknown"
+model_reset_at() {
+    local model="$1"
+    fetch_usage || { printf 'unknown\n'; return 0; }
+    [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || { printf 'unknown\n'; return 0; }
+
+    local val
+    val=$(_bucket_pick "$(_per_model_field "$model")" resets_at unknown)
+    printf '%s\n' "${val:-unknown}"
+}
+
+# --- is_model_exhausted ----------------------------------------------------
+# Three-gate check, in order of recovery cost:
+#   1. five_hour (shared session) — hard cap, overage cannot absorb a rate
+#      window. Crossing it kills every model.
+#   2. per-model weekly — soft cap; if extra_usage is_enabled and below its
+#      own threshold, calls drain against overage and we should NOT escalate.
+#   3. seven_day (all-models weekly) — treated as hard cap (conservative).
+#      Empirical verification of overage absorption deferred to a follow-up.
+
+is_model_exhausted() {
+    local model="$1"
+
+    if [[ "${CLAUDE_USAGE_DISABLE:-0}" == "1" ]]; then
+        return 1
+    fi
+
+    # Check synthetic exhaustion before a network round-trip.
+    # record_inferred_exhaustion() writes this when the orchestrator
+    # infers a rate-limit from API error responses.
+    if _is_synthetically_exhausted "$model"; then
+        return 0
+    fi
+
+    fetch_usage || return 1   # graceful: no data, treat as not exhausted
+    [[ -f "$_CLAUDE_USAGE_CACHE_FILE" ]] || return 1
+
+    # One jq, five fields, TSV. Empty string for missing per-model bucket
+    # (haiku, unknowns) — bash arithmetic later treats it as 0 / not-exhausted.
+    local field five_hour_pct seven_day_pct extra_enabled extra_pct per_model_pct
+    field=$(_per_model_field "$model")
+    IFS=$'\t' read -r five_hour_pct seven_day_pct extra_enabled extra_pct per_model_pct < <(
+        jq -r --arg f "$field" '
+            [
+                (.five_hour.utilization // 0),
+                (.seven_day.utilization // 0),
+                (.extra_usage.is_enabled // false),
+                (.extra_usage.utilization // 0),
+                (if $f != "" then (.[$f] // {}) | (.utilization // "") else "" end)
+            ] | @tsv
+        ' "$_CLAUDE_USAGE_CACHE_FILE" 2>/dev/null
+    )
+
+    five_hour_pct=$(printf '%.0f' "${five_hour_pct:-0}")
+    seven_day_pct=$(printf '%.0f' "${seven_day_pct:-0}")
+    extra_pct=$(printf '%.0f' "${extra_pct:-0}")
+
+    # 1. Session gate — overage cannot absorb a rate window.
+    if (( five_hour_pct >= CLAUDE_USAGE_SESSION_THRESHOLD )); then
+        return 0
+    fi
+
+    # 2. Per-model weekly with overage absorption guard.
+    if [[ -n "$per_model_pct" ]]; then
+        per_model_pct=$(printf '%.0f' "$per_model_pct")
+        if (( per_model_pct >= CLAUDE_USAGE_MODEL_THRESHOLD )); then
+            if [[ "$extra_enabled" == "true" ]] && (( extra_pct < CLAUDE_USAGE_EXTRA_THRESHOLD )); then
+                : # overage absorbing — fall through to weekly check
+            else
+                return 0
+            fi
+        fi
+    fi
+
+    # 3. All-models weekly — treated as hard cap (conservative; see SKILL).
+    if (( seven_day_pct >= CLAUDE_USAGE_WEEKLY_THRESHOLD )); then
+        return 0
+    fi
+
+    return 1
+}
+
+# --- record_inferred_exhaustion / synthetic exhaustion ----------------------
+# Lets the orchestrator record a model as exhausted when it infers a
+# rate-limit from API error responses without a real usage API fetch.
+# The record persists for WAIT_SECS seconds; after expiry the function
+# returns false and normal cache/API checks resume.
+
+_is_synthetically_exhausted() {
+    local model="$1"
+    [[ -f "$_CLAUDE_USAGE_SYNTH_FILE" ]] || return 1
+
+    local exhausted_until
+    exhausted_until=$(jq -r --arg m "$model" \
+        '.[$m].exhausted_until // empty' \
+        "$_CLAUDE_USAGE_SYNTH_FILE" 2>/dev/null)
+    [[ -n "$exhausted_until" ]] || return 1
+
+    (( exhausted_until > $(date +%s) ))
+}
+
+# record_inferred_exhaustion MODEL WAIT_SECS
+# Atomic-write a synthetic exhaustion record for MODEL expiring in
+# WAIT_SECS seconds.  Merges with existing records; other models' state
+# is preserved.  is_model_exhausted() checks this file before fetch_usage.
+record_inferred_exhaustion() {
+    local model="$1" wait_secs="$2"
+
+    [[ -n "$model" ]] || {
+        _usage_warn "record_inferred_exhaustion: missing MODEL"
+        return 1
+    }
+    [[ -n "$wait_secs" ]] || {
+        _usage_warn "record_inferred_exhaustion: missing WAIT_SECS"
+        return 1
+    }
+
+    mkdir -p "$_CLAUDE_USAGE_CACHE_DIR"
+
+    local exhausted_until
+    exhausted_until=$(( $(date +%s) + wait_secs ))
+
+    # Merge with existing records — preserve other models' state.
+    local existing_json='{}'
+    if [[ -f "$_CLAUDE_USAGE_SYNTH_FILE" ]] \
+            && jq empty "$_CLAUDE_USAGE_SYNTH_FILE" 2>/dev/null; then
+        existing_json=$(< "$_CLAUDE_USAGE_SYNTH_FILE")
+    fi
+
+    local tmp_file
+    tmp_file=$(mktemp "${_CLAUDE_USAGE_CACHE_DIR}/synthetic.XXXXXX")
+
+    jq --arg m "$model" --argjson u "$exhausted_until" \
+        '.[$m] = {"exhausted_until": $u}' \
+        <<< "$existing_json" \
+        > "$tmp_file" 2>/dev/null \
+        && mv "$tmp_file" "$_CLAUDE_USAGE_SYNTH_FILE" \
+        || {
+            rm -f "$tmp_file"
+            _usage_warn \
+                "record_inferred_exhaustion: write failed for $model"
+            return 1
+        }
+
+    _usage_log \
+        "INFO claude-usage: synthetic exhaustion model=$model wait=${wait_secs}s"
+}

--- a/plugins/pipeline-core/scripts/context-mode-check.sh
+++ b/plugins/pipeline-core/scripts/context-mode-check.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+#
+# context-mode-check.sh
+# Smoke check for Context Mode integration health.
+#
+# Wraps `ctx doctor`/`ctx stats` (or `context-mode doctor`/`context-mode stats`)
+# and runs the orchestrator BATS parsing-assertion suite to confirm
+# output-parsing is unaffected when Context Mode is active.
+#
+# Usage: context-mode-check.sh [options]
+#
+# Options:
+#   -h, --help           Show this help message
+#   --skip-bats          Skip the BATS parsing-assertion suite
+#   --ctx-only           Run ctx checks only; skip BATS suite
+#   --bats-dir <path>    BATS test directory
+#                        (default: .claude/scripts/implement-issue-test)
+#   --bats-filter <pat>  bats --filter pattern (default: all tests)
+#
+# Environment:
+#   CONTEXT_MODE_ENABLED  1 = ctx must be present (exit 1 when absent).
+#                         0 (default) = skip gracefully when ctx missing.
+#
+# Exit codes:
+#   0  all enabled checks passed (or gracefully skipped)
+#   1  ctx health check failed (BATS not run or passed)
+#   2  BATS parsing-assertion suite failed (ctx passed or was skipped)
+#   3  usage / configuration error
+#   4  BOTH ctx and BATS failed; both FAIL lines are printed to stderr
+#
+
+set -uo pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Default BATS dir: co-located with the orchestrator scripts
+readonly DEFAULT_BATS_DIR="$SCRIPT_DIR/implement-issue-test"
+
+# =============================================================================
+# OUTPUT HELPERS
+# =============================================================================
+
+log() {
+	printf '[%s] %s\n' "$SCRIPT_NAME" "$*" >&2
+}
+
+result_pass() {
+	printf 'PASS  %s\n' "$*"
+}
+
+result_fail() {
+	printf 'FAIL  %s\n' "$*" >&2
+}
+
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 3
+}
+
+usage() {
+	cat <<EOF
+Usage: $SCRIPT_NAME [options]
+
+Smoke check for Context Mode integration health.
+
+Wraps 'ctx doctor' and 'ctx stats', then runs the orchestrator BATS
+parsing-assertion suite to confirm output-parsing is unaffected.
+
+Options:
+    -h, --help           Show this help message
+    --skip-bats          Skip the BATS parsing-assertion suite
+    --ctx-only           Run ctx checks only; skip BATS suite
+    --bats-dir <path>    BATS test directory
+                         (default: $DEFAULT_BATS_DIR)
+    --bats-filter <pat>  bats --filter pattern (default: all tests)
+
+Environment:
+    CONTEXT_MODE_ENABLED  1 = ctx must be present (exit 1 when absent).
+                          0 (default) = skip ctx gracefully when not
+                          installed.
+
+Exit codes:
+    0  all enabled checks passed (or gracefully skipped)
+    1  ctx health check failed (BATS not run or passed)
+    2  BATS parsing-assertion suite failed (ctx passed or was skipped)
+    3  usage / configuration error
+    4  BOTH ctx and BATS failed; both FAIL lines are printed to stderr
+EOF
+}
+
+# =============================================================================
+# CTX CHECKS
+# =============================================================================
+
+check_ctx() {
+	local ctx_enabled="${CONTEXT_MODE_ENABLED:-0}"
+
+	# Resolve the CLI binary once — prefer ctx, fall back to context-mode
+	local cli_bin=""
+	if command -v ctx &>/dev/null; then
+		cli_bin="ctx"
+	elif command -v context-mode &>/dev/null; then
+		cli_bin="context-mode"
+	fi
+
+	if [[ -z "$cli_bin" ]]; then
+		if [[ "$ctx_enabled" == "1" ]]; then
+			result_fail \
+				"ctx (or context-mode) not installed;" \
+				"CONTEXT_MODE_ENABLED=1 requires it"
+			return 1
+		fi
+		log "ctx / context-mode not in PATH;" \
+			"skipping (install plugin to enable)"
+		return 0
+	fi
+
+	# --- doctor ---
+	log "Running: $cli_bin doctor"
+	local doctor_out
+	if ! doctor_out=$("$cli_bin" doctor 2>&1); then
+		result_fail "$cli_bin doctor"
+		printf '%s\n' "$doctor_out" >&2
+		return 1
+	fi
+	result_pass "$cli_bin doctor"
+	printf '%s\n' "$doctor_out"
+
+	# --- stats ---
+	log "Running: $cli_bin stats"
+	local stats_out
+	if ! stats_out=$("$cli_bin" stats 2>&1); then
+		result_fail "$cli_bin stats"
+		printf '%s\n' "$stats_out" >&2
+		return 1
+	fi
+	result_pass "$cli_bin stats"
+	printf '%s\n' "$stats_out"
+
+	return 0
+}
+
+# =============================================================================
+# BATS PARSING ASSERTION
+# =============================================================================
+
+check_bats() {
+	local bats_dir="$1"
+	local bats_filter="$2"
+
+	if ! command -v bats &>/dev/null; then
+		result_fail "bats not found; install bats-core to run assertions"
+		return 2
+	fi
+
+	if [[ ! -d "$bats_dir" ]]; then
+		result_fail "BATS test directory not found: $bats_dir"
+		return 2
+	fi
+
+	# Collect test files; nullglob ensures empty array on no match
+	local -a test_files=()
+	shopt -s nullglob
+	test_files=("$bats_dir"/test-*.bats)
+	shopt -u nullglob
+
+	if (( ${#test_files[@]} == 0 )); then
+		result_fail "No test-*.bats files found in: $bats_dir"
+		return 2
+	fi
+
+	local -a bats_args=()
+	if [[ -n "$bats_filter" ]]; then
+		bats_args+=("--filter" "$bats_filter")
+	fi
+
+	log "Running orchestrator BATS suite" \
+		"(${#test_files[@]} files): $bats_dir"
+
+	local bats_out
+	if ! bats_out=$(
+		bats "${bats_args[@]+"${bats_args[@]}"}" \
+			"${test_files[@]}" 2>&1
+	); then
+		result_fail "Orchestrator BATS suite: parsing assertions failed"
+		printf '%s\n' "$bats_out" >&2
+		return 2
+	fi
+
+	local passed_count=0
+	passed_count=$(
+		printf '%s\n' "$bats_out" | grep -c '^ok ' || true
+	)
+	result_pass "Orchestrator BATS suite (${passed_count} tests passed)"
+	return 0
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+main() {
+	local skip_bats=false
+	local ctx_only=false
+	local bats_dir="$DEFAULT_BATS_DIR"
+	local bats_filter=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			-h|--help)
+				usage
+				exit 0
+				;;
+			--skip-bats)
+				skip_bats=true
+				shift
+				;;
+			--ctx-only)
+				ctx_only=true
+				shift
+				;;
+			--bats-dir)
+				[[ $# -ge 2 ]] || die "--bats-dir requires a value"
+				bats_dir="$2"
+				shift 2
+				;;
+			--bats-filter)
+				[[ $# -ge 2 ]] || die "--bats-filter requires a value"
+				bats_filter="$2"
+				shift 2
+				;;
+			--)
+				shift
+				break
+				;;
+			-*)
+				die "unknown option: $1"
+				;;
+			*)
+				die "unexpected argument: $1"
+				;;
+		esac
+	done
+
+	local overall_exit=0
+	local ctx_failed=false
+
+	# ctx health checks
+	if ! check_ctx; then
+		overall_exit=1
+		ctx_failed=true
+	fi
+
+	# Orchestrator parsing-assertion suite
+	if [[ "$ctx_only" == false && "$skip_bats" == false ]]; then
+		if ! check_bats "$bats_dir" "$bats_filter"; then
+			# When ctx also failed, use exit code 4 so callers can distinguish
+			# "only BATS failed" (2) from "both checks failed" (4).  Both FAIL
+			# lines are always printed to stderr for the human reading the log.
+			if $ctx_failed; then
+				overall_exit=4
+			else
+				overall_exit=2
+			fi
+		fi
+	fi
+
+	if [[ "$overall_exit" -eq 0 ]]; then
+		printf '\n%s: all checks passed\n' "$SCRIPT_NAME"
+	else
+		printf '\n%s: one or more checks failed (exit %d)\n' \
+			"$SCRIPT_NAME" "$overall_exit" >&2
+	fi
+
+	return "$overall_exit"
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/cost-trend-guard.sh
+++ b/plugins/pipeline-core/scripts/cost-trend-guard.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#
+# cost-trend-guard.sh — advisory cost/token trend guard for the pipeline.
+#
+# Computes a rolling MT/issue (megatokens per completed issue) baseline over
+# the most recent N batch summaries and warns when the current batch exceeds
+# that baseline by a configurable factor. The guard is ADVISORY: it never
+# blocks or fails a batch. It emits a JSON verdict on stdout that the batch
+# orchestrator attaches to summary.json (as cost_rollup / trend_warning) and
+# forwards to the event stream as a `cost_trend_warning` event.
+#
+# Metric source:
+#   The batch-level `cost_summary` token totals — total_input_tokens,
+#   total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens —
+#   emitted per-issue by #580 and rolled up across the batch by
+#   batch-orchestrator.sh (init_status / update_progress).
+#
+# NO-OP contract: when `cost_summary` is absent (older summaries pre-#580) or
+# carries only total_cost_usd with no token totals, the token sum is 0 and no
+# MT/issue is derivable, so the verdict is {"status":"noop",...} and no warning
+# is produced.
+#
+# Environment:
+#   COST_TREND_WINDOW  Rolling window size (# of recent batches).  Default 5.
+#   COST_TREND_FACTOR  Warn when latest > baseline * factor.        Default 1.5.
+#
+# Usage:
+#   cost-trend-guard.sh --current <summary-or-status.json> \
+#                       [--history-dir <dir containing batch-*/summary.json>] \
+#                       [--window N] [--factor F]
+#
+# Output (stdout): a single-line JSON verdict. Exit code is always 0 for a
+# well-formed invocation so callers can treat the guard as non-blocking.
+#
+# This file is safe to `source` for unit testing: the CLI entry point only
+# runs when the script is executed directly, not when sourced.
+#
+
+set -uo pipefail
+
+COST_TREND_WINDOW="${COST_TREND_WINDOW:-5}"
+COST_TREND_FACTOR="${COST_TREND_FACTOR:-1.5}"
+
+# -----------------------------------------------------------------------------
+# ctg_batch_mt <summary_json_file>
+#
+# Prints the batch's MT/issue (megatokens per completed issue) as a decimal,
+# or prints NOTHING when the metric is unavailable (no cost_summary, zero
+# completed issues, or no derivable token total). An empty result is the
+# no-op signal.
+# -----------------------------------------------------------------------------
+ctg_batch_mt() {
+	local file="$1"
+	[[ -f "$file" ]] || return 0
+
+	# NO-OP gate: cost_summary must be present (issue #580 prerequisite).
+	local has_cs
+	has_cs=$(jq -r 'if (.cost_summary // null) == null then "no" else "yes" end' \
+		"$file" 2>/dev/null) || has_cs="no"
+	[[ "$has_cs" == "yes" ]] || return 0
+
+	local completed tokens
+	completed=$(jq -r '
+		.progress.completed
+		// ([.issues[]? | select(.status == "completed"
+			or .status == "already_done")] | length)
+		// 0' "$file" 2>/dev/null) || completed=0
+
+	# Sum the batch-level token totals emitted by #580 (per-issue
+	# cost_summary) and rolled up by batch-orchestrator.sh (init_status /
+	# update_progress). When cost_summary carries only total_cost_usd (older
+	# summaries pre-token-rollup), every field is absent → sum is 0 → no-op.
+	tokens=$(jq -r '
+		(.cost_summary) as $cs
+		| (($cs.total_input_tokens // 0)
+			+ ($cs.total_output_tokens // 0)
+			+ ($cs.total_cache_read_tokens // 0)
+			+ ($cs.total_cache_creation_tokens // 0))' \
+		"$file" 2>/dev/null) || tokens=0
+
+	# Not computable → no-op (print nothing).
+	[[ -n "$tokens" && "$tokens" != "0" && "$tokens" != "null" ]] || return 0
+	[[ -n "$completed" && "$completed" != "0" && "$completed" != "null" ]] \
+		|| return 0
+
+	awk -v t="$tokens" -v c="$completed" \
+		'BEGIN { printf "%.6f", (t / 1000000) / c }'
+}
+
+# -----------------------------------------------------------------------------
+# ctg_baseline <window> <summary_file>...
+#
+# Computes the rolling baseline: the mean MT/issue over up to <window> of the
+# most-recent computable summaries. Non-computable summaries (no cost_summary)
+# are skipped. Files are consumed in the order given; the caller is expected to
+# pass them oldest-first (lexical batch-<ts> sort), so the last <window> are
+# the most recent. Prints the mean, or NOTHING when no computable summary
+# exists.
+# -----------------------------------------------------------------------------
+ctg_baseline() {
+	local window="$1"; shift
+	local -a vals=()
+	local f v
+	for f in "$@"; do
+		v=$(ctg_batch_mt "$f")
+		[[ -n "$v" ]] && vals+=("$v")
+	done
+
+	local n=${#vals[@]}
+	(( n > 0 )) || return 0
+
+	local start=0
+	(( n > window )) && start=$(( n - window ))
+	local -a recent=("${vals[@]:start}")
+
+	printf '%s\n' "${recent[@]}" \
+		| awk '{ sum += $1; c++ } END { if (c > 0) printf "%.6f", sum / c }'
+}
+
+# -----------------------------------------------------------------------------
+# ctg_evaluate <current_summary> [history_dir]
+#
+# Produces the advisory verdict JSON on stdout. Honors COST_TREND_WINDOW and
+# COST_TREND_FACTOR. Never exits non-zero for a computable/uncomputable metric.
+# -----------------------------------------------------------------------------
+ctg_evaluate() {
+	local current="$1"
+	local history_dir="${2:-}"
+	local window="${COST_TREND_WINDOW:-5}"
+	local factor="${COST_TREND_FACTOR:-1.5}"
+
+	local latest
+	latest=$(ctg_batch_mt "$current")
+
+	if [[ -z "$latest" ]]; then
+		jq -nc \
+			--argjson window "$window" \
+			--argjson factor "$factor" \
+			'{
+				status: "noop",
+				warning: false,
+				reason: "cost_summary absent or MT/issue not derivable",
+				latest_mt_per_issue: null,
+				baseline_mt_per_issue: null,
+				window: $window,
+				factor: $factor
+			}'
+		return 0
+	fi
+
+	local -a hist_files=()
+	if [[ -n "$history_dir" && -d "$history_dir" ]]; then
+		local f
+		while IFS= read -r f; do
+			[[ -n "$f" ]] || continue
+			[[ "$f" -ef "$current" ]] && continue
+			hist_files+=("$f")
+		done < <(find "$history_dir" -type f -name 'summary.json' \
+			2>/dev/null | sort)
+	fi
+
+	local baseline=""
+	(( ${#hist_files[@]} > 0 )) \
+		&& baseline=$(ctg_baseline "$window" "${hist_files[@]}")
+
+	if [[ -z "$baseline" ]]; then
+		jq -nc \
+			--argjson latest "$latest" \
+			--argjson window "$window" \
+			--argjson factor "$factor" \
+			'{
+				status: "ok",
+				warning: false,
+				reason: "no baseline history",
+				latest_mt_per_issue: $latest,
+				baseline_mt_per_issue: null,
+				window: $window,
+				factor: $factor
+			}'
+		return 0
+	fi
+
+	jq -nc \
+		--argjson latest "$latest" \
+		--argjson baseline "$baseline" \
+		--argjson window "$window" \
+		--argjson factor "$factor" \
+		'($baseline * $factor) as $threshold
+		 | ($latest > $threshold) as $warn
+		 | {
+			status: "ok",
+			warning: $warn,
+			latest_mt_per_issue: $latest,
+			baseline_mt_per_issue: $baseline,
+			threshold_mt_per_issue: $threshold,
+			window: $window,
+			factor: $factor,
+			message: (if $warn
+				then "MT/issue \($latest) exceeds baseline "
+					+ "\($baseline) × \($factor) = \($threshold)"
+				else "MT/issue \($latest) within baseline "
+					+ "\($baseline) × \($factor) = \($threshold)"
+				end)
+		 }'
+}
+
+# -----------------------------------------------------------------------------
+# CLI entry point
+# -----------------------------------------------------------------------------
+ctg_usage() {
+	cat >&2 <<'EOF'
+Usage: cost-trend-guard.sh --current <summary.json> [options]
+
+Options:
+  --current <file>       Batch summary/status JSON to evaluate (required)
+  --history-dir <dir>    Directory tree containing prior batch-*/summary.json
+  --window <N>           Rolling window size (overrides COST_TREND_WINDOW)
+  --factor <F>           Warn factor (overrides COST_TREND_FACTOR)
+  -h, --help             Show this help
+
+Environment: COST_TREND_WINDOW (default 5), COST_TREND_FACTOR (default 1.5).
+Output: a single-line advisory JSON verdict on stdout. Never blocking.
+EOF
+}
+
+ctg_main() {
+	local current="" history_dir=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--current)
+				current="${2:-}"; shift 2 ;;
+			--history-dir)
+				history_dir="${2:-}"; shift 2 ;;
+			--window)
+				COST_TREND_WINDOW="${2:-}"; shift 2 ;;
+			--factor)
+				COST_TREND_FACTOR="${2:-}"; shift 2 ;;
+			-h|--help)
+				ctg_usage; return 0 ;;
+			*)
+				printf 'cost-trend-guard: unknown argument: %s\n' "$1" >&2
+				return 2 ;;
+		esac
+	done
+
+	if [[ -z "$current" ]]; then
+		printf 'cost-trend-guard: --current <summary.json> is required\n' >&2
+		return 2
+	fi
+
+	ctg_evaluate "$current" "$history_dir"
+}
+
+# Only run the CLI when executed directly, not when sourced by tests.
+# The `:-` guards keep this safe under `set -u` when sourced by a shell that
+# does not populate BASH_SOURCE.
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+	ctg_main "$@"
+fi

--- a/plugins/pipeline-core/scripts/create-followup-issue.sh
+++ b/plugins/pipeline-core/scripts/create-followup-issue.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# create-followup-issue.sh — deterministic follow-up issue body generator
+#
+# Emits a complete, validated issue body on stdout.
+# Calls assert_issue_valid fail-closed: exits non-zero without printing
+# anything when the generated body fails validation.
+#
+# Usage:
+#   create-followup-issue.sh --title TITLE --description DESC
+#       --file-path FILE_PATH --pr-number PR_NUM
+#       --issue-number ISSUE_NUM --reviewer REVIEWER
+#       [--task-description TASK_DESC] [--labels LABELS]
+#       [--type precise|vague]
+#
+# Environment:
+#   DEPLOY_VERIFY_CMD       When set, appends a ## Deploy Verification section.
+#   FRONTEND_PATH_PATTERNS  Pipe-separated glob patterns (from platform.sh)
+#                           used to disambiguate TS/JS frontend vs backend.
+#   ISSUE_BODY_AGENTS_DIR   Override agents directory (testing/portability).
+#   ISSUE_BODY_REPO_ROOT    Override repo root for path resolution (default: .).
+#
+# Exit codes:
+#   0 — valid body written to stdout
+#   1 — body failed assert_issue_valid (diagnostics on stderr; nothing on stdout)
+#   3 — missing required argument
+#
+
+set -eo pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly SCRIPT_DIR
+
+# Source the shared validator — exposes assert_issue_valid + valid_agents.
+# shellcheck source=issue-body-lib.sh
+source "${SCRIPT_DIR}/issue-body-lib.sh"
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 3
+}
+
+# _infer_agent_from_path is provided by issue-body-lib.sh (sourced above).
+
+# Appends the ## References block to the body being assembled.
+# Writes to stdout.
+_references_block() {
+	local pr_num="$1"
+	local issue_num="$2"
+	local rev="$3"
+
+	printf '\n## References\n'
+	printf '%s\n' "- Parent Issue: #${issue_num}"
+	printf '%s\n' "- PR/MR: #${pr_num}"
+	printf '%s\n' "- Reviewer: @${rev}"
+}
+
+# Appends ## Deploy Verification iff DEPLOY_VERIFY_CMD is set.
+# Writes to stdout (nothing written when DEPLOY_VERIFY_CMD is unset).
+_deploy_verification_block() {
+	[[ -z "${DEPLOY_VERIFY_CMD:-}" ]] && return
+
+	printf '\n## Deploy Verification\n'
+	# Backticks below are markdown delimiters, not command substitution.
+	# shellcheck disable=SC2016
+	printf '\n**Verification command:** `%s`\n' "$DEPLOY_VERIFY_CMD"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+title=""
+description=""
+task_description=""
+file_path=""
+pr_number=""
+issue_number=""
+reviewer=""
+labels=""
+type="precise"
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--title)
+			title="$2"
+			shift 2
+			;;
+		--description)
+			description="$2"
+			shift 2
+			;;
+		--task-description)
+			task_description="$2"
+			shift 2
+			;;
+		--file-path)
+			file_path="$2"
+			shift 2
+			;;
+		--pr-number)
+			pr_number="$2"
+			shift 2
+			;;
+		--issue-number)
+			issue_number="$2"
+			shift 2
+			;;
+		--reviewer)
+			reviewer="$2"
+			shift 2
+			;;
+		--labels)
+			# Labels are applied at issue-creation time — never in the body.
+			# Accepted here for CLI parity with the platform creator.
+			# shellcheck disable=SC2034
+			labels="$2"
+			printf '%s: note: --labels is not embedded in the body; ' \
+				"$SCRIPT_NAME" >&2
+			printf 'pass --labels to create-issue.sh at issue-creation time\n' >&2
+			shift 2
+			;;
+		--type)
+			type="$2"
+			shift 2
+			;;
+		--)
+			shift
+			break
+			;;
+		-*)
+			printf '%s: unknown option: %s\n' "$SCRIPT_NAME" "$1" >&2
+			exit 3
+			;;
+		*)
+			break
+			;;
+	esac
+done
+
+[[ -n "$title" ]]        || die "--title is required"
+[[ -n "$description" ]]  || die "--description is required"
+[[ -n "$file_path" ]]    || die "--file-path is required"
+[[ -n "$pr_number" ]]    || die "--pr-number is required"
+[[ -n "$issue_number" ]] || die "--issue-number is required"
+[[ -n "$reviewer" ]]     || die "--reviewer is required"
+
+case "$type" in
+	precise|vague) ;;
+	*) die "--type must be 'precise' or 'vague' (got: ${type})" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Agent inference
+# ---------------------------------------------------------------------------
+
+agent=$(_infer_agent_from_path "$file_path")
+
+# ---------------------------------------------------------------------------
+# Body construction — mirrors _build_adj_body (orchestrator L3611-3681)
+# ---------------------------------------------------------------------------
+
+# task_description falls back to title when not explicitly provided.
+task_desc="${task_description:-$title}"
+
+body=""
+
+if [[ "$type" == "vague" ]]; then
+	body+="<!-- pipeline-autocreated -->"$'\n'
+	body+="## Context"$'\n'
+	body+="Created from code review of PR/MR #${pr_number}"
+	body+=" (Issue #${issue_number})"$'\n'
+	body+=$'\n'
+	body+="## Description"$'\n'
+	body+="${description}"$'\n'
+	body+=$'\n'
+	body+="> **Note:** This item was classified as vague and needs further"$'\n'
+	body+="> research before implementation. A human or automated explore"$'\n'
+	body+="> sweep should flesh out the implementation tasks."$'\n'
+	body+=$'\n'
+	body+="## Implementation Tasks"$'\n'
+	body+=$'\n'
+	body+="- [ ] \`[${agent}]\` **(S)**"
+	body+=" Explore and implement: ${title} — \`${file_path}\`"$'\n'
+	body+=$'\n'
+	body+="## Acceptance Criteria"$'\n'
+	body+=$'\n'
+	body+="- [ ] The behaviour described in \"${title}\" is observable"
+	body+=" and testable (to be made precise during the explore phase)"$'\n'
+	body+="- [ ] Tests covering the implemented change pass"$'\n'
+else
+	body+="<!-- pipeline-autocreated -->"$'\n'
+	body+="## Context"$'\n'
+	body+="Created from code review of PR/MR #${pr_number}"
+	body+=" (Issue #${issue_number})"$'\n'
+	body+=$'\n'
+	body+="## Description"$'\n'
+	body+="${description}"$'\n'
+	body+=$'\n'
+	body+="## Implementation Tasks"$'\n'
+	body+=$'\n'
+	body+="- [ ] \`[${agent}]\` **(M)**"
+	body+=" ${task_desc} — \`${file_path}\`"$'\n'
+	body+=$'\n'
+	body+="## Acceptance Criteria"$'\n'
+	body+=$'\n'
+	body+="- [ ] \`${file_path}\`: ${task_desc}"
+	body+=" produces the expected behaviour"$'\n'
+	body+="- [ ] Tests covering the change in \`${file_path}\` pass"$'\n'
+fi
+
+body+=$(_references_block "$pr_number" "$issue_number" "$reviewer")
+body+=$(_deploy_verification_block)
+
+# ---------------------------------------------------------------------------
+# Fail-closed validation — nothing is emitted when the body is invalid.
+# assert_issue_valid writes diagnostics to stderr; we add a summary line
+# and exit 1 without touching stdout.
+# ---------------------------------------------------------------------------
+
+if ! assert_issue_valid "$body"; then
+	printf '%s: generated body failed validation — body not emitted\n' \
+		"$SCRIPT_NAME" >&2
+	exit 1
+fi
+
+printf '%s\n' "$body"

--- a/plugins/pipeline-core/scripts/decide-action.sh
+++ b/plugins/pipeline-core/scripts/decide-action.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+#
+# decide-action.sh — glue between orchestrator and escalation-policy skill
+#
+# Usage: decide-action.sh <stage_result_json> <history_json>
+#
+# Routes stage completion by composing two specialist decisions:
+#   - decide-retry.sh         (retry-policy skill)    — retry vs escalate vs bail
+#   - decide-model-fallback.sh (model-fallback skill) — next model on escalate
+#
+# Falls back to an inline bash decision tree on composition failure or when
+# ESCALATION_POLICY_BACKEND=bash.
+#
+# Environment:
+#   ESCALATION_POLICY_BACKEND — set to "bash" to bypass composition and use
+#                               the inline decision tree directly
+#   RETRY_POLICY_BACKEND      — forwarded to decide-retry.sh (default: bash)
+#   MODEL_FALLBACK_BACKEND    — forwarded to decide-model-fallback.sh
+#                               (default: bash)
+#
+# Output (stdout):
+#   {"action":"<accept|escalate|bail|retry_same>",
+#    "model":"<tier>",    # present only when action == "escalate"
+#    "reason":"<string>"}
+#
+# Exit codes:
+#   0 — action decided (composition or bash fallback)
+#   1 — bad arguments
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Per-run escalation cap (issue #579).  Mirrors the orchestrator constant of the
+# same name.  Once the escalation history reaches this length, main() bails fast
+# instead of dispatching another escalation — this prevents the pathological 6+
+# escalation bucket where completion rate collapses.  Env-overridable; set to a
+# large value (e.g. 999) to restore prior unbounded behaviour.
+MAX_ESCALATIONS_PER_RUN="${MAX_ESCALATIONS_PER_RUN:-5}"
+
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 1
+}
+
+# ---------------------------------------------------------------------------
+# _next_model <model>
+# Print the next escalation tier.  haiku→sonnet, sonnet/other→opus.
+# Used by _bash_decide; model selection for the composition path is
+# delegated to decide-model-fallback.sh.
+# ---------------------------------------------------------------------------
+_next_model() {
+	local model="$1"
+	case "$model" in
+		haiku)  printf 'sonnet' ;;
+		sonnet) printf 'opus'   ;;
+		*)      printf 'opus'   ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# _s_opus_gate_bail <error_kind>
+# Emit the S-complexity Opus-gate bail action (issue #579).  A short task at
+# sonnet must not auto-escalate to opus on a single stage failure — Opus buys
+# no completion lift for S tasks, only cost — so bail and require a bounded
+# trigger.  Shared by _bash_decide (double_timeout + default branches) and
+# _compose_decide (escalate branch) so both backends emit identical output.
+# ---------------------------------------------------------------------------
+_s_opus_gate_bail() {
+	local error_kind="${1:-unknown}"
+	printf '{"action":"bail","reason":"%s: S-complexity task at sonnet — not escalating to opus (issue #579)"}\n' \
+		"$error_kind"
+}
+
+# ---------------------------------------------------------------------------
+# _bash_decide <stage_result_json> <history_json>
+# Inline decision tree matching escalation-policy SKILL.md.
+# Prints action JSON to stdout; never calls external scripts.
+# ---------------------------------------------------------------------------
+_bash_decide() {
+	local stage_result="$1"
+	local history="$2"
+
+	local status error_kind model complexity
+	status=$(printf '%s' "$stage_result" | jq -r '.status')
+	error_kind=$(printf '%s' "$stage_result" | jq -r '.error_kind')
+	model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+	complexity=$(printf '%s' "$stage_result" | jq -r '.complexity // empty')
+
+	# success at top level → accept regardless of .output.status presence
+	if [[ "$status" == "success" ]]; then
+		printf '%s\n' \
+			'{"action":"accept","reason":"stage completed successfully"}'
+		return 0
+	fi
+
+	# unrecoverable configuration or permission error → bail
+	if [[ "$error_kind" == "permission_denied" || \
+	      "$error_kind" == "schema_not_found" || \
+	      "$error_kind" == "agent_not_found" ]]; then
+		printf \
+			'{"action":"bail","reason":"%s: unrecoverable error"}\n' \
+			"$error_kind"
+		return 0
+	fi
+
+	# explicitly flagged as ceiling-exhausted → bail
+	if [[ "$error_kind" == "max_turns_exhausted_at_ceiling" ]]; then
+		printf '%s\n' \
+			'{"action":"bail","reason":"max_turns_exhausted_at_ceiling: already at opus ceiling"}'
+		return 0
+	fi
+
+	# quality_stall → escalate, or bail if already at opus ceiling
+	if [[ "$error_kind" == "quality_stall" ]]; then
+		if [[ "$model" == "opus" ]]; then
+			printf '%s\n' \
+				'{"action":"bail","reason":"quality_stall: already at opus ceiling"}'
+		elif [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
+			# S-complexity gate (issue #579): a short task at sonnet must
+			# not auto-escalate to opus on a quality_stall — mirrors the
+			# double_timeout branch, and matches the compose backend which
+			# already bails this case.  run_quality_loop threads task_size
+			# through, so a fix/simplify stage quality-stalling on an S task
+			# reaches here on a realistic path.
+			#
+			# NOTE: M/L quality_stall backend divergence (bash escalates,
+			# compose bails "not a recognised upgrade trigger") is
+			# pre-existing and NOT introduced by #579 — left unchanged here.
+			_s_opus_gate_bail "quality_stall"
+		else
+			local next_model
+			next_model=$(_next_model "$model")
+			printf '{"action":"escalate","model":"%s","reason":"quality_stall: escalating from %s to %s"}\n' \
+				"$next_model" "$model" "$next_model"
+		fi
+		return 0
+	fi
+
+	# double_timeout → escalate, or bail if already at opus ceiling
+	if [[ "$error_kind" == "double_timeout" ]]; then
+		if [[ "$model" == "opus" ]]; then
+			printf '%s\n' \
+				'{"action":"bail","reason":"double_timeout"}'
+		elif [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
+			# S-complexity gate (issue #579): a short task at sonnet must
+			# not auto-escalate to opus on a single double_timeout.
+			_s_opus_gate_bail "double_timeout"
+		else
+			local next_model
+			next_model=$(_next_model "$model")
+			printf '{"action":"escalate","model":"%s","reason":"double_timeout"}\n' \
+				"$next_model"
+		fi
+		return 0
+	fi
+
+	# already at opus → bail (cannot escalate further)
+	if [[ "$model" == "opus" ]]; then
+		printf '%s\n' \
+			'{"action":"bail","reason":"at opus ceiling: cannot escalate further"}'
+		return 0
+	fi
+
+	# rate_limit + no prior attempt at same model → retry_same
+	if [[ "$error_kind" == "rate_limit" ]]; then
+		local prior_count
+		prior_count=$(printf '%s' "$history" | \
+			jq --arg m "$model" \
+			   '[.[] | select(.from_model == $m)] | length')
+		if (( prior_count == 0 )); then
+			printf '%s\n' \
+				'{"action":"retry_same","reason":"rate_limit: transient throttle, retrying with same model"}'
+			return 0
+		fi
+	fi
+
+	# S-complexity gate (issue #579): before the default escalate, bail an
+	# S task at sonnet rather than promoting it to opus.  Placed after the
+	# rate_limit retry_same and opus-ceiling checks so those paths are
+	# unaffected — only the sonnet→opus escalation is gated.
+	if [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
+		_s_opus_gate_bail "${error_kind:-unknown}"
+		return 0
+	fi
+
+	# default: escalate to next tier
+	local next_model reason
+	next_model=$(_next_model "$model")
+	reason="${error_kind:-unknown}: escalating from $model to $next_model"
+	printf '{"action":"escalate","model":"%s","reason":"%s"}\n' \
+		"$next_model" "$reason"
+}
+
+# ---------------------------------------------------------------------------
+# _valid_retry_schema <json>
+# Return 0 if json has a valid retry-policy output schema.
+# ---------------------------------------------------------------------------
+_valid_retry_schema() {
+	local json="$1"
+	local action reason
+	action=$(printf '%s' "$json" | jq -r '.action // empty' 2>/dev/null)
+	reason=$(printf '%s' "$json" | jq -r '.reason // empty' 2>/dev/null)
+	case "$action" in
+		retry|escalate|bail) ;;
+		*) return 1 ;;
+	esac
+	[[ -n "$reason" ]]
+}
+
+# ---------------------------------------------------------------------------
+# _valid_fallback_schema <json>
+# Return 0 if json has a valid model-fallback output schema.
+# Uses != null rather than // empty to handle at_ceiling=false correctly:
+# jq's // operator triggers on false as well as null.
+# ---------------------------------------------------------------------------
+_valid_fallback_schema() {
+	local json="$1"
+	printf '%s' "$json" | \
+		jq -e '.at_ceiling != null' >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# _compose_decide <stage_result_json> <history_json>
+# Delegate retry decisions to decide-retry.sh (retry-policy skill) and
+# model upgrade decisions to decide-model-fallback.sh (model-fallback skill).
+# Falls back to _bash_decide on composition failure.
+# ---------------------------------------------------------------------------
+_compose_decide() {
+	local stage_result="$1"
+	local history="$2"
+
+	local status error_kind model complexity
+	status=$(printf '%s' "$stage_result" | jq -r '.status')
+	error_kind=$(printf '%s' "$stage_result" | jq -r '.error_kind')
+	model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+	complexity=$(printf '%s' "$stage_result" | jq -r '.complexity // empty')
+
+	# success at top level → accept regardless of .output.status presence
+	if [[ "$status" == "success" ]]; then
+		printf '%s\n' \
+			'{"action":"accept","reason":"stage completed successfully"}'
+		return 0
+	fi
+
+	# Derive retry_count from escalation history — count prior same-model
+	# attempts recorded as from_model entries.
+	local retry_count
+	retry_count=$(printf '%s' "$history" | \
+		jq --arg m "$model" \
+		   '[.[] | select(.from_model == $m)] | length')
+
+	# Delegate retry decision to decide-retry.sh (retry-policy skill).
+	# Escalation history lacks per-error-kind records; pass an empty
+	# error_history array so retry-policy uses retry_count for threshold
+	# checks.  Defaults to bash backend unless RETRY_POLICY_BACKEND is set.
+	#
+	# NOTE: the inline ${RETRY_POLICY_BACKEND:-bash} default means callers
+	# MUST use `export RETRY_POLICY_BACKEND=claude` (not a bare assignment)
+	# to reach the live Claude path in decide-retry.sh.  A bare assignment
+	# (e.g. RETRY_POLICY_BACKEND=claude; decide-action.sh) without export
+	# leaves the variable unexported, so $RETRY_POLICY_BACKEND is empty
+	# inside this script and the :-bash default forces the bash path.
+	local retry_out
+	retry_out=$(
+		RETRY_POLICY_BACKEND="${RETRY_POLICY_BACKEND:-bash}" \
+		"$SCRIPT_DIR/decide-retry.sh" \
+		"$stage_result" "$retry_count" '[]' \
+		2>/dev/null
+	) || true
+
+	if ! _valid_retry_schema "$retry_out"; then
+		printf \
+			'%s: warning: retry-policy output invalid; using bash fallback\n' \
+			"$SCRIPT_NAME" >&2
+		_bash_decide "$stage_result" "$history"
+		return 0
+	fi
+
+	local retry_action
+	retry_action=$(printf '%s' "$retry_out" | jq -r '.action')
+
+	case "$retry_action" in
+		retry)
+			# retry-policy wants same-tier retry; map to retry_same
+			printf '%s' "$retry_out" | \
+				jq -c '{action:"retry_same",reason:.reason}'
+			return 0
+			;;
+		bail)
+			printf '%s' "$retry_out" | \
+				jq -c '{action:"bail",reason:.reason}'
+			return 0
+			;;
+		escalate)
+			# S-complexity gate (issue #579): keep the skill-native path in
+			# agreement with _bash_decide — an S task at sonnet bails rather
+			# than escalating to opus, so Opus requires a bounded trigger.
+			# Checked before model-fallback delegation because sonnet's next
+			# tier is opus.
+			if [[ "$complexity" == "S" && "$model" == "sonnet" ]]; then
+				_s_opus_gate_bail "${error_kind:-unknown}"
+				return 0
+			fi
+
+			# Delegate model selection to decide-model-fallback.sh.
+			# Defaults to bash backend unless MODEL_FALLBACK_BACKEND is set.
+			local retry_reason fallback_out
+			retry_reason=$(printf '%s' "$retry_out" | jq -r '.reason')
+			fallback_out=$(
+				MODEL_FALLBACK_BACKEND="${MODEL_FALLBACK_BACKEND:-bash}" \
+				"$SCRIPT_DIR/decide-model-fallback.sh" \
+				"$stage_result" \
+				2>/dev/null
+			) || true
+
+			if ! _valid_fallback_schema "$fallback_out"; then
+				printf \
+					'%s: warning: model-fallback output invalid; using bash fallback\n' \
+					"$SCRIPT_NAME" >&2
+				_bash_decide "$stage_result" "$history"
+				return 0
+			fi
+
+			local at_ceiling next_model fallback_reason
+			at_ceiling=$(printf '%s' "$fallback_out" \
+				| jq -r '.at_ceiling')
+			next_model=$(printf '%s' "$fallback_out" \
+				| jq -r '.next_model')
+			fallback_reason=$(printf '%s' "$fallback_out" \
+				| jq -r '.reason')
+
+			if [[ "$at_ceiling" == "true" || \
+			      "$next_model" == "null" ]]; then
+				printf '%s' "$fallback_out" | \
+					jq -c '{action:"bail",reason:.reason}'
+			else
+				jq -cn \
+					--arg model "$next_model" \
+					--arg reason "$retry_reason; $fallback_reason" \
+					'{action:"escalate",model:$model,reason:$reason}'
+			fi
+			return 0
+			;;
+		*) printf '%s: error: unexpected retry_action: %s\n' \
+			"$SCRIPT_NAME" "$retry_action" >&2; return 1 ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	[[ $# -ge 2 ]] \
+		|| die "usage: $SCRIPT_NAME <stage_result_json> <history_json>"
+
+	local stage_result="$1"
+	local history="$2"
+
+	# Per-run escalation cap (issue #579): once the run has accrued
+	# MAX_ESCALATIONS_PER_RUN escalations, fail fast instead of continuing into
+	# the pathological 6+ bucket where completion rate collapses.  Checked here,
+	# before either backend, so the inline bash and skill-native compose paths
+	# agree.  Only an error stage is capped — a success must still be accepted
+	# regardless of history length, so both backends still run for success.
+	local _status _esc_count
+	_status=$(printf '%s' "$stage_result" | jq -r '.status // empty' 2>/dev/null)
+	_esc_count=$(printf '%s' "$history" | jq 'length' 2>/dev/null) || _esc_count=0
+	if [[ "$_status" != "success" ]] \
+		&& (( _esc_count >= MAX_ESCALATIONS_PER_RUN )); then
+		printf '{"action":"bail","reason":"escalation cap reached: %s escalations >= MAX_ESCALATIONS_PER_RUN=%s (issue #579)"}\n' \
+			"$_esc_count" "$MAX_ESCALATIONS_PER_RUN"
+		return 0
+	fi
+
+	# Kill-switch: bypass composition and use inline bash directly
+	if [[ "${ESCALATION_POLICY_BACKEND:-}" == "bash" ]]; then
+		_bash_decide "$stage_result" "$history"
+		return 0
+	fi
+
+	# Delegate to retry-policy and model-fallback skills via composition
+	_compose_decide "$stage_result" "$history"
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/decide-model-fallback.sh
+++ b/plugins/pipeline-core/scripts/decide-model-fallback.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+#
+# decide-model-fallback.sh — glue between orchestrator and model-fallback
+#
+# Usage: decide-model-fallback.sh <stage_result_json>
+#
+# Given a failed stage_result, decides whether the next attempt should run
+# at a higher model tier.  Inputs are read from .model and .error_kind on
+# the stage_result; output is a JSON object describing the next-model
+# decision and whether the model ceiling has been reached.
+#
+# Environment:
+#   MODEL_FALLBACK_BACKEND — controls backend selection.
+#     "bash"   — bypass skill invocation; use inline decision tree (testing).
+#     "claude" — invoke model-fallback skill via Claude (default when unset).
+#
+# Output (stdout):
+#   {"next_model": "<tier>"|null,
+#    "at_ceiling": <bool>,
+#    "reason": "<string>"}
+#
+# Exit codes:
+#   0 — decision produced
+#   1 — bad arguments
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 1
+}
+
+# Source model-config.sh for _next_model_up().  The file uses readonly
+# arrays guarded by [[ -z "${_STAGE_PREFIXES+set}" ]], so re-sourcing in
+# the same shell is idempotent.
+# shellcheck source=./model-config.sh
+. "$SCRIPT_DIR/model-config.sh"
+
+# ---------------------------------------------------------------------------
+# _is_upgrade_trigger <error_kind>
+# Return 0 when error_kind is one of the recognised upgrade triggers, 1
+# otherwise.  Conservative by design: unknown classes do not upgrade.
+# ---------------------------------------------------------------------------
+_is_upgrade_trigger() {
+	# rate_limit is an upgrade trigger only after same-tier retry limits
+	# are met — see retry-policy.  The orchestrator is responsible for
+	# exhausting per-tier retries before calling this script.
+	case "$1" in
+		timeout|double_timeout|max_turns_exhausted|no_structured_output|\
+		structured_error|rate_limit)
+			return 0
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# _bash_model_fallback <stage_result_json>
+# Inline decision tree for the model-fallback skill.  Prints decision
+# JSON to stdout; never calls claude.
+# ---------------------------------------------------------------------------
+_bash_model_fallback() {
+	local stage_result="$1"
+
+	local model error_kind
+	model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+	error_kind=$(printf '%s' "$stage_result" \
+		| jq -r '.error_kind // "null"')
+
+	# Non-escalatable errors: a higher model cannot fix these regardless of
+	# the current tier.  Must be checked before the opus ceiling test so
+	# haiku/sonnet also return at_ceiling=true for these error kinds.
+	case "$error_kind" in
+		permission_denied|schema_not_found|\
+		max_turns_exhausted_at_ceiling)
+			local reason
+			reason="${error_kind}: non-escalatable, no model can fix this"
+			jq -nc --argjson next_model null \
+				--arg reason "$reason" \
+				--argjson at_ceiling true \
+				'{next_model: $next_model, at_ceiling: $at_ceiling, reason: $reason}'
+			return 0
+			;;
+	esac
+
+	# At ceiling: opus has no higher tier to upgrade to.
+	if [[ "$model" == "opus" ]]; then
+		local reason
+		reason="at opus ceiling: no higher tier available"
+		jq -nc --argjson next_model null \
+			--arg reason "$reason" \
+			--argjson at_ceiling true \
+			'{next_model: $next_model, at_ceiling: $at_ceiling, reason: $reason}'
+		return 0
+	fi
+
+	# Recognised upgrade trigger: bump to the next tier up.
+	if _is_upgrade_trigger "$error_kind"; then
+		local next reason
+		next=$(_next_model_up "$model")
+		reason="${error_kind}: upgrading ${model} → ${next}"
+		jq -nc --arg next_model "$next" \
+			--arg reason "$reason" \
+			--argjson at_ceiling false \
+			'{next_model: $next_model, at_ceiling: $at_ceiling, reason: $reason}'
+		return 0
+	fi
+
+	# Unrecognised error_kind: conservative no-upgrade.
+	local reason
+	reason="${error_kind}: not a recognised upgrade trigger, no-upgrade"
+	jq -nc --argjson next_model null \
+		--arg reason "$reason" \
+		--argjson at_ceiling false \
+		'{next_model: $next_model, at_ceiling: $at_ceiling, reason: $reason}'
+}
+
+# ---------------------------------------------------------------------------
+# _run_with_timeout <seconds> <command> [args...]
+# Run a command with a wall-clock timeout.  Uses GNU timeout when available;
+# falls back to direct execution on systems where timeout is not installed
+# (e.g. macOS without coreutils).
+# ---------------------------------------------------------------------------
+_run_with_timeout() {
+	local secs="$1"
+	shift
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$secs" "$@"
+	else
+		"$@"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# _claude_model_fallback <stage_result_json>
+# Live Claude skill invocation via /model-fallback.
+# Prints decision JSON to stdout; exits non-zero on invocation failure.
+# ---------------------------------------------------------------------------
+_claude_model_fallback() {
+	local stage_result="$1"
+
+	local schema_file="$SCRIPT_DIR/schemas/model-fallback-output.json"
+	# Prefer the post-git-mv plugin layout (plugins/pipeline-core/skills/) and
+	# fall back to the legacy .claude/skills/ layout so this works on both sides
+	# of the restructure.
+	local skill_file="$SCRIPT_DIR/../../plugins/pipeline-core/skills/model-fallback/SKILL.md"
+	if [[ ! -f "$skill_file" ]]; then
+		skill_file="$SCRIPT_DIR/../skills/model-fallback/SKILL.md"
+	fi
+
+	if [[ ! -f "$skill_file" ]]; then
+		printf '%s: model-fallback SKILL.md not found: %s\n' \
+			"$SCRIPT_NAME" "$skill_file" >&2
+		return 1
+	fi
+	if [[ ! -f "$schema_file" ]]; then
+		printf '%s: model-fallback schema not found: %s\n' \
+			"$SCRIPT_NAME" "$schema_file" >&2
+		return 1
+	fi
+
+	local schema_compact
+	schema_compact=$(jq -c . "$schema_file" 2>&1) || {
+		printf '%s: failed to compact schema: %s\n' \
+			"$SCRIPT_NAME" "$schema_compact" >&2
+		return 1
+	}
+
+	local current_model error_kind
+	current_model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+	error_kind=$(printf '%s' "$stage_result" | jq -r '.error_kind // "null"')
+
+	local prompt
+	prompt=$(printf '/model-fallback\n\nINPUTS:\ncurrent_model: %s\nerror_kind: %s\n' \
+		"$current_model" "$error_kind")
+
+	local output rc
+	output=$(_run_with_timeout "${CLAUDE_SKILL_TIMEOUT:-120}" \
+		env -u CLAUDECODE claude -p "$prompt" \
+		--dangerously-skip-permissions \
+		--output-format json \
+		--json-schema "$schema_compact" 2>&1)
+	rc=$?
+
+	if (( rc != 0 )); then
+		printf '%s: claude invocation failed (exit %d): %s\n' \
+			"$SCRIPT_NAME" "$rc" "$output" >&2
+		return 1
+	fi
+
+	# Extract the structured payload from the claude output envelope.
+	# Mirrors sg_extract_payload() in skill-golden-lib.sh and run_stage() in
+	# implement-issue-orchestrator.sh — keep these in sync.
+	local payload
+	payload=$(printf '%s' "$output" | jq -c '
+		.structured_output
+		// (.result | if type == "string" then fromjson? else . end)
+		// .
+	' 2>/dev/null)
+
+	if [[ -z "$payload" ]] || ! printf '%s' "$payload" \
+		| jq -e 'has("next_model")' >/dev/null 2>&1; then
+		printf '%s: no valid next_model in claude output\n' \
+			"$SCRIPT_NAME" >&2
+		return 1
+	fi
+
+	printf '%s\n' "$payload"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	[[ $# -ge 1 ]] \
+		|| die "usage: $SCRIPT_NAME <stage_result_json>"
+
+	local stage_result="$1"
+
+	case "${MODEL_FALLBACK_BACKEND:-claude}" in
+		bash)
+			_bash_model_fallback "$stage_result"
+			;;
+		claude)
+			_claude_model_fallback "$stage_result" \
+				|| _bash_model_fallback "$stage_result"
+			;;
+		*)
+			die "unknown MODEL_FALLBACK_BACKEND" \
+				"'${MODEL_FALLBACK_BACKEND}'; valid values: bash, claude"
+			;;
+	esac
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/decide-retry.sh
+++ b/plugins/pipeline-core/scripts/decide-retry.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+#
+# decide-retry.sh — glue between orchestrator and retry-policy skill
+#
+# Usage: decide-retry.sh <stage_result_json> <retry_count> <error_history_json>
+#
+# Applies the retry-policy skill decision tree: given a failed stage_result,
+# the number of retries already attempted at the current model tier, and the
+# per-tier error history, decides whether to retry the stage, escalate to a
+# higher tier, or bail permanently.
+#
+# Environment:
+#   RETRY_POLICY_BACKEND — unset or "claude": invoke retry-policy skill via Claude (default)
+#                          "bash": bypass Claude and use the inline decision tree (for testing)
+#
+# Output (stdout):
+#   {"action":"<retry|escalate|bail>",
+#    "reason":"<string>",
+#    "backoff_ms": N}   # present only when action==retry and error_kind==rate_limit
+#
+# Exit codes:
+#   0 — action decided (skill or bash fallback)
+#   1 — bad arguments or Claude invocation failure
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 1
+}
+
+# ---------------------------------------------------------------------------
+# _run_with_timeout <seconds> <command> [args...]
+# Run a command with a wall-clock timeout.  Uses GNU timeout when available;
+# falls back to direct execution on systems where timeout is not installed
+# (e.g. macOS without coreutils).
+# ---------------------------------------------------------------------------
+_run_with_timeout() {
+	local secs="$1"
+	shift
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$secs" "$@"
+	else
+		"$@"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# _next_model <model>
+# Print the next escalation tier.  haiku→sonnet, sonnet/other→opus.
+# ---------------------------------------------------------------------------
+_next_model() {
+	local model="$1"
+	case "$model" in
+		haiku) printf 'sonnet' ;;
+		*)     printf 'opus'   ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# _max_retries <error_kind>
+# Print the maximum same-tier retry count for the given error class.
+# ---------------------------------------------------------------------------
+_max_retries() {
+	local error_kind="$1"
+	case "$error_kind" in
+		rate_limit)           printf '3' ;;
+		no_structured_output) printf '1' ;;
+		timeout)              printf '1' ;;
+		structured_error)     printf '1' ;;
+		# Known non-retriable errors: escalate or bail immediately.
+		# Listed explicitly so new error_kinds don't silently inherit 0-retry
+		# behaviour — add an entry here when extending the error_kind enum.
+		max_turns_exhausted|quality_stall|double_timeout) printf '0' ;;
+		# Unknown error_kind: fail closed — 0 retries causes immediate bail.
+		# This prevents silent retries when the policy table has no entry for
+		# an unrecognised class.
+		*)                    printf '0' ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# _bash_retry_decide <stage_result_json> <retry_count> <error_history_json>
+# Inline decision tree matching retry-policy SKILL.md.
+# Prints action JSON to stdout; never calls claude.
+# ---------------------------------------------------------------------------
+_bash_retry_decide() {
+	local stage_result="$1"
+	local retry_count="$2"
+	local error_history="$3"
+
+	local error_kind model
+	error_kind=$(printf '%s' "$stage_result" | jq -r '.error_kind // "null"')
+	model=$(printf '%s' "$stage_result" | jq -r '.model // "haiku"')
+
+	# Unretryable configuration/permission errors → bail immediately
+	case "$error_kind" in
+		permission_denied|schema_not_found|max_turns_exhausted_at_ceiling)
+			local reason
+			reason="${error_kind}: configuration error, retrying cannot fix this"
+			printf '{"action":"bail","reason":"%s"}\n' "$reason"
+			return 0
+			;;
+	esac
+
+	# max_turns_exhausted at non-ceiling model → escalate immediately
+	if [[ "$error_kind" == "max_turns_exhausted" ]]; then
+		if [[ "$model" == "opus" ]]; then
+			printf '%s\n' \
+				'{"action":"bail","reason":"max_turns_exhausted: at opus ceiling, cannot escalate"}'
+		else
+			local next_model
+			next_model=$(_next_model "$model")
+			printf \
+				'{"action":"escalate","reason":"max_turns_exhausted: escalating %s → %s"}\n' \
+				"$model" "$next_model"
+		fi
+		return 0
+	fi
+
+	# quality_stall at non-ceiling model → escalate immediately
+	if [[ "$error_kind" == "quality_stall" ]]; then
+		if [[ "$model" == "opus" ]]; then
+			printf '%s\n' \
+				'{"action":"bail","reason":"quality_stall: at opus ceiling, cannot escalate"}'
+		else
+			printf '%s\n' \
+				'{"action":"escalate","reason":"quality_stall: fix made no commits"}'
+		fi
+		return 0
+	fi
+
+	local max
+	max=$(_max_retries "$error_kind")
+
+	# Count prior failures of same error_kind at same model in error_history
+	local history_count
+	history_count=$(printf '%s' "$error_history" | \
+		jq --arg m "$model" --arg ek "$error_kind" \
+		   '[.[] | select(.model == $m and .error_kind == $ek)] | length')
+
+	# Threshold exceeded or history shows same error at same model
+	if (( retry_count >= max )) || (( history_count > 0 )); then
+		if [[ "$model" == "opus" ]]; then
+			local reason
+			reason="${error_kind}: retry_count=${retry_count} meets threshold"
+			reason+=" and at opus ceiling"
+			printf '{"action":"bail","reason":"%s"}\n' "$reason"
+		else
+			local next_model reason
+			next_model=$(_next_model "$model")
+			reason="${error_kind}: retry_count=${retry_count} meets threshold"
+			reason+="; escalating ${model} → ${next_model}"
+			printf '{"action":"escalate","reason":"%s"}\n' "$reason"
+		fi
+		return 0
+	fi
+
+	# Retry — include backoff_ms for rate_limit errors
+	if [[ "$error_kind" == "rate_limit" ]]; then
+		local backoff_ms
+		backoff_ms=$(( 30000 * (1 << retry_count) ))
+		if (( backoff_ms > 120000 )); then
+			backoff_ms=120000
+		fi
+		local reason
+		reason="rate_limit: transient throttle, retry_count=${retry_count}"
+		reason+=", waiting ${backoff_ms}ms"
+		printf '{"action":"retry","reason":"%s","backoff_ms":%d}\n' \
+			"$reason" "$backoff_ms"
+	else
+		local reason
+		reason="${error_kind}: first retry at ${model}, retry_count=${retry_count}"
+		printf '{"action":"retry","reason":"%s"}\n' "$reason"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# _claude_retry_decide <stage_result_json> <retry_count> <error_history_json>
+# Live Claude skill invocation via /retry-policy.
+# Prints action JSON to stdout; exits non-zero on invocation failure.
+# ---------------------------------------------------------------------------
+_claude_retry_decide() {
+	local stage_result="$1"
+	local retry_count="$2"
+	local error_history="$3"
+
+	local schema_file="$SCRIPT_DIR/schemas/retry-policy.json"
+	# Prefer the post-git-mv plugin layout (plugins/pipeline-core/skills/) and
+	# fall back to the legacy .claude/skills/ layout so this works on both sides
+	# of the restructure.
+	local skill_file="$SCRIPT_DIR/../../plugins/pipeline-core/skills/retry-policy/SKILL.md"
+	if [[ ! -f "$skill_file" ]]; then
+		skill_file="$SCRIPT_DIR/../skills/retry-policy/SKILL.md"
+	fi
+
+	if [[ ! -f "$skill_file" ]]; then
+		printf '%s: retry-policy SKILL.md not found: %s\n' \
+			"$SCRIPT_NAME" "$skill_file" >&2
+		return 1
+	fi
+	if [[ ! -f "$schema_file" ]]; then
+		printf '%s: retry-policy schema not found: %s\n' \
+			"$SCRIPT_NAME" "$schema_file" >&2
+		return 1
+	fi
+
+	local schema_compact
+	schema_compact=$(jq -c . "$schema_file" 2>&1) || {
+		printf '%s: failed to compact schema: %s\n' "$SCRIPT_NAME" "$schema_compact" >&2
+		return 1
+	}
+
+	local prompt
+	prompt=$(printf '/retry-policy\n\nINPUTS:\nstage_result: %s\nretry_count: %s\nerror_history: %s\n' \
+		"$stage_result" "$retry_count" "$error_history")
+
+	local output rc
+	output=$(_run_with_timeout "${CLAUDE_SKILL_TIMEOUT:-120}" \
+		env -u CLAUDECODE claude -p "$prompt" \
+		--dangerously-skip-permissions \
+		--output-format json \
+		--json-schema "$schema_compact" 2>&1)
+	rc=$?
+
+	if (( rc != 0 )); then
+		printf '%s: claude invocation failed (exit %d): %s\n' \
+			"$SCRIPT_NAME" "$rc" "$output" >&2
+		return 1
+	fi
+
+	# Extract the structured payload from the claude output envelope.
+	# Mirrors sg_extract_payload() in skill-golden-lib.sh and run_stage() in
+	# implement-issue-orchestrator.sh — keep these in sync.
+	local payload
+	payload=$(printf '%s' "$output" | jq -c '
+		.structured_output
+		// (.result | if type == "string" then fromjson? else . end)
+		// .
+	' 2>/dev/null)
+
+	if [[ -z "$payload" ]] || ! printf '%s' "$payload" \
+		| jq -e '.action' >/dev/null 2>&1; then
+		printf '%s: no valid action in claude output\n' "$SCRIPT_NAME" >&2
+		return 1
+	fi
+
+	printf '%s\n' "$payload"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	[[ $# -ge 3 ]] || die \
+		"usage: $SCRIPT_NAME <stage_result_json> <retry_count> <error_history_json>"
+
+	local stage_result="$1"
+	local retry_count="$2"
+	local error_history="$3"
+
+	if [[ "${RETRY_POLICY_BACKEND:-}" == "bash" ]]; then
+		_bash_retry_decide "$stage_result" "$retry_count" "$error_history"
+		return 0
+	fi
+
+	_claude_retry_decide "$stage_result" "$retry_count" "$error_history"
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/event-emit.sh
+++ b/plugins/pipeline-core/scripts/event-emit.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# event-emit.sh — Append one structured JSON event to the run's event stream
+#
+# Usage: event-emit.sh '<json-event>'
+#
+# Validates the JSON event against schemas/pipeline-event.json using jq,
+# then appends it as one JSONL line to ${LOG_DIR}/events.jsonl.
+# Uses flock(1) for concurrent-safe writes; falls back to mkdir-based
+# advisory locking when flock is unavailable (e.g. macOS without
+# util-linux).
+#
+# Environment:
+#   LOG_DIR   Directory where events.jsonl lives (required)
+#
+# Exit codes:
+#   0   Event appended successfully
+#   1   Schema validation failed (event NOT appended)
+#   2   Usage / argument error
+#   3   Environment / system error (LOG_DIR unset, unwritable, lock timeout)
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly SCHEMA_FILE="${SCRIPT_DIR}/schemas/pipeline-event.json"
+
+_err() {
+	printf '%s: %s\n' "$SCRIPT_NAME" "$*" >&2
+}
+
+_validate_json() {
+	local json="$1"
+	if ! jq -e . <<< "$json" > /dev/null 2>&1; then
+		_err "event is not valid JSON"
+		return 1
+	fi
+}
+
+_check_required() {
+	local event="$1" schema="$2"
+	local -a missing=()
+	while IFS= read -r field; do
+		[[ -n "$field" ]] && missing+=("$field")
+	done < <(jq -r --argjson ev "$event" \
+		'.required[]? | select(in($ev) | not)' \
+		<<< "$schema" 2>/dev/null)
+	if (( ${#missing[@]} > 0 )); then
+		_err "schema validation failed: missing required field(s): ${missing[*]}"
+		return 1
+	fi
+}
+
+_check_event_enum() {
+	local event="$1" schema="$2"
+	local value in_enum
+
+	value=$(jq -r '.event // empty' <<< "$event")
+	[[ -z "$value" ]] && return 0  # absent — caught by _check_required
+
+	in_enum=$(jq -r \
+		--arg v "$value" \
+		'.properties.event.enum
+		| if . != null then (index($v) != null) else true end' \
+		<<< "$schema" 2>/dev/null)
+
+	if [[ "$in_enum" != "true" ]]; then
+		_err "schema validation failed: \"event\" value \"$value\" not in enum"
+		return 1
+	fi
+}
+
+_check_oneof_required() {
+	local event="$1" schema="$2"
+	local event_type
+	event_type=$(jq -r '.event // empty' <<< "$event")
+	[[ -z "$event_type" ]] && return 0  # absent — caught by _check_required
+
+	local -a missing=()
+	while IFS= read -r field; do
+		[[ -n "$field" ]] && missing+=("$field")
+	done < <(jq -r --argjson ev "$event" --arg et "$event_type" \
+		'.oneOf[]?
+		| select(.properties.event.const == $et)
+		| .required[]?
+		| select(in($ev) | not)' \
+		<<< "$schema" 2>/dev/null)
+
+	if (( ${#missing[@]} > 0 )); then
+		_err "schema validation failed: \"$event_type\" event" \
+			"missing required field(s): ${missing[*]}"
+		return 1
+	fi
+}
+
+validate_event() {
+	local event="$1"
+
+	_validate_json "$event" || return 1
+
+	if [[ ! -f "$SCHEMA_FILE" ]]; then
+		_err "warning: schema not found at $SCHEMA_FILE;" \
+			"skipping deep validation"
+		return 0
+	fi
+
+	local schema
+	schema=$(< "$SCHEMA_FILE")
+	_check_required "$event" "$schema" || return 1
+	_check_event_enum "$event" "$schema" || return 1
+	_check_oneof_required "$event" "$schema" || return 1
+}
+
+_mkdir_locked_append() {
+	local file="$1"
+	local data="$2"
+	local lockdir="${file}.lock"
+	local pidfile="${lockdir}/pid"
+	local attempts=0
+
+	while ! mkdir "$lockdir" 2>/dev/null; do
+		if [[ -f "$pidfile" ]]; then
+			local lock_pid
+			lock_pid=$(cat "$pidfile" 2>/dev/null)
+			if [[ -n "$lock_pid" ]] \
+				&& ! kill -0 "$lock_pid" 2>/dev/null; then
+				rm -rf "$lockdir" 2>/dev/null || true
+				continue
+			fi
+		fi
+
+		if (( attempts >= 10 )); then
+			_err "timed out waiting for lock on $file"
+			return 1
+		fi
+		sleep 1
+		(( attempts++ )) || true
+	done
+
+	# Record our PID so stale-lock cleanup works if this process dies
+	printf '%d\n' "$$" > "$pidfile" 2>/dev/null || true
+
+	printf '%s\n' "$data" >> "$file"
+	local rc=$?
+	rm -rf "$lockdir" 2>/dev/null || true
+	return $rc
+}
+
+append_event() {
+	local event="$1"
+	local events_file="${LOG_DIR}/events.jsonl"
+
+	if ! mkdir -p "$LOG_DIR" 2>/dev/null; then
+		_err "cannot create directory: $LOG_DIR"
+		return 3
+	fi
+
+	if command -v flock > /dev/null 2>&1; then
+		(
+			flock -x -w 10 9 || {
+				_err "timed out waiting for lock on $events_file"
+				exit 1
+			}
+			printf '%s\n' "$event" >&9
+		) 9>> "$events_file"
+	else
+		# flock unavailable (e.g. macOS without util-linux)
+		_mkdir_locked_append "$events_file" "$event"
+	fi
+}
+
+main() {
+	if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+		cat <<EOF
+Usage: $SCRIPT_NAME '<json-event>'
+
+Validate a JSON event against the pipeline-event schema and append it as
+one JSONL line to \${LOG_DIR}/events.jsonl under flock.
+
+Environment:
+  LOG_DIR   Directory where events.jsonl lives (required)
+
+Exit codes:
+  0   Event appended successfully
+  1   Schema validation failed
+  2   Usage / argument error
+  3   Environment / system error
+EOF
+		return 0
+	fi
+
+	if [[ $# -ne 1 ]]; then
+		_err "expected 1 argument, got $#"
+		_err "Usage: $SCRIPT_NAME '<json-event>'"
+		return 2
+	fi
+
+	local event="$1"
+
+	if [[ -z "${LOG_DIR:-}" ]]; then
+		_err "LOG_DIR is not set"
+		return 3
+	fi
+
+	validate_event "$event" || return 1
+	append_event "$event" || return 3
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/explore-orchestrator.sh
+++ b/plugins/pipeline-core/scripts/explore-orchestrator.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+#
+# explore-orchestrator.sh — Lightweight orchestrator for the explore research phase.
+# Runs a single research subagent to investigate an idea against a project.
+#
+# Usage:
+#   ./explore-orchestrator.sh --idea "description of what to explore"
+#   ./explore-orchestrator.sh --idea "description" --project-dir /path/to/project
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMA_DIR="$SCRIPT_DIR/schemas"
+source "$SCRIPT_DIR/model-config.sh"
+
+# Claude CLI — allow override via env, else resolve path
+if [[ -z "${CLAUDE_CLI:-}" ]]; then
+    if [[ -x "$HOME/.claude/local/claude" ]]; then
+        CLAUDE_CLI="$HOME/.claude/local/claude"
+    else
+        CLAUDE_CLI="claude"
+    fi
+fi
+
+STAGE_TIMEOUT="${EXPLORE_TIMEOUT:-600}"
+
+# Portable timeout (macOS does not ship GNU timeout)
+if ! command -v timeout &>/dev/null; then
+    timeout() {
+        local duration="$1"; shift
+        perl -e '
+            use POSIX ":sys_wait_h";
+            alarm shift @ARGV;
+            $SIG{ALRM} = sub { kill 15, $pid; waitpid($pid, 0); exit 124 };
+            $pid = fork // die "fork: $!";
+            if ($pid == 0) { exec @ARGV; die "exec: $!" }
+            waitpid($pid, 0);
+            exit ($? >> 8);
+        ' "$duration" "$@"
+    }
+fi
+
+# --- Argument parsing ---
+IDEA=""
+PROJECT_DIR=""
+
+usage() {
+    cat <<EOF
+Usage: $0 --idea "description" [--project-dir /path/to/project]
+Options:
+  --idea <text>           Description of what to explore (required)
+  --project-dir <path>    Project directory (defaults to \$PWD)
+  --help, -h              Show this help
+EOF
+    exit 3
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --idea)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --idea requires a value" >&2; exit 3; }
+            IDEA="$2"; shift 2 ;;
+        --project-dir)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --project-dir requires a value" >&2; exit 3; }
+            PROJECT_DIR="$2"; shift 2 ;;
+        --help|-h) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+[[ -n "$IDEA" ]] || { echo "ERROR: --idea is required" >&2; usage; }
+
+PROJECT_DIR="${PROJECT_DIR:-$PWD}"
+[[ "$PROJECT_DIR" == /* ]] || PROJECT_DIR="$PWD/$PROJECT_DIR"
+[[ -d "$PROJECT_DIR" ]] || { echo "ERROR: project directory does not exist: $PROJECT_DIR" >&2; exit 1; }
+
+# --- Log directory ---
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+LOG_DIR="$PROJECT_DIR/logs/explore/explore-${TIMESTAMP}"
+mkdir -p "$LOG_DIR/stages"
+LOG_FILE="$LOG_DIR/orchestrator.log"
+STATUS_FILE="$LOG_DIR/status.json"
+STAGE_LOG="$LOG_DIR/stages/01-research.log"
+
+# --- Logging ---
+log()       { local m="[$(date -Iseconds)] $*"; printf '%s\n' "$m" >> "$LOG_FILE"; printf '%s\n' "$m" >&2; }
+log_error() { local m="[$(date -Iseconds)] ERROR: $*"; printf '%s\n' "$m" >> "$LOG_FILE"; printf '%s\n' "$m" >&2; }
+
+# --- Status file ---
+init_status() {
+    local now; now=$(date -Iseconds)
+    jq -n --argjson issue "null" --arg log_dir "$LOG_DIR" --arg now "$now" \
+        '{
+            state: "running", issue: $issue,
+            tasks: [{description: "**(S)** Research codebase for explore", agent: "research-agent", status: "in_progress"}],
+            stages: { research: {status: "in_progress", started_at: $now} },
+            quality_iterations: 0, test_iterations: 0,
+            last_update: $now, log_dir: $log_dir
+        }' > "$STATUS_FILE"
+}
+
+update_status() {
+    local state="$1" stage_status="$2" task_status="$3" now
+    now=$(date -Iseconds)
+    jq --arg state "$state" --arg ss "$stage_status" --arg ts "$task_status" --arg now "$now" \
+        '.state=$state | .stages.research.status=$ss | .stages.research.completed_at=$now
+         | .tasks[0].status=$ts | .last_update=$now' \
+        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+}
+
+# Load a skill's SKILL.md content for injection into stage prompts.
+# Usage: local content; content=$(load_skill "test-discovery")
+# Returns empty string if skill file not found (non-fatal).
+load_skill() {
+    local skill_name="$1"
+    local skill_file=""
+
+    # A project may override a plugin-shipped skill by placing its own copy
+    # at .claude/skills/<name>/SKILL.md. CLAUDE_PROJECT_DIR is set by Claude
+    # Code and absent when this script runs headlessly outside a session, so
+    # the override is only consulted when it is actually available.
+    if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+        local project_skill_file="$CLAUDE_PROJECT_DIR/.claude/skills/$skill_name/SKILL.md"
+        if [[ -f "$project_skill_file" ]]; then
+            skill_file="$project_skill_file"
+        fi
+    fi
+
+    if [[ -z "$skill_file" ]]; then
+        # Default: read the skill bundled with the plugin. CLAUDE_PLUGIN_ROOT
+        # is set by Claude Code when this script runs from an installed
+        # plugin. Fall back to the repo root computed from this script's own
+        # location, preferring the post-git-mv plugin layout
+        # (plugins/pipeline-core/skills/) and falling back to the legacy
+        # .claude/skills/ layout so this works on both sides of the restructure.
+        local _plugin_root="${CLAUDE_PLUGIN_ROOT:-}"
+        if [[ -z "$_plugin_root" ]]; then
+            local _repo_root
+            _repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+            if [[ -d "$_repo_root/plugins/pipeline-core/skills" ]]; then
+                _plugin_root="$_repo_root/plugins/pipeline-core"
+            else
+                _plugin_root="$_repo_root/.claude"
+            fi
+        fi
+        skill_file="$_plugin_root/skills/$skill_name/SKILL.md"
+    fi
+
+    if [[ -f "$skill_file" ]]; then
+        cat "$skill_file"
+    else
+        log "Skill file not found: $skill_file"
+        printf ''
+    fi
+}
+
+# --- Metrics ---
+START_EPOCH=$(date +%s)
+ESCALATIONS=0
+MODEL_USED=""
+
+write_metrics() {
+    local end_epoch; end_epoch=$(date +%s)
+    jq -n --argjson duration "$(( end_epoch - START_EPOCH ))" \
+        --arg model "$MODEL_USED" --argjson escalations "$ESCALATIONS" \
+        '{ duration_seconds: $duration, model_used: $model, escalations: $escalations }' \
+        > "$LOG_DIR/metrics.json"
+}
+
+# --- Main ---
+log "Explore orchestrator started"
+log "  Idea: $IDEA"
+log "  Project: $PROJECT_DIR"
+log "  Log dir: $LOG_DIR"
+init_status
+
+# Resolve model — research stage, S complexity
+MODEL=$(resolve_model research S)
+FALLBACK=$(_next_model_up "$MODEL")
+MODEL_USED="$MODEL"
+log "  Model: $MODEL (fallback: $FALLBACK)"
+
+test_discovery_skill=$(load_skill "test-discovery")
+
+PROMPT="You are a research agent investigating a project codebase.
+
+## Your task
+Investigate the following idea against this project:
+
+$IDEA
+
+## Project directory
+$PROJECT_DIR
+
+${test_discovery_skill:+## Skill Instructions — READ AND FOLLOW THESE
+
+$test_discovery_skill
+
+## End Skill Instructions
+
+}## Instructions
+1. Explore the project structure, key files, and relevant code
+2. Understand the current behavior related to the idea
+3. Identify files that would need to change
+4. Note existing patterns the implementation should follow
+5. Summarize your findings clearly
+
+Be thorough but focused. Read relevant files, understand the architecture, and provide actionable findings."
+
+SCHEMA=$(jq -c . "$SCHEMA_DIR/explore-research.json")
+
+FALLBACK_ARGS=()
+[[ "$FALLBACK" != "$MODEL" ]] && FALLBACK_ARGS=(--fallback-model "$FALLBACK")
+
+log "Running research stage..."
+OUTPUT=""
+EXIT_CODE=0
+
+OUTPUT=$(timeout "$STAGE_TIMEOUT" env -u CLAUDECODE "$CLAUDE_CLI" -p "$PROMPT" \
+    --model "$MODEL" \
+    ${FALLBACK_ARGS[@]+"${FALLBACK_ARGS[@]}"} \
+    --max-turns 15 \
+    --dangerously-skip-permissions \
+    --output-format json \
+    --json-schema "$SCHEMA" \
+    2>&1) || EXIT_CODE=$?
+
+printf '%s\n' "=== research output ===" >> "$STAGE_LOG"
+printf '%s\n' "$OUTPUT" >> "$STAGE_LOG"
+printf '%s\n' "=== exit code: $EXIT_CODE ===" >> "$STAGE_LOG"
+
+# Handle max_turns exhaustion — escalate to sonnet, retry without turn cap
+if (( EXIT_CODE != 0 )); then
+    SUBTYPE=$(printf '%s' "$OUTPUT" | jq -r '.subtype // empty' 2>/dev/null || true)
+    if [[ "$SUBTYPE" == "error_max_turns" ]]; then
+        log "Max turns exhausted — escalating to sonnet and retrying without turn cap"
+        ESCALATIONS=$((ESCALATIONS + 1))
+        MODEL="sonnet"; MODEL_USED="sonnet"
+        FALLBACK=$(_next_model_up "$MODEL")
+        FALLBACK_ARGS=()
+        [[ "$FALLBACK" != "$MODEL" ]] && FALLBACK_ARGS=(--fallback-model "$FALLBACK")
+
+        EXIT_CODE=0
+        OUTPUT=$(timeout "$STAGE_TIMEOUT" env -u CLAUDECODE "$CLAUDE_CLI" -p "$PROMPT" \
+            --model "$MODEL" ${FALLBACK_ARGS[@]+"${FALLBACK_ARGS[@]}"} \
+            --dangerously-skip-permissions --output-format json --json-schema "$SCHEMA" \
+            2>&1) || EXIT_CODE=$?
+
+        printf '%s\n' "=== escalated output ===" >> "$STAGE_LOG"
+        printf '%s\n' "$OUTPUT" >> "$STAGE_LOG"
+        printf '%s\n' "=== exit code: $EXIT_CODE ===" >> "$STAGE_LOG"
+    fi
+fi
+
+# Handle timeout — retry once with 20% longer timeout
+if (( EXIT_CODE == 124 )); then
+    TIMEOUT_STRUCTURED=$(printf '%s' "$OUTPUT" | jq -c '.structured_output // empty' 2>/dev/null || true)
+    if [[ -n "$TIMEOUT_STRUCTURED" ]]; then
+        log "WARN: Timed out but produced structured output — using it"
+        EXIT_CODE=0
+    else
+        RETRY_TIMEOUT=$(( STAGE_TIMEOUT * 120 / 100 ))
+        log "Timed out after ${STAGE_TIMEOUT}s — retrying with ${RETRY_TIMEOUT}s"
+        ESCALATIONS=$((ESCALATIONS + 1))
+        EXIT_CODE=0
+        OUTPUT=$(timeout "$RETRY_TIMEOUT" env -u CLAUDECODE "$CLAUDE_CLI" -p "$PROMPT" \
+            --model "$MODEL" ${FALLBACK_ARGS[@]+"${FALLBACK_ARGS[@]}"} \
+            --max-turns 15 --dangerously-skip-permissions --output-format json --json-schema "$SCHEMA" \
+            2>&1) || EXIT_CODE=$?
+
+        printf '%s\n' "=== timeout retry output ===" >> "$STAGE_LOG"
+        printf '%s\n' "$OUTPUT" >> "$STAGE_LOG"
+        printf '%s\n' "=== exit code: $EXIT_CODE ===" >> "$STAGE_LOG"
+    fi
+fi
+
+# Extract structured output
+STRUCTURED=""
+if (( EXIT_CODE == 0 )); then
+    STRUCTURED=$(printf '%s' "$OUTPUT" | jq -c '.structured_output // empty' 2>/dev/null || true)
+    if [[ -z "$STRUCTURED" ]]; then
+        STRUCTURED=$(printf '%s' "$OUTPUT" | jq -c '.result // empty' 2>/dev/null || true)
+        [[ -n "$STRUCTURED" ]] && log "WARN: No .structured_output — using .result fallback"
+    fi
+fi
+
+# Write results or handle failure
+if [[ -n "$STRUCTURED" ]]; then
+    log "Research completed successfully"
+    printf '%s\n' "$STRUCTURED" | jq . > "$LOG_DIR/research-summary.json"
+    update_status "completed" "completed" "completed"
+    write_metrics
+    printf '%s\n' "$LOG_DIR/research-summary.json"
+else
+    log_error "Research stage failed (exit code: $EXIT_CODE)"
+    update_status "failed" "failed" "failed"
+    write_metrics
+    printf '%s\n' "$LOG_DIR"
+    exit 1
+fi

--- a/plugins/pipeline-core/scripts/feedback-record.sh
+++ b/plugins/pipeline-core/scripts/feedback-record.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# feedback-record.sh
+# Append a structured JSONL feedback record to logs/feedback/<kind>.jsonl
+#
+# Invoked by the pipeline-feedback skill to record structured observations
+# about classification or routing errors for offline analysis.
+#
+# Usage:
+#   ./feedback-record.sh --kind <kind> --issue <issue> --observed <text> \
+#       --expected <text> [--evidence <path>] [--notes <text>]
+#
+# Required:
+#   --kind      One of: triage_misclassification prompt_regression
+#               criterion_drift agent_misroute escalation_loop
+#   --issue     Issue number or identifier (string)
+#   --observed  What the pipeline actually did
+#   --expected  What the pipeline should have done
+#
+# Optional:
+#   --evidence  Relative path to a supporting log or artifact
+#   --notes     Free-form context or reproduction steps
+#
+# Output:
+#   logs/feedback/<kind>.jsonl  — one JSONL line appended per unique record
+#
+# Exit codes:
+#   0 - Success (record appended, or duplicate skipped within 60s window)
+#   1 - Validation failure (invalid kind, missing required field, write error)
+#
+
+set -euo pipefail
+
+# =============================================================================
+# CONSTANTS
+# =============================================================================
+
+readonly -a VALID_KINDS=(
+	triage_misclassification
+	prompt_regression
+	criterion_drift
+	agent_misroute
+	escalation_loop
+)
+
+readonly IDEMPOTENT_WINDOW=60
+
+# Schema file — used for jq validation before append
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+	SCHEMA_FILE="${CLAUDE_PROJECT_DIR}/.claude/scripts/schemas/pipeline-feedback.json"
+else
+	SCHEMA_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/schemas/pipeline-feedback.json"
+fi
+readonly SCHEMA_FILE
+
+# =============================================================================
+# ARGUMENT PARSING
+# =============================================================================
+
+KIND=""
+ISSUE=""
+OBSERVED=""
+EXPECTED=""
+EVIDENCE=""
+NOTES=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--kind)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			KIND="$2"
+			shift 2
+			;;
+		--issue)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			ISSUE="$2"
+			shift 2
+			;;
+		--observed)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			OBSERVED="$2"
+			shift 2
+			;;
+		--expected)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			EXPECTED="$2"
+			shift 2
+			;;
+		--evidence)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			EVIDENCE="$2"
+			shift 2
+			;;
+		--notes)
+			[[ $# -ge 2 ]] || { printf 'ERROR: %s requires a value\n' "$1" >&2; exit 1; }
+			NOTES="$2"
+			shift 2
+			;;
+		*)
+			printf 'ERROR: Unknown option: %s\n' "$1" >&2
+			exit 1
+			;;
+	esac
+done
+
+# =============================================================================
+# VALIDATION
+# =============================================================================
+
+if [[ -z "$KIND" ]]; then
+	printf 'ERROR: --kind is required\n' >&2
+	exit 1
+fi
+
+if [[ -z "$ISSUE" ]]; then
+	printf 'ERROR: --issue is required\n' >&2
+	exit 1
+fi
+
+if [[ -z "$OBSERVED" ]]; then
+	printf 'ERROR: --observed is required\n' >&2
+	exit 1
+fi
+
+if [[ -z "$EXPECTED" ]]; then
+	printf 'ERROR: --expected is required\n' >&2
+	exit 1
+fi
+
+# Validate kind against enum
+kind_valid=false
+for k in "${VALID_KINDS[@]}"; do
+	if [[ "$KIND" == "$k" ]]; then
+		kind_valid=true
+		break
+	fi
+done
+
+if [[ "$kind_valid" != "true" ]]; then
+	printf 'ERROR: Invalid kind "%s". Valid kinds: %s\n' \
+		"$KIND" "${VALID_KINDS[*]}" >&2
+	exit 1
+fi
+
+# =============================================================================
+# BUILD RECORD
+# =============================================================================
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+JSONL_DIR="logs/feedback"
+JSONL_FILE="${JSONL_DIR}/${KIND}.jsonl"
+
+# Build compact JSON record; omit optional fields if empty
+RECORD=$(jq -cn \
+	--arg ts       "$TIMESTAMP" \
+	--arg kind     "$KIND" \
+	--arg issue    "$ISSUE" \
+	--arg observed "$OBSERVED" \
+	--arg expected "$EXPECTED" \
+	--arg evidence "$EVIDENCE" \
+	--arg notes    "$NOTES" \
+	'{
+		timestamp: $ts,
+		kind:      $kind,
+		issue:     $issue,
+		observed:  $observed,
+		expected:  $expected
+	}
+	+ (if $evidence != "" then {evidence_path: $evidence} else {} end)
+	+ (if $notes    != "" then {notes: $notes}            else {} end)')
+
+# =============================================================================
+# SCHEMA VALIDATION
+# =============================================================================
+
+if [[ -f "$SCHEMA_FILE" ]]; then
+	while IFS= read -r _req_field; do
+		_field_val=$(printf '%s' "$RECORD" | jq -r ".${_req_field} // empty" 2>/dev/null)
+		if [[ -z "$_field_val" ]]; then
+			printf 'ERROR: schema validation failed — required field "%s" missing or empty\n' \
+				"$_req_field" >&2
+			exit 1
+		fi
+	done < <(jq -r '.required[]' "$SCHEMA_FILE" 2>/dev/null)
+fi
+
+# =============================================================================
+# IDEMPOTENCY CHECK
+# =============================================================================
+
+if [[ -f "$JSONL_FILE" ]]; then
+	now_epoch=$(date -u +%s)
+
+	while IFS= read -r existing; do
+		[[ -n "$existing" ]] || continue
+
+		rec_kind=$(printf '%s' "$existing" | jq -r '.kind     // empty' 2>/dev/null)
+		rec_issue=$(printf '%s' "$existing" | jq -r '.issue    // empty' 2>/dev/null)
+		rec_observed=$(printf '%s' "$existing" | jq -r '.observed // empty' 2>/dev/null)
+		rec_expected=$(printf '%s' "$existing" | jq -r '.expected // empty' 2>/dev/null)
+		rec_ts=$(printf '%s' "$existing" | jq -r '.timestamp // empty' 2>/dev/null)
+
+		if [[ "$rec_kind"     == "$KIND"     && \
+		      "$rec_issue"    == "$ISSUE"    && \
+		      "$rec_observed" == "$OBSERVED" && \
+		      "$rec_expected" == "$EXPECTED" ]]; then
+
+			if [[ -n "$rec_ts" ]]; then
+				# Parse timestamp to epoch — GNU date first, BSD date (macOS) fallback
+				rec_epoch=$(date -u -d "$rec_ts" +%s 2>/dev/null \
+					|| date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$rec_ts" +%s 2>/dev/null \
+					|| printf '%s' '0')
+				age=$(( now_epoch - rec_epoch ))
+				if (( age >= 0 && age <= IDEMPOTENT_WINDOW )); then
+					# Duplicate within window — exit without appending
+					exit 0
+				fi
+			fi
+		fi
+	done < "$JSONL_FILE"
+fi
+
+# =============================================================================
+# APPEND RECORD
+# =============================================================================
+
+mkdir -p "$JSONL_DIR"
+printf '%s\n' "$RECORD" >> "$JSONL_FILE"

--- a/plugins/pipeline-core/scripts/implement-issue-orchestrator.sh
+++ b/plugins/pipeline-core/scripts/implement-issue-orchestrator.sh
@@ -1,0 +1,9454 @@
+#!/usr/bin/env bash
+#
+# implement-issue-orchestrator.sh
+# Orchestrates implement-issue workflow via Claude CLI calls per stage
+#
+# Usage:
+#   ./implement-issue-orchestrator.sh --issue 123 --branch test
+#   ./implement-issue-orchestrator.sh --issue 123 --branch test --agent precis-backend-developer
+#
+# Outputs:
+#   - status.json: Real-time progress
+#   - logs/implement-issue/<timestamp>/: Per-stage logs
+#
+# Stage Execution Contract:
+#   run_stage <name> <prompt_file> [options]
+#     Runs a single pipeline stage and emits a stage_result JSON envelope on
+#     stdout (schema: schemas/stage-result.json).  Callers must capture this
+#     value and pass it to _apply_stage_action for routing — never inspect the
+#     raw exit code or attempt to parse stage output directly.
+#
+#   _apply_stage_action <stage_result> <action> [reason]
+#     The single dispatch point for all post-stage outcome handling.  The
+#     caller (run_stage) inspects the stage_result envelope (.error_kind /
+#     .output.status) to determine which action to take, then passes both the
+#     envelope and the action string as arguments — the action is NOT embedded
+#     in the stage_result envelope (schema: schemas/stage-result.json).
+#     Actions: "accept" | "bail" | "escalate" | "retry_same"
+#     All new escalation or retry logic belongs here, not in run_stage callers.
+#
+#   Typical call pattern:
+#     result=$(run_stage "implement" "$prompt_file" ...)
+#     # Caller inspects .error_kind / .output.status to decide the action:
+#     _apply_stage_action "$result" "accept"   # or "bail" / "escalate" / "retry_same"
+#
+# Triage Routing:
+#   Issue classification (fast-path vs. full pipeline) is performed by invoking
+#   the triage-classify skill via _run_triage_composition(), following the
+#   dispatch_composition(isolated=false) pattern — no filesystem writes required.
+#
+
+set -uo pipefail  # Note: not -e, we handle errors explicitly
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMA_DIR="$SCRIPT_DIR/schemas"
+source "$SCRIPT_DIR/model-config.sh"
+# claude-usage.sh provides is_model_exhausted, used by effective_model in
+# model-config.sh. Sourcing is no-op when CLAUDE_USAGE_SESSION_KEY is unset
+# (graceful fallback to today's behavior — see claude-usage.sh).
+source "$SCRIPT_DIR/claude-usage.sh"
+# shellcheck source=prompts/triage-prompt.sh
+source "$SCRIPT_DIR/prompts/triage-prompt.sh"
+source "$SCRIPT_DIR/../config/platform.sh"
+PLATFORM_DIR="$SCRIPT_DIR/platform"
+
+# Resolve PLATFORM_CONTEXT_FILE to an absolute path so file checks work regardless of CWD
+if [[ -n "${PLATFORM_CONTEXT_FILE:-}" && "${PLATFORM_CONTEXT_FILE}" != /* ]]; then
+    PLATFORM_CONTEXT_FILE="$(cd "$SCRIPT_DIR/../.." && pwd)/$PLATFORM_CONTEXT_FILE"
+fi
+
+# Read project context file for agent prompt injection
+# PLATFORM_CONTEXT_FILE is configured in platform.sh; defaults to .claude/config/context.md
+PLATFORM_CONTEXT_CONTENT=""
+if [[ -n "${PLATFORM_CONTEXT_FILE:-}" && -f "$PLATFORM_CONTEXT_FILE" ]]; then
+    PLATFORM_CONTEXT_CONTENT="$(< "$PLATFORM_CONTEXT_FILE")"
+fi
+
+# Build the prefix block injected before task descriptions in implement, fix, and review prompts.
+# Defined once at startup so every prompt inherits a consistent project patterns header.
+if [[ -n "$PLATFORM_CONTEXT_CONTENT" ]]; then
+    PLATFORM_PATTERNS_PREFIX="## Project Patterns
+
+$PLATFORM_CONTEXT_CONTENT
+
+"
+else
+    PLATFORM_PATTERNS_PREFIX=""
+fi
+
+# Timeouts and limits
+# These can be overridden by platform.sh (sourced above) or env vars
+MAX_QUALITY_ITERATIONS="${MAX_QUALITY_ITERATIONS:-5}"
+MAX_TEST_ITERATIONS="${MAX_TEST_ITERATIONS:-7}"
+MAX_PR_REVIEW_ITERATIONS="${MAX_PR_REVIEW_ITERATIONS:-2}"
+MAX_VALIDATION_FIX_ITERATIONS="${MAX_VALIDATION_FIX_ITERATIONS:-2}"
+# Per-run escalation cap (issue #579).  Bounds the number of model escalations
+# a single run may accrue.  Once .escalations[] reaches this length,
+# decide-action.sh bails fast instead of continuing into the pathological 6+
+# escalation bucket where completion rate collapses (85% at 0-2 vs 60% at 6+).
+# Purely a cost lever — env-overridable, so operators can restore prior
+# unbounded behaviour with MAX_ESCALATIONS_PER_RUN=999.
+MAX_ESCALATIONS_PER_RUN="${MAX_ESCALATIONS_PER_RUN:-5}"
+# Default = sum of per-phase budgets so the global cap never pre-empts
+# a loop that is within its own budget.  See calc_orchestrator_wall_time()
+# for the formula; the numeric default mirrors its calculation:
+#   test-loop  (1500s × 3 + 120s slack)              = 4620s
+#   pr-review  (1200s × 2 + 120s slack, 200+ lines)  = 2520s
+#   overhead   (validate 1800 + implement 1800
+#               + task-review 900 + test 600 + pr 600) = 5700s
+#                                              Total : 12840s (~3.5h)
+# Recalculated at runtime by calc_orchestrator_wall_time() using the
+# actual env-overridden per-phase budget variables.  The invariant
+# MAX_ORCHESTRATOR_WALL_TIME >= calc_orchestrator_wall_time() must hold so
+# the global cap never fires while a per-loop budget still has time left;
+# the default therefore tracks the test-iter timeout (raised 900→1500 in
+# issue #512, which the earlier 11040 default was never reconciled with).
+# Override via MAX_ORCHESTRATOR_WALL_TIME env to set a different base.
+MAX_ORCHESTRATOR_WALL_TIME="${MAX_ORCHESTRATOR_WALL_TIME:-12840}"
+MAX_TASK_WALL_TIME_SECS="${MAX_TASK_WALL_TIME_SECS:-1800}"
+# Slack added on top of the per-iteration timeout when computing the
+# PR-review loop wall-clock budget.  Override via env to tune.
+PR_REVIEW_WALL_TIME_SLACK="${PR_REVIEW_WALL_TIME_SLACK:-120}"
+# Full override for the PR-review loop budget (seconds).  When set,
+# replaces the formula pr_review_timeout*max(max_iter,1)+slack entirely.
+PR_REVIEW_WALL_BUDGET="${PR_REVIEW_WALL_BUDGET:-}"
+# Sane planned-iteration count used when computing the test loop's
+# own wall-clock budget.  Intentionally smaller than MAX_TEST_ITERATIONS
+# (7) so the budget reflects realistic expected usage, not worst-case.
+# Override via env to tune without changing the hard iteration cap.
+TEST_LOOP_PLANNED_ITERATIONS="${TEST_LOOP_PLANNED_ITERATIONS:-3}"
+# Slack added on top of the per-iteration timeout for the test-loop budget.
+TEST_ITER_WALL_TIME_SLACK="${TEST_ITER_WALL_TIME_SLACK:-120}"
+# Full override for the test-loop wall-clock budget (seconds).  When set,
+# replaces test-iter-timeout×planned_iter+slack entirely.
+TEST_LOOP_WALL_BUDGET="${TEST_LOOP_WALL_BUDGET:-}"
+
+# Per-run token/cost budget ceiling (issue #583).  Mirrors the wall-clock
+# budget idiom above but bounds spend instead of wall time.  Defaults are
+# NON-BREAKING: 0 (or empty) means "disabled", so existing runs are entirely
+# unaffected until an operator opts in.  When set, check_run_budget() compares
+# the run's accumulated token/cost total (rolled up from issue #580's per-stage
+# .stages[].tokens / .stages[].estimated_cost accounting in status.json) against
+# these ceilings BETWEEN stages via _apply_stage_action.  A hard breach halts
+# the run with terminal state budget_exceeded — never escalating or retrying —
+# and a soft breach (>= RUN_BUDGET_SOFT_PCT% of a ceiling) emits a one-shot
+# warning first.  Env-overridable for tuning and tests.
+MAX_RUN_TOKENS="${MAX_RUN_TOKENS:-0}"
+MAX_RUN_COST_USD="${MAX_RUN_COST_USD:-0}"
+RUN_BUDGET_SOFT_PCT="${RUN_BUDGET_SOFT_PCT:-80}"
+
+# Per-command timeouts (seconds) for the merge_pr stage.  Each long-running
+# sub-step is wrapped in `timeout` so a hung network/git/CLI call cannot stall
+# the orchestrator indefinitely.  On timeout the stage transitions to
+# merge_pr_timeout and the orchestrator exits in the error state.
+#   MERGE_MR_STEP_TIMEOUT : merge-mr.sh (PR/MR merge)
+#   MERGE_GIT_TIMEOUT     : git fetch / checkout / pull
+#   MERGE_COMMENT_TIMEOUT : post-merge completion comment
+# Override any of these via env to tune for slow remotes.
+MERGE_MR_STEP_TIMEOUT="${MERGE_MR_STEP_TIMEOUT:-120}"
+MERGE_GIT_TIMEOUT="${MERGE_GIT_TIMEOUT:-60}"
+MERGE_COMMENT_TIMEOUT="${MERGE_COMMENT_TIMEOUT:-60}"
+
+# Per-command timeouts (seconds) for the validate_plan, implement, and
+# test_loop stages.  Each long-running git/network sub-step is wrapped in
+# `timeout` so a hung subprocess cannot pin the stage indefinitely.
+#   VALIDATE_PLAN_GIT_TIMEOUT     : git rev-list (early scope check)
+#   VALIDATE_PLAN_COMMENT_TIMEOUT : post-validation plan comment
+#   IMPLEMENT_GIT_TIMEOUT         : git checkout at end of implement loop
+#   TEST_LOOP_GIT_TIMEOUT         : git diff for changed-file detection
+# Override any of these via env to tune for slow remotes.
+VALIDATE_PLAN_GIT_TIMEOUT="${VALIDATE_PLAN_GIT_TIMEOUT:-30}"
+VALIDATE_PLAN_COMMENT_TIMEOUT="${VALIDATE_PLAN_COMMENT_TIMEOUT:-60}"
+IMPLEMENT_GIT_TIMEOUT="${IMPLEMENT_GIT_TIMEOUT:-30}"
+TEST_LOOP_GIT_TIMEOUT="${TEST_LOOP_GIT_TIMEOUT:-30}"
+
+# Kill-switch for emergency bash fallback.  The escalation-policy skill is
+# now the default routing backend.  Set ESCALATION_POLICY_BACKEND=bash to
+# force the inline bash decision tree instead.
+#   Unset / empty  → use escalation-policy skill (skill-native default)
+#   "bash"         → always use inline bash escalation branches
+ESCALATION_POLICY_BACKEND="${ESCALATION_POLICY_BACKEND:-}"
+ORCHESTRATOR_START_EPOCH=$(date +%s)
+declare -a DEGRADED_STAGES=()
+# The run-budget soft-threshold warning is emitted at most once per run
+# (issue #583).  The latch lives in status.json (.run_budget_soft_warned), NOT a
+# shell global: check_run_budget() runs inside the run_stage command-substitution
+# subshell, so a global would reset every stage and re-fire the "one-shot"
+# warning on every stage.  Durable state survives the subshell.
+readonly RATE_LIMIT_BUFFER=60
+readonly RATE_LIMIT_DEFAULT_WAIT=3600
+# Waits longer than this imply a weekly-cap exhaustion (rather than a transient
+# 5-hour-window backoff). When handle_rate_limit sees a parsed wait above this
+# threshold it records an inferred-exhaustion entry via claude-usage.sh so
+# subsequent stages escalate via effective_model instead of sleeping.
+# Env-overridable for tests / tuning. See issue #364.
+readonly RATE_LIMIT_EXHAUSTION_THRESHOLD="${RATE_LIMIT_EXHAUSTION_THRESHOLD:-1800}"
+readonly _AGENT_SENTINEL_DEFAULT="default"
+
+# Canonical "Implementation Tasks" heading matcher (issue #584 parity) — the
+# SINGLE source of truth shared by both orchestrator heading sites: the PARSE
+# ISSUE awk slice and the resume-path grep guard.  Mirrors the library's
+# ISSUE_BODY_TASKS_HEADING_RE (issue-body-lib.sh) behaviour EXACTLY:
+#   * UNANCHORED tail — annotated headings ("## Implementation Tasks (draft)")
+#     are recognised so the per-line lint report actually fires (do NOT anchor).
+#   * Case-insensitive — awk folds via tolower($0); grep folds via -i.  The
+#     literal is kept lowercase so the awk `tolower($0) ~ h` comparison matches.
+#   * CRLF-tolerant — the awk strips a trailing CR; grep matches the unanchored
+#     substring regardless of a trailing CR.
+# test-parser-parity.bats runs shared fixtures through BOTH this path and the
+# library parsers and asserts identical results, guarding against drift.
+readonly ISSUE_TASKS_HEADING_ERE='^##+[[:space:]]+implementation tasks'
+
+# =============================================================================
+# PORTABLE TIMEOUT (macOS does not ship GNU timeout)
+# =============================================================================
+#
+# Prefer the coreutils timeout binary when present — it exits 124 on timeout,
+# matching the GNU contract.  When absent, fall back to the perl implementation
+# below which provides identical exit-124 semantics.
+#
+# Detection order:
+#   1. timeout  — GNU coreutils (standard on Linux, optional on macOS via Homebrew)
+#   2. gtimeout — GNU coreutils installed with g-prefix (common macOS Homebrew config)
+#   3. perl     — portable fallback; exits 124 via SIGALRM handler
+#
+# The named helper _timeout_perl_fallback is always defined so that BATS tests
+# can call it directly to verify exit-124 semantics independent of host binaries.
+
+_timeout_perl_fallback() {
+    local duration="$1"; shift
+    perl -e '
+        use POSIX ":sys_wait_h";
+        alarm shift @ARGV;
+        $SIG{ALRM} = sub { kill 15, $pid; waitpid($pid, 0); exit 124 };
+        $pid = fork // die "fork: $!";
+        if ($pid == 0) { exec @ARGV; die "exec: $!" }
+        waitpid($pid, 0);
+        exit ($? >> 8);
+    ' "$duration" "$@"
+}
+
+if command -v timeout &>/dev/null; then
+    : # coreutils timeout binary available — use it directly (exits 124 on timeout)
+elif command -v gtimeout &>/dev/null; then
+    # GNU coreutils installed as gtimeout (common on macOS via Homebrew)
+    timeout() { gtimeout "$@"; }
+else
+    # No timeout binary — perl fallback with identical exit-124 semantics
+    timeout() { _timeout_perl_fallback "$@"; }
+fi
+
+# =============================================================================
+# STAGE-TYPE-BASED TIMEOUTS
+# =============================================================================
+#
+# Replaces the flat STAGE_TIMEOUT constant with per-stage timeouts.
+# Compound prefixes (test-iter, pr-review) are matched first to avoid
+# being swallowed by their shorter generic siblings (test, pr).
+#
+
+get_stage_timeout() {
+    local stage_name="${1:-}"
+    local complexity="${2:-}"
+
+    case "$stage_name" in
+        test-iter*)     printf '%s' 1500 ;;
+        pr-review*)     printf '%s' 1800 ;;
+        deploy-verify*) printf '%s' 900 ;;
+        e2e-verify*)    printf '%s' 600 ;;
+        fix-e2e*)       printf '%s' 900 ;;
+        test*|docs*|pr*) printf '%s' 600 ;;
+        task-review*)    printf '%s' 900 ;;
+        implement*|fix*)
+            if [[ "$complexity" == "L" ]]; then
+                printf '%s' 3600
+            else
+                printf '%s' 1800
+            fi
+            ;;
+        *)               printf '%s' 1800 ;;
+    esac
+}
+
+# =============================================================================
+# GLOBAL WALL-CLOCK TIMEOUT
+# =============================================================================
+
+check_wall_timeout() {
+    local now elapsed
+    now=$(date +%s)
+    elapsed=$(( now - ORCHESTRATOR_START_EPOCH ))
+    if (( elapsed > MAX_ORCHESTRATOR_WALL_TIME )); then
+        log_warn "Global wall-clock timeout: ${elapsed}s elapsed (limit: ${MAX_ORCHESTRATOR_WALL_TIME}s). Soft-exiting current loop."
+        return 1
+    fi
+    return 0
+}
+
+# Check the PR-review loop's own wall-clock budget.
+# Returns 0 if within budget, 1 if the budget has been exceeded.
+#
+# Arguments:
+#   $1 - loop_start : epoch (seconds) when the PR-review loop began
+#   $2 - budget     : total allowed seconds for the loop
+check_pr_review_wall_timeout() {
+    local loop_start="$1"
+    local budget="$2"
+    local now elapsed
+    now=$(date +%s)
+    elapsed=$(( now - loop_start ))
+    if (( elapsed > budget )); then
+        log_warn "PR-review wall-clock budget exceeded: ${elapsed}s elapsed (limit: ${budget}s). Soft-exiting review loop."
+        return 1
+    fi
+    return 0
+}
+
+# Check the test loop's own wall-clock budget.
+# Returns 0 if within budget, 1 if the budget has been exceeded.
+#
+# Arguments:
+#   $1 - loop_start : epoch (seconds) when the test loop began
+#   $2 - budget     : total allowed seconds for the loop
+check_test_loop_wall_timeout() {
+    local loop_start="$1"
+    local budget="$2"
+    local now elapsed
+    now=$(date +%s)
+    elapsed=$(( now - loop_start ))
+    if (( elapsed > budget )); then
+        log_warn "Test-loop wall-clock budget exceeded:" \
+            "${elapsed}s elapsed (limit: ${budget}s)." \
+            "Soft-exiting test loop."
+        return 1
+    fi
+    return 0
+}
+
+# Compute the test loop's own wall-clock budget (seconds).
+#
+# Formula: get_stage_timeout("test-iter") × max(planned_iter, 1)
+#            + TEST_ITER_WALL_TIME_SLACK
+#
+# When TEST_LOOP_WALL_BUDGET is set, it overrides the formula entirely.
+# TEST_LOOP_PLANNED_ITERATIONS and TEST_ITER_WALL_TIME_SLACK are both
+# env-overridable at the call site.
+#
+# Output: budget seconds to stdout
+calc_test_loop_budget() {
+    if [[ -n "${TEST_LOOP_WALL_BUDGET:-}" ]]; then
+        printf '%s' "$TEST_LOOP_WALL_BUDGET"
+        return 0
+    fi
+    local test_iter_timeout effective_iter
+    test_iter_timeout=$(get_stage_timeout "test-iter" "")
+    effective_iter=$(( TEST_LOOP_PLANNED_ITERATIONS > 1 \
+        ? TEST_LOOP_PLANNED_ITERATIONS : 1 ))
+    printf '%s' "$(( test_iter_timeout * effective_iter \
+        + TEST_ITER_WALL_TIME_SLACK ))"
+}
+
+# Compute the minimum orchestrator wall-clock budget as the sum of all
+# per-phase budgets.  Used as a floor for MAX_ORCHESTRATOR_WALL_TIME at
+# the complexity-adjustment step so the global cap never fires while a
+# per-loop budget still has time remaining.
+#
+# Components:
+#   test loop   — calc_test_loop_budget() (respects TEST_LOOP_WALL_BUDGET)
+#   pr review   — PR_REVIEW_WALL_BUDGET when set; otherwise worst-case:
+#                 1200s × max(MAX_PR_REVIEW_ITERATIONS,1) +
+#                 PR_REVIEW_WALL_TIME_SLACK  (200+ line diff, full iters)
+#   overhead    — stages outside the per-loop budgets (constants from
+#                 get_stage_timeout):
+#                   validate_plan(1800) + implement-one-task(1800)
+#                   + task-review(900) + test-single(600) + pr-create(600)
+#                 = 5700s
+#
+# Output: minimum budget seconds to stdout
+calc_orchestrator_wall_time() {
+	local test_budget pr_budget pr_iter
+	test_budget=$(calc_test_loop_budget)
+	if [[ -n "${PR_REVIEW_WALL_BUDGET:-}" ]]; then
+		pr_budget="$PR_REVIEW_WALL_BUDGET"
+	else
+		pr_iter=$(( MAX_PR_REVIEW_ITERATIONS > 1 \
+			? MAX_PR_REVIEW_ITERATIONS : 1 ))
+		pr_budget=$(( 1200 * pr_iter + PR_REVIEW_WALL_TIME_SLACK ))
+	fi
+	printf '%s' "$(( test_budget + pr_budget + 5700 ))"
+}
+
+# =============================================================================
+# RUN-LEVEL TOKEN/COST BUDGET CEILING (issue #583)
+# =============================================================================
+
+# Check the run-level token/cost budget ceiling.
+#
+# Reuses issue #580's accounting rather than re-parsing the CLI JSON: every
+# stage already persists its tokens (.stages[].tokens) and estimated cost
+# (.stages[].estimated_cost) into status.json via set_stage_completed.  This
+# helper sums those into a run-level running total and compares it to the
+# configured ceilings.  No second parse of the --output-format json capture.
+#
+# Returns:
+#   0 — within budget, OR only a soft breach (a one-shot warning is emitted
+#       once, latched durably in status.json .run_budget_soft_warned, and the
+#       run continues)
+#   1 — HARD breach: the caller must halt the run with budget_exceeded and
+#       must NOT escalate or retry
+#
+# Disabled (always returns 0) when both ceilings are unset/0, so existing runs
+# are unaffected.  Mirrors the check_*_wall_timeout idiom above.
+check_run_budget() {
+    local max_tokens="${MAX_RUN_TOKENS:-0}"
+    local max_cost="${MAX_RUN_COST_USD:-0}"
+    local soft_pct="${RUN_BUDGET_SOFT_PCT:-80}"
+
+    # Disabled unless at least one ceiling is a positive value.
+    if awk -v t="$max_tokens" -v c="$max_cost" \
+        'BEGIN { exit !((t+0) <= 0 && (c+0) <= 0) }'; then
+        return 0
+    fi
+    [[ -f "$STATUS_FILE" ]] || return 0
+
+    # Run-level running total from #580's per-stage accounting.  Each jq filter
+    # is kept on a single line so the BATS function extractor -- which counts
+    # braces to find a function end -- is never tripped by a multi-line filter.
+    local used_tokens used_cost
+    used_tokens=$(jq -r '[.stages[]?.tokens.input_tokens // 0, .stages[]?.tokens.output_tokens // 0, .stages[]?.tokens.cache_creation_input_tokens // 0, .stages[]?.tokens.cache_read_input_tokens // 0] | add // 0' "$STATUS_FILE" 2>/dev/null) || used_tokens=0
+    used_cost=$(jq -r '[.stages[]?.estimated_cost // 0] | add // 0' "$STATUS_FILE" 2>/dev/null) || used_cost=0
+    [[ -n "$used_tokens" ]] || used_tokens=0
+    [[ -n "$used_cost" ]] || used_cost=0
+
+    # Classify in awk so the float cost comparison is safe.
+    local verdict
+    verdict=$(awk -v ut="$used_tokens" -v uc="$used_cost" \
+        -v mt="$max_tokens" -v mc="$max_cost" -v sp="$soft_pct" '
+        BEGIN {
+            hard = 0; soft = 0;
+            if (mt + 0 > 0) {
+                if (ut + 0 >= mt + 0) hard = 1;
+                else if (ut + 0 >= (mt + 0) * (sp + 0) / 100) soft = 1;
+            }
+            if (mc + 0 > 0) {
+                if (uc + 0 >= mc + 0) hard = 1;
+                else if (uc + 0 >= (mc + 0) * (sp + 0) / 100) soft = 1;
+            }
+            if (hard) print "hard";
+            else if (soft) print "soft";
+            else print "ok";
+        }')
+
+    case "$verdict" in
+        hard)
+            log_warn "Run budget ceiling exceeded:" \
+                "tokens=${used_tokens}/${max_tokens}" \
+                "cost=\$${used_cost}/\$${max_cost}." \
+                "Halting run with budget_exceeded (no escalate/retry)."
+            return 1
+            ;;
+        soft)
+            # One-shot warning, latched in status.json so it survives the
+            # run_stage subshell (a shell global would reset every stage and
+            # re-warn each time).  Read the durable latch; warn + set it once.
+            local _soft_warned="false"
+            if [[ -f "$STATUS_FILE" ]]; then
+                _soft_warned=$(jq -r '.run_budget_soft_warned // false' \
+                    "$STATUS_FILE" 2>/dev/null) || _soft_warned="false"
+            fi
+            if [[ "$_soft_warned" != "true" ]]; then
+                if [[ -f "$STATUS_FILE" ]]; then
+                    jq '.run_budget_soft_warned = true | .last_update = (now | todate)' \
+                        "$STATUS_FILE" > "${STATUS_FILE}.tmp" \
+                        && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+                fi
+                log_warn "Run budget soft threshold reached (${soft_pct}%):" \
+                    "tokens=${used_tokens}/${max_tokens}" \
+                    "cost=\$${used_cost}/\$${max_cost}." \
+                    "Approaching hard ceiling — one more breach will halt."
+            fi
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+# =============================================================================
+# BRANCH VERIFICATION
+# =============================================================================
+#
+# Guards fix stages against committing on the wrong branch.  Called before
+# each fix-* stage invocation so that a stale checkout or unexpected HEAD
+# is caught early rather than silently committing to the wrong ref.
+#
+
+verify_on_feature_branch() {
+    local expected="${1:-}"
+
+    if [[ -z "$expected" ]]; then
+        log_error "verify_on_feature_branch: no expected branch provided"
+        return 1
+    fi
+
+    local actual
+    actual=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+    if [[ "$actual" != "$expected" ]]; then
+        log_error "Expected branch '$expected' but HEAD is on '$actual'"
+        return 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# ARGUMENT PARSING
+# =============================================================================
+
+ISSUE_NUMBER=""
+BASE_BRANCH=""
+AGENT=""
+STATUS_FILE="status.json"
+[[ "$STATUS_FILE" != /* ]] && STATUS_FILE="$(pwd)/$STATUS_FILE"
+RESUME_MODE=""
+RESUME_LOG_DIR=""
+QUIET=false
+
+usage() {
+    cat <<EOF
+Usage: $0 --issue <number> --branch <name> [options]
+       $0 --resume [--status-file <path>]
+       $0 --resume-from <log-dir>
+
+Options:
+  --issue <number>       Issue number or key (required for new runs)
+  --branch <name>        Base branch for PR (required for new runs)
+  --agent <name>         Default agent for setup stage (optional)
+  --status-file <path>   Custom status file path (optional)
+  --quiet                Suppress all issue comments (no tracker noise)
+  --resume               Resume from existing status.json
+  --resume-from <dir>    Resume from specific log directory
+
+Resume modes:
+  --resume uses the current status.json (or --status-file path)
+  --resume-from reads status.json from the specified log directory
+
+Agents are determined per-task from setup output.
+EOF
+    exit 3
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --issue)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --issue requires a value" >&2; exit 3; }
+            ISSUE_NUMBER="$2"
+            shift 2
+            ;;
+        --branch)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --branch requires a value" >&2; exit 3; }
+            BASE_BRANCH="$2"
+            shift 2
+            ;;
+        --agent)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --agent requires a value" >&2; exit 3; }
+            AGENT="$2"
+            shift 2
+            ;;
+        --status-file)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --status-file requires a value" >&2; exit 3; }
+            STATUS_FILE="$2"
+            [[ "$STATUS_FILE" != /* ]] && STATUS_FILE="$(pwd)/$STATUS_FILE"
+            shift 2
+            ;;
+        --quiet)
+            QUIET=true
+            shift
+            ;;
+        --resume)
+            RESUME_MODE="status"
+            shift
+            ;;
+        --resume-from)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --resume-from requires a log directory path" >&2; exit 3; }
+            RESUME_MODE="logdir"
+            RESUME_LOG_DIR="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Validate arguments based on mode
+if [[ -n "$RESUME_MODE" ]]; then
+    # Resume mode - issue and branch will be read from status.json
+    :
+elif [[ -z "$ISSUE_NUMBER" || -z "$BASE_BRANCH" ]]; then
+    echo "ERROR: --issue and --branch are required (or use --resume/--resume-from)"
+    usage
+fi
+
+# Sanitize BASE_BRANCH: reject characters that could enable prompt injection or shell injection
+# Valid git branch chars: alphanumeric, hyphen, underscore, dot, forward slash
+if [[ -n "$BASE_BRANCH" ]] && ! [[ "$BASE_BRANCH" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+    echo "ERROR: BASE_BRANCH contains invalid characters: $BASE_BRANCH" >&2
+    echo "Branch names must match [a-zA-Z0-9._/-]+" >&2
+    exit 3
+fi
+
+# =============================================================================
+# LOGGING FUNCTIONS (defined early so other functions can use log/log_error)
+# Note: LOG_FILE and mkdir happen later after LOG_BASE is set
+# =============================================================================
+
+LOG_FILE=""
+STAGE_COUNTER=0
+_CONSECUTIVE_TIMEOUTS=0
+_TIMED_OUT_STAGE_NAMES=""
+
+log() {
+    local msg="[$(date -Iseconds)] $*"
+    if [[ -n "$LOG_FILE" ]]; then
+        printf '%s\n' "$msg" >> "$LOG_FILE"
+    fi
+    printf '%s\n' "$msg" >&2
+}
+
+log_error() {
+    local msg="[$(date -Iseconds)] ERROR: $*"
+    if [[ -n "$LOG_FILE" ]]; then
+        printf '%s\n' "$msg" >> "$LOG_FILE"
+    fi
+    printf '%s\n' "$msg" >&2
+}
+
+log_warn() {
+    local msg="[$(date -Iseconds)] WARN: $*"
+    if [[ -n "$LOG_FILE" ]]; then
+        printf '%s\n' "$msg" >> "$LOG_FILE"
+    fi
+    printf '%s\n' "$msg" >&2
+}
+
+next_stage_log() {
+    local stage_name="$1"
+    STAGE_COUNTER=$((STAGE_COUNTER + 1))
+    printf "%02d-%s.log" "$STAGE_COUNTER" "$stage_name"
+}
+
+# =============================================================================
+# STRUCTURED EVENT EMISSION
+# =============================================================================
+#
+# emit_event <event_type> [key=value ...]
+#
+# Builds a JSON envelope with ts/run_id/event/stage and forwards it to
+# event-emit.sh, which validates against schemas/pipeline-event.json and
+# appends one JSONL line to $LOG_BASE/events.jsonl under flock.
+#
+# Design notes:
+#   - Parallel to existing text logs: every text-log call site that maps to one
+#     of the 8 event types (stage_start, stage_end, escalation, retry,
+#     model_call, rate_limit_hit, schema_validation_fail, status_change) gets
+#     a parallel emit_event call.  Text logs are retained verbatim for human
+#     debugging — see issue #180.
+#   - Safe-by-default: silently no-ops when event-emit.sh is missing or
+#     LOG_BASE is unset (e.g. during early init or when the helper has not yet
+#     landed in this branch).  A schema-invalid emit exits non-zero from
+#     event-emit.sh but never crashes the orchestrator (stderr-redirected,
+#     `|| true`).
+#   - run_id is derived from the LOG_BASE basename which already encodes
+#     issue+timestamp (e.g. "issue-180-20260502-183541").
+emit_event() {
+    local event_type="$1"
+    shift
+
+    # Parallel-task safety: if the helper hasn't been added yet (sub-issue
+    # tasks land out of order), skip silently rather than break the pipeline.
+    local emit_script="$SCRIPT_DIR/event-emit.sh"
+    if [[ ! -x "$emit_script" ]]; then
+        return 0
+    fi
+
+    # Skip if LOG_BASE isn't established yet (very early init paths).
+    if [[ -z "${LOG_BASE:-}" ]]; then
+        return 0
+    fi
+
+    local run_id="${LOG_BASE##*/}"
+
+    local -a jq_args=(
+        --arg ts "$(date -Iseconds)"
+        --arg run_id "$run_id"
+        --arg event "$event_type"
+    )
+    local filter='{ts: $ts, run_id: $run_id, event: $event}'
+
+    local kv key value safe_key json_value
+    for kv in "$@"; do
+        # Support `key:=value` for JSON-typed values (numbers, booleans, null)
+        # in addition to `key=value` for strings. Required because the schema
+        # types fields like attempt/max_attempts/stage_attempt as integer.
+        if [[ "$kv" == *":="* ]]; then
+            key="${kv%%:=*}"
+            value="${kv#*:=}"
+            json_value=true
+        else
+            key="${kv%%=*}"
+            value="${kv#*=}"
+            json_value=false
+        fi
+        # Defensive: only allow alphanumeric/underscore in keys to keep the
+        # generated jq filter safe.
+        safe_key="${key//[^A-Za-z0-9_]/}"
+        if [[ -z "$safe_key" ]]; then
+            continue
+        fi
+        if $json_value; then
+            jq_args+=(--argjson "$safe_key" "$value")
+        else
+            jq_args+=(--arg "$safe_key" "$value")
+        fi
+        filter+=" | .${safe_key} = \$${safe_key}"
+    done
+
+    local event_json
+    event_json=$(jq -nc "${jq_args[@]}" "$filter" 2>/dev/null) || return 0
+
+    LOG_DIR="$LOG_BASE" "$emit_script" "$event_json" >/dev/null 2>>"$LOG_BASE/orchestrator.log" || true
+}
+
+# =============================================================================
+# STATUS FILE MANAGEMENT
+# =============================================================================
+
+init_status() {
+    jq -n \
+        --arg state "initializing" \
+        --arg issue "$ISSUE_NUMBER" \
+        --arg base_branch "$BASE_BRANCH" \
+        --arg branch "" \
+        --arg current_stage "parse_issue" \
+        --argjson current_task "null" \
+        --arg log_dir "$LOG_BASE" \
+        '{
+            state: $state,
+            issue: $issue,
+            base_branch: $base_branch,
+            branch: $branch,
+            current_stage: $current_stage,
+            current_task: $current_task,
+            route: null,
+            stages: {
+                parse_issue: {status: "pending", started_at: null, completed_at: null},
+                triage: {status: "pending", started_at: null, completed_at: null,
+                         route: null, confidence: null, disqualifying_criterion: null},
+                validate_plan: {status: "pending", started_at: null, completed_at: null},
+                implement: {status: "pending", task_progress: "0/0"},
+                quality_loop: {status: "pending", iteration: 0},
+                test_loop: {status: "pending", iteration: 0},
+                e2e_verify: {status: "pending"},
+                acceptance_test: {status: "pending"},
+                deploy_verify: {status: "pending"},
+                docs: {status: "pending"},
+                pr: {status: "pending"},
+                pr_review: {status: "pending", iteration: 0},
+                complete: {status: "pending"},
+                fast_path_implement: {status: "pending"},
+                fast_path_pr: {status: "pending"},
+                fast_path_merge: {status: "pending"}
+            },
+            tasks: [],
+            quality_iterations: 0,
+            test_iterations: 0,
+            pr_review_iterations: 0,
+            stage_started_at: null,
+            last_update: (now | todate),
+            log_dir: $log_dir,
+            merge_blocked_reason: null,
+            escalations: [],
+            cost_summary: {
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                total_cache_read_tokens: 0,
+                total_cache_creation_tokens: 0,
+                total_cost_usd: 0
+            }
+        }' > "$STATUS_FILE"
+
+    log "Initialized status file: $STATUS_FILE"
+    sync_status_to_log
+}
+
+update_stage() {
+    local stage="$1"
+    local status="$2"
+    local extra_field="${3:-}"
+    local extra_value="${4:-}"
+
+    if [[ -n "$extra_field" ]]; then
+        jq --arg stage "$stage" \
+           --arg status "$status" \
+           --arg field "$extra_field" \
+           --arg value "$extra_value" \
+           '.stages[$stage].status = $status |
+            .stages[$stage][$field] = $value |
+            .current_stage = $stage |
+            .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    else
+        jq --arg stage "$stage" \
+           --arg status "$status" \
+           '.stages[$stage].status = $status |
+            .current_stage = $stage |
+            .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    fi
+    sync_status_to_log
+}
+
+# =============================================================================
+# PER-STAGE TOKEN/COST ACCUMULATOR (issue #580)
+# =============================================================================
+#
+# run_stage is always invoked as `result=$(run_stage ...)`, so it executes in a
+# command-substitution subshell — a shell-global accumulator assigned there
+# would not survive back to the parent. The bridge is therefore FILE-BACKED,
+# one file per LOGICAL stage under $LOG_BASE/.stage-acc:
+#
+#   set_stage_started     (re)initialises the current logical stage's file and
+#                         records the stage name in _STAGE_ACC_CURRENT, which
+#                         the run_stage subshell inherits via the environment.
+#   _apply_stage_action   on `accept`, appends the accepted stage_result's
+#                         tokens + cost.estimated_usd to that file (one JSONL
+#                         line per accepted run_stage call — so a stage with
+#                         several run_stage calls, e.g. test_loop / pr_review
+#                         iterations, ACCUMULATES rather than last-wins).
+#   set_stage_completed   sums the file to default its tokens/cost args when the
+#                         caller didn't pass them explicitly.
+#
+# Keying by logical stage (not the run_stage name, which is e.g. "test-iter-3")
+# means each set_stage_completed reads only its own stage's file: two completes
+# in a row (implement then quality_loop) never double-count, and a stage that
+# completes WITHOUT a preceding set_stage_started has no file and records ZERO —
+# so config-only-skip paths never inherit a previous stage's spend. Every jq
+# extraction is `// 0` / `// {}` guarded so a missing field degrades to zero.
+# bash-3.2 safe (no associative arrays; float sums done in jq).
+
+_stage_acc_dir() {
+    printf '%s/.stage-acc' "${LOG_BASE:-.}"
+}
+
+_stage_acc_file() {
+    local _s="${1//[^A-Za-z0-9_-]/_}"
+    printf '%s/%s.jsonl' "$(_stage_acc_dir)" "$_s"
+}
+
+# Truncate/create the accumulator file for a logical stage.
+_stage_acc_reset() {
+    local _dir
+    _dir=$(_stage_acc_dir)
+    mkdir -p "$_dir" 2>/dev/null || true
+    : > "$(_stage_acc_file "$1")" 2>/dev/null || true
+}
+
+# Append one accepted stage_result's tokens/cost to the current logical stage's
+# file. Safe to call from inside the run_stage subshell (it writes to a file,
+# which the parent can read). No-op when no logical stage is active.
+_stage_acc_add() {
+    local _sr="$1"
+    local _cur="${_STAGE_ACC_CURRENT:-}"
+    [[ -n "$_cur" ]] || return 0
+    local _line
+    _line=$(printf '%s' "$_sr" \
+        | jq -c '{tokens: (.tokens // {}), cost: (.cost.estimated_usd // 0)}' \
+        2>/dev/null) || return 0
+    [[ -n "$_line" ]] || return 0
+    printf '%s\n' "$_line" >> "$(_stage_acc_file "$_cur")" 2>/dev/null || true
+}
+
+# Sum a logical stage's accumulator file into one {tokens,cost} object. Prints
+# nothing when the file is absent or empty so callers can detect "no data".
+_stage_acc_sum() {
+    local _f
+    _f=$(_stage_acc_file "$1")
+    [[ -s "$_f" ]] || return 0
+    jq -cs '{
+        tokens: {
+            input_tokens:                (map(.tokens.input_tokens // 0) | add // 0),
+            output_tokens:               (map(.tokens.output_tokens // 0) | add // 0),
+            cache_creation_input_tokens: (map(.tokens.cache_creation_input_tokens // 0) | add // 0),
+            cache_read_input_tokens:     (map(.tokens.cache_read_input_tokens // 0) | add // 0)
+        },
+        cost: (map(.cost // 0) | add // 0)
+    }' "$_f" 2>/dev/null || true
+}
+
+set_stage_started() {
+    local stage="$1"
+    local model="${2:-}"
+
+    # issue #580: mark this the active logical stage and clear its accumulator
+    # so per-stage token/cost starts from zero for this run.
+    _STAGE_ACC_CURRENT="$stage"
+    _stage_acc_reset "$stage"
+
+    jq --arg stage "$stage" \
+       '.stages[$stage].started_at = (now | todate) |
+        .stages[$stage].status = "in_progress" |
+        .current_stage = $stage |
+        .stage_started_at = (now | todate) |
+        .state = "running" |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+
+    # Resolve the model so the stage_start event satisfies the schema's
+    # required `model` field. If effective_model isn't usable yet, fall back
+    # to a stable placeholder so the event still validates.
+    if [[ -z "$model" ]]; then
+        model=$(effective_model "$stage" "" 2>/dev/null) || model=""
+        [[ -n "$model" ]] || model="unresolved"
+    fi
+    emit_event "stage_start" "stage=$stage" "model=$model"
+}
+
+set_stage_completed() {
+    local stage="$1"
+    local tokens_json="${2:-}"
+    local estimated_cost="${3:-}"
+
+    # issue #580 bridge: real call sites pass only the stage name, so default
+    # tokens/cost from the per-stage accumulator that run_stage populated via
+    # _apply_stage_action. Explicit args (used by unit tests and any direct
+    # caller) always win. A stage with no accumulator file — a config-only-skip
+    # path, or a stage that ran no CLI call — yields nothing here and is
+    # persisted as zero/absent, never inheriting a previous stage's spend.
+    if [[ -z "$tokens_json" || -z "$estimated_cost" ]]; then
+        local _acc_sum
+        _acc_sum=$(_stage_acc_sum "$stage")
+        if [[ -n "$_acc_sum" ]]; then
+            [[ -n "$tokens_json" ]] \
+                || tokens_json=$(printf '%s' "$_acc_sum" | jq -c '.tokens' 2>/dev/null)
+            [[ -n "$estimated_cost" ]] \
+                || estimated_cost=$(printf '%s' "$_acc_sum" | jq -r '.cost' 2>/dev/null)
+        fi
+    fi
+
+    if [[ -n "$tokens_json" ]]; then
+        # Mirror the existing `.model` write (see run_stage's resolved-model
+        # persistence above): thread the stage_result envelope's tokens
+        # object and estimated cost onto the stage entry so per-stage spend
+        # survives into status.json/metrics.json (issue #580).
+        jq --arg stage "$stage" \
+           --argjson tokens "$tokens_json" \
+           --argjson estimated_cost "${estimated_cost:-0}" \
+           '.stages[$stage].completed_at = (now | todate) |
+            .stages[$stage].status = "completed" |
+            .stages[$stage].tokens = $tokens |
+            .stages[$stage].estimated_cost = $estimated_cost |
+            # Roll every stage'"'"'s tokens/estimated_cost up into the run-level
+            # top-level cost_summary NOW (issue #580). Recomputed from .stages[]
+            # on every completion — idempotent and resume-safe (re-derived, not
+            # incremented, so re-running a stage never double-counts). This
+            # makes status.json the canonical live per-run cost source that
+            # batch-orchestrator.sh reads (metrics.json stays the final
+            # artifact, written by export_metrics). Field names match
+            # init_status'"'"'s seed and metrics.json. `// 0` guards throughout.
+            .cost_summary = {
+                total_input_tokens:          ([.stages[]?.tokens.input_tokens // 0] | add // 0),
+                total_output_tokens:         ([.stages[]?.tokens.output_tokens // 0] | add // 0),
+                total_cache_read_tokens:     ([.stages[]?.tokens.cache_read_input_tokens // 0] | add // 0),
+                total_cache_creation_tokens: ([.stages[]?.tokens.cache_creation_input_tokens // 0] | add // 0),
+                total_cost_usd:              ([.stages[]?.estimated_cost // 0] | add // 0)
+            } |
+            .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    else
+        # No token data for this stage — still recompute the top-level
+        # cost_summary from .stages[] so it stays consistent with whatever
+        # other stages have recorded (issue #580).
+        jq --arg stage "$stage" \
+           '.stages[$stage].completed_at = (now | todate) |
+            .stages[$stage].status = "completed" |
+            .cost_summary = {
+                total_input_tokens:          ([.stages[]?.tokens.input_tokens // 0] | add // 0),
+                total_output_tokens:         ([.stages[]?.tokens.output_tokens // 0] | add // 0),
+                total_cache_read_tokens:     ([.stages[]?.tokens.cache_read_input_tokens // 0] | add // 0),
+                total_cache_creation_tokens: ([.stages[]?.tokens.cache_creation_input_tokens // 0] | add // 0),
+                total_cost_usd:              ([.stages[]?.estimated_cost // 0] | add // 0)
+            } |
+            .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    fi
+    sync_status_to_log
+    # Schema enum for stage_end.status is ["success","error","rate_limit"];
+    # "completed" is the status.json column name, not the event-stream value.
+    #
+    # When per-stage token/cost data is available, thread it onto the
+    # stage_end event so events.jsonl carries per-stage spend (issue #580).
+    # `:=` passes JSON-typed (numeric) values; the schema's stage_end branch
+    # declares these fields optional so events without them still validate.
+    local -a _stage_end_args=("stage=$stage" "status=success")
+    if [[ -n "$tokens_json" ]]; then
+        local _end_in _end_out _end_cache_creation _end_cache_read
+        _end_in=$(printf '%s' "$tokens_json" | jq -r '.input_tokens // 0' 2>/dev/null)
+        _end_out=$(printf '%s' "$tokens_json" | jq -r '.output_tokens // 0' 2>/dev/null)
+        _end_cache_creation=$(printf '%s' "$tokens_json" | jq -r '.cache_creation_input_tokens // 0' 2>/dev/null)
+        _end_cache_read=$(printf '%s' "$tokens_json" | jq -r '.cache_read_input_tokens // 0' 2>/dev/null)
+        _stage_end_args+=(
+            "input_tokens:=${_end_in:-0}"
+            "output_tokens:=${_end_out:-0}"
+            "cache_creation_input_tokens:=${_end_cache_creation:-0}"
+            "cache_read_input_tokens:=${_end_cache_read:-0}"
+            "estimated_cost:=${estimated_cost:-0}"
+        )
+    fi
+    emit_event "stage_end" "${_stage_end_args[@]}"
+}
+
+set_stage_failed() {
+    local stage="$1"
+    local error_kind="$2"
+    jq --arg stage "$stage" \
+       '.stages[$stage].completed_at = (now | todate) |
+        .stages[$stage].status = "error" |
+        .state = "failed" |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+    emit_event "stage_end" "stage=$stage" "status=error" "error_kind=$error_kind"
+}
+
+# Terminal-state writer for a run-level token/cost budget ceiling breach
+# (issue #583).  Sibling of set_stage_failed, but records the dedicated
+# budget_exceeded state so downstream consumers (and the batch orchestrator)
+# treat the run as a clean spend-halt — never as a failure to escalate/retry.
+# The state is written to status.json (a real file that survives the run_stage
+# subshell) and set_final_state() refuses to overwrite it, so the halt is
+# preserved even as the bail path unwinds the stack.
+set_run_budget_exceeded() {
+    local stage="$1"
+    local detail="${2:-run token/cost ceiling exceeded}"
+    jq --arg stage "$stage" \
+       --arg detail "$detail" \
+       '.stages[$stage].completed_at = (now | todate) |
+        .stages[$stage].status = "budget_exceeded" |
+        .state = "budget_exceeded" |
+        .budget_exceeded_reason = $detail |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+    log_warn "Run halted: $detail (stage=$stage) — state set to budget_exceeded"
+    emit_event "budget_exceeded" \
+        "stage=$stage" \
+        "scope=run" \
+        "max_tokens:=${MAX_RUN_TOKENS:-0}" \
+        "max_cost_usd:=${MAX_RUN_COST_USD:-0}"
+}
+
+# Parent-shell halt guard for the run-level budget ceiling (issue #583).
+#
+# check_run_budget()/set_run_budget_exceeded() run INSIDE the run_stage
+# command-substitution subshell (`result=$(run_stage ...)`), so a `return 1`
+# there cannot stop the parent — the caller inspects the stage_result JSON, not
+# $?, and would otherwise call set_stage_completed and advance to the next
+# (spending) stage.  The one signal that DOES survive the subshell is the
+# durable state written to status.json: `.state == "budget_exceeded"`.
+#
+# This guard is invoked in the PARENT shell immediately after every run_stage
+# capture that can spend.  It reads that durable state and, on a breach,
+# finalizes the run and exits 2 (the issue's chosen budget-halt exit code) so
+# NO subsequent stage's CLI call can run.  It is a cheap no-op otherwise, so
+# sprinkling it after each spending stage is safe.
+_halt_if_budget_exceeded() {
+    [[ -f "$STATUS_FILE" ]] || return 0
+    local _state
+    _state=$(jq -r '.state // empty' "$STATUS_FILE" 2>/dev/null) || return 0
+    [[ "$_state" == "budget_exceeded" ]] || return 0
+
+    # set_final_state is a no-op when already budget_exceeded (it refuses to
+    # overwrite the terminal spend-halt), but call it so the EXIT trap / metrics
+    # observe a consistent terminal state regardless of entry path.
+    set_final_state "budget_exceeded"
+    local _reason
+    _reason=$(jq -r '.budget_exceeded_reason // "run token/cost ceiling exceeded"' \
+        "$STATUS_FILE" 2>/dev/null) || _reason="run token/cost ceiling exceeded"
+    log_error "Run halted (budget ceiling): $_reason — no further stages will run."
+    exit 2
+}
+
+record_escalation() {
+    local stage="$1"
+    local from_model="$2"
+    local to_model="$3"
+    local reason="$4"
+
+    jq --arg stage "$stage" \
+       --arg from_model "$from_model" \
+       --arg to_model "$to_model" \
+       --arg reason "$reason" \
+       '.escalations += [{stage: $stage, from_model: $from_model, to_model: $to_model, reason: $reason}] |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+    emit_event "escalation" \
+        "stage=$stage" \
+        "from_model=$from_model" \
+        "to_model=$to_model" \
+        "reason=$reason"
+}
+
+update_task() {
+    local task_id="$1"
+    local status="$2"
+    local review_attempts="${3:-0}"
+
+    jq --argjson id "$task_id" \
+       --arg status "$status" \
+       --argjson attempts "$review_attempts" \
+       '(.tasks[] | select(.id == $id)).status = $status |
+        (.tasks[] | select(.id == $id)).review_attempts = $attempts |
+        .current_task = $id |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+}
+
+set_tasks() {
+    local tasks_json="$1"
+    jq --argjson tasks "$tasks_json" \
+       '.tasks = $tasks |
+        .stages.implement.task_progress = "0/\($tasks | length)" |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+}
+
+set_branch_info() {
+    local branch="$1"
+    jq --arg branch "$branch" \
+       '.branch = $branch | .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+}
+
+set_final_state() {
+    local state="$1"
+    local prev_state stage
+    # Capture the previous state and current stage BEFORE we overwrite, so the
+    # status_change event can carry from_state/to_state per schema.
+    prev_state=$(jq -r '.state // "running"' "$STATUS_FILE" 2>/dev/null) \
+        || prev_state="running"
+    stage=$(jq -r '.current_stage // "unknown"' "$STATUS_FILE" 2>/dev/null) \
+        || stage="unknown"
+
+    # Issue #583: budget_exceeded is a terminal spend-halt.  Once the run-budget
+    # ceiling fires (set_run_budget_exceeded), the bail path unwinds the stack
+    # and a caller may try to stamp a downstream error/failed state.  Refuse it
+    # here so the clean budget_exceeded halt is preserved end-to-end.
+    if [[ "$prev_state" == "budget_exceeded" && "$state" != "budget_exceeded" ]]; then
+        log_warn "set_final_state: run already halted (budget_exceeded);" \
+            "ignoring transition to '$state'"
+        return 0
+    fi
+
+    jq --arg state "$state" \
+       '.state = $state | .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+    emit_event "status_change" \
+        "stage=$stage" \
+        "from_state=$prev_state" \
+        "to_state=$state"
+}
+
+# ---------------------------------------------------------------------------
+# persist_merge_blocked_reason <reason>
+# Persist a merge-block reason into status.json so the merge gate honours it
+# on a resumed run — after a crash+resume the in-memory DEGRADED_STAGES array
+# is empty, so soft-fail sites (implement:partial, pr_review:*) must durably
+# record WHY the merge is blocked. Uses `// $reason` so a reason a prior gate
+# already set (e.g. quality convergence) is not clobbered.
+# ---------------------------------------------------------------------------
+persist_merge_blocked_reason() {
+    local reason="$1"
+    [[ -f "$STATUS_FILE" ]] || return 0
+    jq --arg reason "$reason" \
+       '.merge_blocked_reason = (.merge_blocked_reason // $reason) | .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+}
+
+increment_quality_iteration() {
+    jq '.quality_iterations += 1 |
+        .stages.quality_loop.iteration = .quality_iterations |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+}
+
+increment_test_iteration() {
+    jq '.test_iterations += 1 |
+        .stages.test_loop.iteration = .test_iterations |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+}
+
+increment_pr_review_iteration() {
+    jq '.pr_review_iterations += 1 |
+        .stages.pr_review.iteration = .pr_review_iterations |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+}
+
+# =============================================================================
+# TASK SUMMARY
+# =============================================================================
+
+compute_task_summary() {
+    jq '
+        # Map size labels to Fibonacci points
+        def size_points:
+            if . == "M" then 3
+            elif . == "L" then 5
+            else 1
+            end;
+
+        # Extract size from description: **(S)**, **(M)**, **(L)** -> default S
+        def extract_size:
+            if .description | test("\\*\\*\\(L\\)\\*\\*") then "L"
+            elif .description | test("\\*\\*\\(M\\)\\*\\*") then "M"
+            else "S"
+            end;
+
+        # Annotate each task with its size
+        [.tasks[] | . + {size: extract_size}] as $tasks |
+
+        # Count by status and size
+        {
+            completed: {
+                S: [$tasks[] | select(.status == "completed" and .size == "S")] | length,
+                M: [$tasks[] | select(.status == "completed" and .size == "M")] | length,
+                L: [$tasks[] | select(.status == "completed" and .size == "L")] | length
+            },
+            failed: {
+                S: [$tasks[] | select(.status == "failed" and .size == "S")] | length,
+                M: [$tasks[] | select(.status == "failed" and .size == "M")] | length,
+                L: [$tasks[] | select(.status == "failed" and .size == "L")] | length
+            },
+            sp_completed: ([$tasks[] | select(.status == "completed") | .size | size_points] | add // 0),
+            sp_total: ([$tasks[] | .size | size_points] | add // 0)
+        }
+    ' "$STATUS_FILE"
+}
+
+# _format_task_summary_line() — emit a single human-readable task-summary line
+# for inclusion in terminal issue/PR comments (issue #577).  Reads the task
+# roster from status.json and reports "<completed>/<total> tasks completed",
+# appending "(<n> failed)" when any task failed.  Prints nothing when there is
+# no task roster (e.g. surgical fast-path runs) so callers can splice the
+# result unconditionally.  Data-returning function: no log() to stdout.
+_format_task_summary_line() {
+    [[ -f "$STATUS_FILE" ]] || { printf ''; return 0; }
+
+    local total done_count failed_count
+    total=$(jq -r '(.tasks // []) | length' "$STATUS_FILE" 2>/dev/null || printf '0')
+    [[ "$total" =~ ^[0-9]+$ ]] || total=0
+    (( total > 0 )) || { printf ''; return 0; }
+
+    done_count=$(jq -r '[(.tasks // [])[] | select(.status == "completed")] | length' \
+        "$STATUS_FILE" 2>/dev/null || printf '0')
+    failed_count=$(jq -r '[(.tasks // [])[] | select(.status == "failed")] | length' \
+        "$STATUS_FILE" 2>/dev/null || printf '0')
+    [[ "$done_count" =~ ^[0-9]+$ ]] || done_count=0
+    [[ "$failed_count" =~ ^[0-9]+$ ]] || failed_count=0
+
+    if (( failed_count > 0 )); then
+        printf '**Task summary:** %s/%s tasks completed (%s failed).' \
+            "$done_count" "$total" "$failed_count"
+    else
+        printf '**Task summary:** %s/%s tasks completed.' "$done_count" "$total"
+    fi
+}
+
+# _rewrite_running_to_interrupted() — called from the EXIT trap to surface
+# interrupted runs as a distinct state rather than leaving state="running".
+# When state is "running" at exit time, rewrites it to
+# "interrupted_during_<current_stage>" (falling back to "unknown" when
+# current_stage is null).  All other terminal states (completed, error,
+# wall_timeout_*, etc.) are left untouched so normal exits are unaffected.
+_rewrite_running_to_interrupted() {
+	if [[ ! -f "$STATUS_FILE" ]]; then
+		return 0
+	fi
+
+	local state stage
+	state=$(jq -r '.state // "running"' "$STATUS_FILE" 2>/dev/null) \
+		|| state="running"
+
+	[[ "$state" == "running" ]] || return 0
+
+	stage=$(jq -r '.current_stage // "unknown"' "$STATUS_FILE" 2>/dev/null) \
+		|| stage="unknown"
+	[[ -n "$stage" && "$stage" != "null" ]] || stage="unknown"
+
+	jq --arg new_state "interrupted_during_${stage}" \
+	   '.state = $new_state | .last_update = (now | todate)' \
+	   "$STATUS_FILE" > "${STATUS_FILE}.tmp" \
+		&& mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+	sync_status_to_log
+}
+
+# _propagate_sigterm() — called from the TERM trap before exit 143 to forward
+# SIGTERM to every background task PID registered in _bg_pids.  Sending to
+# the process group (-PID) first ensures entire subtrees are torn down when
+# the background subshell is a group leader; the individual-PID fallback
+# handles subshells that did not acquire a new process group.
+_propagate_sigterm() {
+	local pid
+	for pid in "${_bg_pids[@]+"${_bg_pids[@]}"}"; do
+		# Try group kill first; silence errors when pid is not a PGID.
+		kill -TERM -- -"$pid" 2>/dev/null || true
+		# Also signal the process itself in case it is not a group leader.
+		kill -TERM "$pid" 2>/dev/null || true
+	done
+}
+
+# write_task_summary_to_status() — compute task summary and persist it as
+# .task_summary in status.json.  Called on every exit path via the EXIT trap.
+write_task_summary_to_status() {
+    if [[ ! -f "$STATUS_FILE" ]]; then
+        return 0
+    fi
+
+    local summary
+    summary=$(compute_task_summary) || return 0
+
+    jq --argjson summary "$summary" \
+       '.task_summary = $summary' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    sync_status_to_log
+}
+
+# =============================================================================
+# METRICS EXPORT
+# =============================================================================
+
+# export_metrics() — emit metrics.json to $LOG_BASE/ at orchestrator completion
+#
+# Schema:
+# {
+#   "schema_version": "1",          -- bump when fields are added/removed
+#   "issue":          string,        -- issue number or key
+#   "base_branch":    string,
+#   "branch":         string,        -- feature branch used
+#   "state":          string,        -- final orchestrator state
+#   "started_at":     ISO8601|null,  -- earliest stage started_at across all stages
+#   "completed_at":   ISO8601|null,  -- latest stage completed_at across all stages
+#   "total_duration_seconds": number|null,
+#   "stages": {
+#     "<stage_key>": {
+#       "status":             string,
+#       "started_at":         ISO8601|null,
+#       "completed_at":       ISO8601|null,
+#       "duration_seconds":   number|null,  -- null if missing timestamps
+#       "model":              string|null   -- model used (if tracked)
+#     }, ...
+#   },
+#   "iteration_summary": {
+#     "quality_iterations":    number,
+#     "test_iterations":       number,
+#     "pr_review_iterations":  number
+#   },
+#   "escalations": [
+#     { "stage": string, "from_model": string, "to_model": string, "reason": string }, ...
+#   ],
+#   "cost_summary": {
+#     "total_input_tokens":          number,
+#     "total_output_tokens":         number,
+#     "total_cache_read_tokens":     number,
+#     "total_cache_creation_tokens": number,
+#     "total_cost_usd":              number
+#   }
+# }
+export_metrics() {
+    local metrics_file="$LOG_BASE/metrics.json"
+
+    if [[ ! -f "$STATUS_FILE" ]]; then
+        log "WARN: export_metrics: STATUS_FILE not found, skipping metrics export"
+        return 0
+    fi
+
+    jq --arg schema_version "1" '
+        # Helper: parse ISO8601 to epoch seconds via @sh/strptime is not portable;
+        # use todate/fromdate round-trip available in jq >= 1.6.
+        def iso_to_epoch:
+            if . == null or . == "" then null
+            else try (. | fromdate) catch null
+            end;
+
+        def duration_seconds(s; e):
+            if (s | iso_to_epoch) != null and (e | iso_to_epoch) != null
+            then ((e | iso_to_epoch) - (s | iso_to_epoch))
+            else null
+            end;
+
+        # Per-stage enrichment
+        def enrich_stage(s):
+            s + {
+                duration_seconds: duration_seconds(s.started_at // null; s.completed_at // null)
+            };
+
+        # Collect all started_at / completed_at values across stages
+        def all_started: [.stages[].started_at // empty] | map(select(. != null));
+        def all_completed: [.stages[].completed_at // empty] | map(select(. != null));
+
+        # Default cost_summary for status.json predating issue #580 (or any
+        # run where init_status has not yet seeded the object) so metrics.json
+        # always exposes the full schema rather than a null field.
+        def default_cost_summary:
+            { total_input_tokens: 0, total_output_tokens: 0,
+              total_cache_read_tokens: 0, total_cache_creation_tokens: 0,
+              total_cost_usd: 0 };
+
+        # Roll each per-stage tokens/estimated_cost (written by
+        # set_stage_completed) up into run-level totals. This is the run-level
+        # analogue of the batch-orchestrator per-issue cost rollup (issue #580).
+        # Missing tokens/estimated_cost on a stage coalesce to 0.
+        def stage_cost_rollup:
+            {
+                total_input_tokens:          ([.stages[]?.tokens.input_tokens // 0] | add // 0),
+                total_output_tokens:         ([.stages[]?.tokens.output_tokens // 0] | add // 0),
+                total_cache_read_tokens:     ([.stages[]?.tokens.cache_read_input_tokens // 0] | add // 0),
+                total_cache_creation_tokens: ([.stages[]?.tokens.cache_creation_input_tokens // 0] | add // 0),
+                total_cost_usd:              ([.stages[]?.estimated_cost // 0] | add // 0)
+            };
+
+        . as $status |
+
+        # Calculate overall start/end from earliest/latest stage timestamps
+        ($status | all_started | sort | first // null) as $run_started |
+        ($status | all_completed | sort | last // null) as $run_completed |
+
+        {
+            schema_version: $schema_version,
+            issue:          $status.issue,
+            base_branch:    $status.base_branch,
+            branch:         $status.branch,
+            state:          $status.state,
+            started_at:     $run_started,
+            completed_at:   $run_completed,
+            total_duration_seconds: duration_seconds($run_started; $run_completed),
+            stages: (
+                $status.stages | to_entries | map(
+                    { key: .key, value: enrich_stage(.value) }
+                ) | from_entries
+            ),
+            iteration_summary: {
+                quality_iterations:   ($status.quality_iterations // 0),
+                test_iterations:      ($status.test_iterations // 0),
+                pr_review_iterations: ($status.pr_review_iterations // 0)
+            },
+            escalations: ($status.escalations // []),
+            # Roll per-stage tokens/estimated_cost up into the run-level
+            # cost_summary (issue #580). When no stage carries token data
+            # (e.g. a pre-#580 status file, or a run that recorded only a
+            # top-level cost_summary), fall back to the seeded/persisted
+            # cost_summary rather than emitting all zeros.
+            cost_summary: (
+                ($status | stage_cost_rollup) as $rollup |
+                if ([$rollup[]] | add // 0) > 0
+                then $rollup
+                else ($status.cost_summary // default_cost_summary)
+                end
+            )
+        }
+    ' "$STATUS_FILE" > "$metrics_file" 2>/dev/null
+
+    if [[ $? -eq 0 && -f "$metrics_file" ]]; then
+        log "Metrics exported to $metrics_file"
+    else
+        log "WARN: export_metrics: jq transform failed, metrics.json not written"
+    fi
+}
+
+# =============================================================================
+# RESUME FUNCTIONALITY
+# =============================================================================
+
+# Validate that a status file has required fields for resumption
+# Returns 0 if valid, 1 if invalid
+validate_resume_status() {
+    local status_path="$1"
+
+    if [[ ! -f "$status_path" ]]; then
+        echo "ERROR: Status file not found: $status_path" >&2
+        return 1
+    fi
+
+    # Check required fields exist
+    local required_fields=("issue" "branch" "current_stage" "log_dir")
+    local field
+    for field in "${required_fields[@]}"; do
+        local value
+        value=$(jq -r ".$field // empty" "$status_path" 2>/dev/null)
+        if [[ -z "$value" || "$value" == "null" ]]; then
+            echo "ERROR: Status file missing required field: $field" >&2
+            return 1
+        fi
+    done
+
+    # Check state is resumable (not already completed or in error)
+    local state
+    state=$(jq -r '.state' "$status_path" 2>/dev/null)
+    if [[ "$state" == "completed" ]]; then
+        echo "ERROR: Cannot resume - workflow already completed" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# Load resume state from status file
+# Sets global variables: ISSUE_NUMBER, BASE_BRANCH, LOG_BASE, BRANCH
+# Also sets: RESUME_STAGE, RESUME_TASK, RESUME_TASKS_JSON
+load_resume_state() {
+    local status_path="$1"
+
+    ISSUE_NUMBER=$(jq -r '.issue' "$status_path")
+    # Restore BASE_BRANCH from status file (fall back to command-line value if not stored)
+    local stored_base_branch
+    stored_base_branch=$(jq -r '.base_branch // empty' "$status_path")
+    if [[ -n "$stored_base_branch" ]]; then
+        if ! [[ "$stored_base_branch" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+            echo "ERROR: Stored base_branch contains invalid characters: $stored_base_branch" >&2
+            exit 3
+        fi
+        BASE_BRANCH="$stored_base_branch"
+    elif [[ -z "$BASE_BRANCH" ]]; then
+        echo "WARNING: No base_branch in status file and none provided via --branch" >&2
+    fi
+    BRANCH=$(jq -r '.branch' "$status_path")
+    LOG_BASE=$(jq -r '.log_dir' "$status_path")
+    # Ensure absolute path (worktree subshells cd away from project root)
+    [[ "$LOG_BASE" != /* ]] && LOG_BASE="$(pwd)/$LOG_BASE"
+
+    RESUME_STAGE=$(jq -r '.current_stage' "$status_path")
+    RESUME_TASK=$(jq -r '.current_task // 0' "$status_path")
+    RESUME_TASKS_JSON=$(jq -c '.tasks // []' "$status_path")
+
+    # Restore iteration counters
+    RESUME_QUALITY_ITERATIONS=$(jq -r '.quality_iterations // 0' "$status_path")
+    RESUME_TEST_ITERATIONS=$(jq -r '.test_iterations // 0' "$status_path")
+    RESUME_PR_ITERATIONS=$(jq -r '.pr_review_iterations // 0' "$status_path")
+
+    # Get PR number if it exists
+    RESUME_PR_NUMBER=$(jq -r '.stages.pr.pr_number // empty' "$status_path")
+}
+
+# Check if a stage is completed in status file
+# Returns 0 if completed, 1 if not
+is_stage_completed() {
+    local stage="$1"
+    local status
+    status=$(jq -r ".stages.$stage.status" "$STATUS_FILE" 2>/dev/null)
+    [[ "$status" == "completed" ]]
+}
+
+# Check if a stage result is a timeout error
+# Arguments:
+#   $1 - stage_result JSON envelope from run_stage (see schemas/stage-result.json)
+# Returns 0 if timeout, 1 if not
+is_stage_timeout() {
+    local result="${1:-}"
+    [[ -z "$result" ]] && return 1
+    local err_status err_kind
+    err_status=$(printf '%s' "$result" | jq -r '.status // empty' 2>/dev/null)
+    err_kind=$(printf '%s' "$result" | jq -r '.error_kind // empty' 2>/dev/null)
+    [[ "$err_status" == "error" && "$err_kind" == "timeout" ]]
+}
+
+# Get count of completed tasks
+get_completed_task_count() {
+    jq '[.tasks[] | select(.status == "completed")] | length' "$STATUS_FILE" 2>/dev/null || echo "0"
+}
+
+# =============================================================================
+# RESUME MODE INITIALIZATION
+# =============================================================================
+
+# These will be populated in resume mode
+BRANCH=""
+RESUME_STAGE=""
+RESUME_TASK=""
+RESUME_TASKS_JSON=""
+RESUME_QUALITY_ITERATIONS=0
+RESUME_TEST_ITERATIONS=0
+RESUME_PR_ITERATIONS=0
+RESUME_PR_NUMBER=""
+
+if [[ "$RESUME_MODE" == "logdir" ]]; then
+    # Resume from specific log directory
+    if [[ ! -d "$RESUME_LOG_DIR" ]]; then
+        echo "ERROR: Log directory not found: $RESUME_LOG_DIR" >&2
+        exit 1
+    fi
+
+    local_status_file="$RESUME_LOG_DIR/status.json"
+    if [[ ! -f "$local_status_file" ]]; then
+        # Try parent directory's status.json (log_dir may be relative)
+        local_status_file="status.json"
+    fi
+
+    if ! validate_resume_status "$local_status_file"; then
+        exit 1
+    fi
+
+    load_resume_state "$local_status_file"
+    STATUS_FILE="$local_status_file"
+    [[ "$STATUS_FILE" != /* ]] && STATUS_FILE="$(pwd)/$STATUS_FILE"
+    # LOG_BASE was set by load_resume_state
+
+elif [[ "$RESUME_MODE" == "status" ]]; then
+    # Resume from current status file
+    if ! validate_resume_status "$STATUS_FILE"; then
+        exit 1
+    fi
+
+    load_resume_state "$STATUS_FILE"
+
+else
+    # Normal mode - set LOG_BASE
+    LOG_BASE="$(pwd)/logs/implement-issue/issue-${ISSUE_NUMBER}-$(date +%Y%m%d-%H%M%S)"
+fi
+
+# Display mode info
+if [[ -n "$RESUME_MODE" ]]; then
+    echo "Implement Issue Orchestrator (RESUME MODE)"
+    echo "Resuming from: $STATUS_FILE"
+    echo "Issue: #$ISSUE_NUMBER"
+    echo "Branch: $BRANCH"
+    echo "Resume stage: $RESUME_STAGE"
+    [[ -n "$RESUME_TASK" && "$RESUME_TASK" != "null" ]] && echo "Resume task: $RESUME_TASK"
+    echo "Log dir: $LOG_BASE"
+else
+    echo "Implement Issue Orchestrator"
+    echo "Issue: #$ISSUE_NUMBER"
+    echo "Branch: $BASE_BRANCH"
+    echo "Agent: ${AGENT:-default}"
+    echo "Status file: $STATUS_FILE"
+    echo "Log dir: $LOG_BASE"
+fi
+
+# Create log directories
+mkdir -p "$LOG_BASE/stages" "$LOG_BASE/context"
+LOG_FILE="$LOG_BASE/orchestrator.log"
+STAGE_COUNTER=0
+_CONSECUTIVE_TIMEOUTS=0
+_TIMED_OUT_STAGE_NAMES=""
+
+# Registry of top-level background task PIDs.  Populated as each parallel
+# subshell is launched so the TERM handler can forward SIGTERM before
+# exit 143 is called, preventing orphaned child processes.
+_bg_pids=()
+
+# Register EXIT trap so interrupted runs surface as a distinct state and
+# metrics are always exported.  All three helpers are forward-referenced —
+# bash traps evaluate at exit time, so the definitions need not precede this
+# line.  Call order:
+#   1. _rewrite_running_to_interrupted — rewrite state="running" to
+#      "interrupted_during_<stage>" before anything else reads it
+#   2. write_task_summary_to_status   — persist task summary
+#   3. export_metrics                 — emit metrics.json
+trap '_rewrite_running_to_interrupted; write_task_summary_to_status; export_metrics' EXIT
+
+# Catch SIGTERM so the EXIT trap above fires properly.  Without this, bash may
+# not run the EXIT pseudo-signal handler when it is blocked waiting on a child
+# process (e.g. a running claude stage) and receives SIGTERM.  Exit code 143
+# encodes SIGTERM (128 + 15) per POSIX convention.
+# _propagate_sigterm is forward-referenced — defined near the other EXIT-trap
+# helpers — it sends SIGTERM to every registered background task PID/group so
+# that child subshells do not outlive the orchestrator.
+trap '_propagate_sigterm; exit 143' TERM
+
+# =============================================================================
+# STATUS SYNC TO LOG DIRECTORY
+# =============================================================================
+
+# Sync status.json to log directory after every update
+# This ensures status.json exists in LOG_BASE for resume-from functionality
+sync_status_to_log() {
+	if [[ -n "$LOG_BASE" && -d "$LOG_BASE" && -f "$STATUS_FILE" ]]; then
+		local target="$LOG_BASE/status.json"
+		# Avoid copying file to itself (happens with --resume-from)
+		# Guard: realpath fails if target doesn't exist yet (first sync call)
+		if [[ ! -f "$target" ]] || [[ "$(realpath "$STATUS_FILE")" != "$(realpath "$target")" ]]; then
+			cp "$STATUS_FILE" "$target"
+		fi
+	fi
+}
+
+# =============================================================================
+# ISSUE/PR COMMENT HELPERS
+# =============================================================================
+
+# comment_issue <title> <body> [agent]
+# If agent is provided, shows "Written by `agent`", otherwise "Posted by orchestrator"
+# When QUIET=true, this is a no-op — ALL issue comments are suppressed (use --quiet
+# for automated runs where issue tracker noise should be eliminated entirely).
+comment_issue() {
+	[[ "${QUIET:-false}" == "true" ]] && return 0
+	local title="$1"
+	local body="$2"
+	local agent="${3:-}"
+	local timeout_sec="${4:-}"
+	local attribution
+
+	if [[ -n "$agent" ]]; then
+		attribution="Written by \`$agent\`"
+	else
+		attribution="Posted by \`implement-issue-orchestrator\`"
+	fi
+
+	local comment
+	comment=$(cat <<EOF
+## $title
+###### *$attribution*
+
+$body
+EOF
+)
+
+	log "Commenting on issue #$ISSUE_NUMBER: $title"
+	local _ci_exit
+	if [[ -n "$timeout_sec" ]]; then
+		timeout "$timeout_sec" "$PLATFORM_DIR/comment-issue.sh" "$ISSUE_NUMBER" "$comment" \
+			2>>"${LOG_FILE:-/dev/stderr}"
+		_ci_exit=$?
+	else
+		"$PLATFORM_DIR/comment-issue.sh" "$ISSUE_NUMBER" "$comment" \
+			2>>"${LOG_FILE:-/dev/stderr}"
+		_ci_exit=$?
+	fi
+	if (( _ci_exit != 0 )); then
+		log_error "Failed to comment on issue #$ISSUE_NUMBER"
+	fi
+	return $_ci_exit
+}
+
+# comment_pr <pr_num> <title> <body> [agent]
+# If agent is provided, shows "Written by `agent`", otherwise "Posted by orchestrator"
+comment_pr() {
+	[[ "${QUIET:-false}" == "true" ]] && return 0
+	local pr_num="$1"
+	local title="$2"
+	local body="$3"
+	local agent="${4:-}"
+	local attribution
+
+	if [[ -n "$agent" ]]; then
+		attribution="Written by \`$agent\`"
+	else
+		attribution="Posted by \`implement-issue-orchestrator\`"
+	fi
+
+	local comment
+	comment=$(cat <<EOF
+## $title
+###### *$attribution*
+
+$body
+EOF
+)
+
+	log "Commenting on PR #$pr_num: $title"
+	if ! "$PLATFORM_DIR/comment-mr.sh" "$pr_num" "$comment" 2>>"${LOG_FILE:-/dev/stderr}"; then
+		log_error "Failed to comment on PR #$pr_num"
+	fi
+}
+
+# =============================================================================
+# TEST RUNNER
+# =============================================================================
+
+run_tests() {
+    local exit_code=0
+
+    if [[ -n "${TEST_UNIT_CMD:-}" ]]; then
+        log "Running unit tests: $TEST_UNIT_CMD"
+        eval "$TEST_UNIT_CMD" || exit_code=$?
+    fi
+
+    if [[ $exit_code -eq 0 ]] && [[ -n "${TEST_E2E_CMD:-}" ]]; then
+        log "Running E2E tests: $TEST_E2E_CMD"
+        eval "$TEST_E2E_CMD" || exit_code=$?
+    fi
+
+    return $exit_code
+}
+
+# =============================================================================
+# RATE LIMIT DETECTION
+# =============================================================================
+
+detect_rate_limit() {
+    local output="$1"
+
+    # Check structured output first
+    local status
+    status=$(printf '%s' "$output" | jq -r '.structured_output.status // empty' 2>/dev/null)
+
+    if [[ "$status" == "success" ]]; then
+        return 1
+    fi
+
+    if [[ "$status" == "rate_limit" ]]; then
+        return 0
+    fi
+
+    # Only check text patterns if there's an actual error
+    # (prevents false positives when reviews mention "rate limiting" as a feature)
+    local is_error
+    is_error=$(printf '%s' "$output" | jq -r '.is_error // false' 2>/dev/null)
+
+    if [[ "$is_error" != "true" ]]; then
+        return 1
+    fi
+
+    # Fallback to text pattern matching (only for errors)
+    local result
+    result=$(printf '%s' "$output" | jq -r '.result // empty' 2>/dev/null)
+    if printf '%s' "$result" | grep -qiE 'rate.limit|429|too many requests|quota.exceeded'; then
+        return 0
+    fi
+
+    return 1
+}
+
+extract_wait_time() {
+    local output="$1"
+    local result
+    result=$(printf '%s' "$output" | jq -r '.result // empty' 2>/dev/null)
+    local search_text="$result $output"
+
+    # Try retry-after
+    local retry_after
+    retry_after=$(printf '%s' "$search_text" | grep -oiE 'retry.after[^0-9]*([0-9]+)' | grep -oE '[0-9]+' | head -1)
+    if [[ -n "$retry_after" ]] && (( retry_after > 0 )); then
+        printf '%s\n' "$retry_after"
+        return
+    fi
+
+    # Try wait X minutes
+    local wait_mins
+    wait_mins=$(printf '%s' "$search_text" | grep -oiE 'wait[^0-9]*([0-9]+)[^0-9]*min' | grep -oE '[0-9]+' | head -1)
+    if [[ -n "$wait_mins" ]] && (( wait_mins > 0 )); then
+        printf '%s\n' "$((wait_mins * 60))"
+        return
+    fi
+
+    printf '%s\n' "$RATE_LIMIT_DEFAULT_WAIT"
+}
+
+handle_rate_limit() {
+    local output="$1"
+    local model="${2:-}"
+    local parsed_wait wait_time
+    parsed_wait=$(extract_wait_time "$output")
+    wait_time=$((parsed_wait + RATE_LIMIT_BUFFER))
+
+    local resume_at
+    resume_at=$(date -Iseconds -d "+${wait_time} seconds" 2>/dev/null || date -v+${wait_time}S -Iseconds 2>/dev/null)
+
+    log "Rate limit hit. Waiting ${wait_time}s until $resume_at"
+    emit_event "rate_limit_hit" \
+        "stage=${_RUN_STAGE_NAME:-}" \
+        "retry_after_seconds:=$wait_time" \
+        "resume_at=${resume_at:-}"
+
+    # Long waits imply a weekly-cap exhaustion. Record a synthetic exhaustion
+    # entry so subsequent stages escalate via effective_model instead of
+    # repeatedly sleeping. Only do this when we know which model to mark; if
+    # claude-usage.sh did not provide the helper (older checkout / test stub)
+    # the recording is skipped silently — the sleep below still proceeds.
+    if [[ -n "$model" ]] \
+        && (( parsed_wait > RATE_LIMIT_EXHAUSTION_THRESHOLD )) \
+        && declare -F record_inferred_exhaustion >/dev/null 2>&1; then
+        log "Wait ${parsed_wait}s > ${RATE_LIMIT_EXHAUSTION_THRESHOLD}s — recording inferred exhaustion for $model"
+        record_inferred_exhaustion "$model" "$parsed_wait" || \
+            log_warn "record_inferred_exhaustion failed for $model"
+    fi
+
+    sleep "$wait_time"
+}
+
+# =============================================================================
+# SKILL LOADER
+# =============================================================================
+
+# Load a skill's SKILL.md content for injection into stage prompts.
+# Usage: local content; content=$(load_skill "pr-creation")
+# Returns empty string if skill file not found (non-fatal).
+load_skill() {
+    local skill_name="$1"
+    local skill_file=""
+
+    # A project may override a plugin-shipped skill by placing its own copy
+    # at .claude/skills/<name>/SKILL.md. CLAUDE_PROJECT_DIR is set by Claude
+    # Code and absent when this script runs headlessly outside a session, so
+    # the override is only consulted when it is actually available.
+    if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+        local project_skill_file="$CLAUDE_PROJECT_DIR/.claude/skills/$skill_name/SKILL.md"
+        if [[ -f "$project_skill_file" ]]; then
+            skill_file="$project_skill_file"
+        fi
+    fi
+
+    if [[ -z "$skill_file" ]]; then
+        # Default: read the skill bundled with the plugin. CLAUDE_PLUGIN_ROOT
+        # is set by Claude Code when this script runs from an installed
+        # plugin. Fall back to the repo root computed from this script's own
+        # location so skills still resolve in dev/test and pre-migration
+        # checkouts, preferring the post-git-mv plugin layout
+        # (plugins/pipeline-core/skills/) and falling back to the legacy
+        # .claude/skills/ layout so this works on both sides of the restructure.
+        local _plugin_root="${CLAUDE_PLUGIN_ROOT:-}"
+        if [[ -z "$_plugin_root" ]]; then
+            local _repo_root
+            _repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+            if [[ -d "$_repo_root/plugins/pipeline-core/skills" ]]; then
+                _plugin_root="$_repo_root/plugins/pipeline-core"
+            else
+                _plugin_root="$_repo_root/.claude"
+            fi
+        fi
+        skill_file="$_plugin_root/skills/$skill_name/SKILL.md"
+    fi
+
+    if [[ -f "$skill_file" ]]; then
+        cat "$skill_file"
+    else
+        log_warn "Skill file not found: $skill_file"
+        echo ""
+    fi
+}
+
+# =============================================================================
+# STAGE RESULT ENVELOPE
+# =============================================================================
+#
+# run_stage accumulates execution state into local variables and emits a
+# single stage_result JSON envelope (see schemas/stage-result.json) at every
+# exit point. The envelope wraps the parsed structured output under .output
+# and carries the run-level metadata callers need to make escalation
+# decisions: status, raw stdout, permission denials, resolved model,
+# error_kind, and elapsed_ms.
+#
+# Callers reach into .output.<field> for the agent's structured response
+# (e.g., .output.tasks instead of .tasks) — see AC1 of issue #178.
+
+# Get current epoch in milliseconds. EPOCHREALTIME (bash 5+) preferred;
+# python3 fallback covers macOS bash 3.2; date +%s last resort (1s resolution).
+_epoch_ms() {
+    if [[ -n "${EPOCHREALTIME:-}" ]]; then
+        local us="${EPOCHREALTIME//./}"
+        printf '%s\n' "$((us / 1000))"
+    elif command -v python3 &>/dev/null; then
+        python3 -c 'import time; print(int(time.time()*1000))'
+    else
+        printf '%s000\n' "$(date +%s)"
+    fi
+}
+
+# Extract permission_denials tool_name array from raw CLI output as a JSON
+# array. Returns "[]" when absent, malformed, or jq fails.
+_extract_denials() {
+    local raw="$1"
+    local denials
+    denials=$(printf '%s' "$raw" \
+        | jq -c '[.permission_denials[]?.tool_name // empty]' 2>/dev/null)
+    if [[ -z "$denials" || "$denials" == "null" ]]; then
+        printf '[]\n'
+    else
+        printf '%s\n' "$denials"
+    fi
+}
+
+# Extract token usage and reported cost from raw CLI output as a JSON
+# object. Every field is guarded with `// 0` so a missing/null value
+# (e.g. an error response emitted before usage accrued) degrades to zero
+# rather than corrupting downstream status.json / stage_result consumers.
+# Returns a zeroed object when raw is empty, malformed, or jq fails.
+#
+# See issue #580: usage/total_cost_usd are already present in every
+# --output-format json response but were previously dropped on the floor.
+_extract_usage() {
+    local raw="$1"
+    local usage
+    usage=$(printf '%s' "$raw" \
+        | jq -c '{
+            input_tokens: (.usage.input_tokens // 0),
+            output_tokens: (.usage.output_tokens // 0),
+            cache_creation_input_tokens: (.usage.cache_creation_input_tokens // 0),
+            cache_read_input_tokens: (.usage.cache_read_input_tokens // 0),
+            total_cost_usd: (.total_cost_usd // 0)
+          }' 2>/dev/null)
+    if [[ -z "$usage" || "$usage" == "null" ]]; then
+        printf '{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"total_cost_usd":0}\n'
+    else
+        printf '%s\n' "$usage"
+    fi
+}
+
+# Emit a stage_result JSON envelope on stdout. All payload args are
+# JSON-encoded so callers can pass nested objects/arrays safely via
+# --argjson without shell-quoting hazards.
+#
+# Arguments:
+#   $1 - status:           "success" | "error" | "rate_limit"
+#   $2 - output_json:      JSON object or "null"
+#   $3 - raw:              raw stdout from CLI (string)
+#   $4 - denials_json:     JSON array of tool names
+#   $5 - model:            resolved model id (e.g. haiku|sonnet|opus)
+#   $6 - error_kind_json:  "null" or JSON-encoded string (e.g. "\"timeout\"")
+#   $7 - elapsed_ms:       integer milliseconds
+#   $8 - usage_json:       (optional) JSON object from _extract_usage — token
+#                          counts + the CLI's reported total_cost_usd. Defaults
+#                          to a zeroed object when omitted so older/partial
+#                          call sites still produce a valid envelope.
+#
+# The envelope carries two cost-accounting fields derived from $8 (issue #580):
+#   .tokens - token counts only (input/output/cache_creation/cache_read),
+#             lifted straight out of usage_json for downstream persistence
+#             (e.g. set_stage_completed's tokens arg).
+#   .cost   - {reported_usd, computed_usd, estimated_usd}. reported_usd is
+#             the CLI's own total_cost_usd; computed_usd is priced from the
+#             token counts via _model_cost (model-config.sh) using the
+#             envelope's resolved model; estimated_usd prefers reported_usd
+#             and falls back to computed_usd when the CLI didn't report one
+#             (e.g. a response emitted before usage accrued) — see the
+#             risk mitigation in issue #580's evaluation section.
+_emit_stage_result() {
+    local status="$1"
+    local output_json="$2"
+    local raw="$3"
+    local denials_json="$4"
+    local model="$5"
+    local error_kind_json="$6"
+    local elapsed_ms="$7"
+    local usage_json="${8:-}"
+    # Task complexity (S/M/L or empty) threaded into the envelope so the
+    # escalation decision (decide-action.sh) can gate S-task Opus routing
+    # (issue #579).  Empty when the stage carries no complexity hint.
+    local complexity="${9:-}"
+
+    if [[ -z "$usage_json" || "$usage_json" == "null" ]]; then
+        usage_json='{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"total_cost_usd":0}'
+    fi
+
+    local input_tokens output_tokens cache_creation_tokens cache_read_tokens reported_usd
+    input_tokens=$(printf '%s' "$usage_json" | jq -r '.input_tokens // 0' 2>/dev/null)
+    output_tokens=$(printf '%s' "$usage_json" | jq -r '.output_tokens // 0' 2>/dev/null)
+    cache_creation_tokens=$(printf '%s' "$usage_json" | jq -r '.cache_creation_input_tokens // 0' 2>/dev/null)
+    cache_read_tokens=$(printf '%s' "$usage_json" | jq -r '.cache_read_input_tokens // 0' 2>/dev/null)
+    reported_usd=$(printf '%s' "$usage_json" | jq -r '.total_cost_usd // 0' 2>/dev/null)
+
+    local computed_usd
+    computed_usd=$(_model_cost "$model" \
+        "${input_tokens:-0}" "${output_tokens:-0}" \
+        "${cache_creation_tokens:-0}" "${cache_read_tokens:-0}" 2>/dev/null)
+    computed_usd="${computed_usd:-0}"
+
+    jq -nc \
+        --arg status "$status" \
+        --argjson output "$output_json" \
+        --arg raw "$raw" \
+        --argjson denials "$denials_json" \
+        --arg model "$model" \
+        --argjson error_kind "$error_kind_json" \
+        --argjson elapsed_ms "$elapsed_ms" \
+        --argjson input_tokens "${input_tokens:-0}" \
+        --argjson output_tokens "${output_tokens:-0}" \
+        --argjson cache_creation_tokens "${cache_creation_tokens:-0}" \
+        --argjson cache_read_tokens "${cache_read_tokens:-0}" \
+        --argjson reported_usd "${reported_usd:-0}" \
+        --argjson computed_usd "$computed_usd" \
+        --arg complexity "$complexity" \
+        '{status: $status, output: $output, raw: $raw, denials: $denials,
+          model: $model, error_kind: $error_kind, elapsed_ms: $elapsed_ms,
+          complexity: $complexity,
+          tokens: {input_tokens: $input_tokens, output_tokens: $output_tokens,
+                    cache_creation_input_tokens: $cache_creation_tokens,
+                    cache_read_input_tokens: $cache_read_tokens},
+          cost: {reported_usd: $reported_usd, computed_usd: $computed_usd,
+                 estimated_usd: (if $reported_usd > 0 then $reported_usd else $computed_usd end)}}'
+}
+
+# Apply a stage outcome action to a stage_result envelope.
+#
+# This is the single bash entry point for stage outcome handling. Callers
+# determine which action to take (via the escalation-policy skill or the
+# inline bash decision tree), then delegate execution to this function.
+# Keeping action execution here keeps the interface uniform so tests can
+# target the action logic independently of the routing backend.
+#
+# Arguments:
+#   $1 - stage_result: JSON envelope (see schemas/stage-result.json)
+#   $2 - action:       "accept" | "bail" | "escalate" | "retry_same"
+#   $3 - reason:       (optional) human-readable reason for logging / diagnostics
+#
+# Stdout:
+#   Emits the stage_result JSON envelope unchanged; re-run and retry
+#   logic lives in run_stage, driven by the escalation-policy skill.
+#
+# Returns:
+#   0 for accept / escalate / retry_same
+#   1 for bail (signals caller that stage result is terminal)
+_apply_stage_action() {
+	local stage_result="$1"
+	local action="$2"
+	local reason="${3:-}"
+
+	# Between-stages token/cost budget ceiling check (issue #583).  This is the
+	# single post-stage dispatch point, so it is the only place a budget check
+	# runs — never mid-stage.  A HARD breach overrides the requested action
+	# (accept/escalate/retry_same all included): the run halts cleanly with the
+	# terminal budget_exceeded state and is NEVER escalated or retried.  Soft
+	# breaches emit a one-shot warning inside check_run_budget and fall through
+	# to normal routing.  Disabled by default (ceilings 0), so no behaviour
+	# change for existing runs.
+	if ! check_run_budget; then
+		set_run_budget_exceeded \
+			"${_RUN_STAGE_NAME:-unknown}" \
+			"run token/cost ceiling exceeded (requested action=$action)"
+		printf '%s\n' "$stage_result"
+		return 1
+	fi
+
+	case "$action" in
+		accept)
+			# issue #580: record this accepted run_stage's final (post-
+			# escalation/retry) tokens + cost into the current logical stage's
+			# accumulator. accept is the single choke point every accepted
+			# run_stage exit funnels through, so one append happens per
+			# accepted run_stage call.
+			_stage_acc_add "$stage_result"
+			printf '%s\n' "$stage_result"
+			return 0
+			;;
+		bail)
+			log_error "Stage bailed: ${reason:-action=bail}"
+			set_stage_failed \
+				"${_RUN_STAGE_NAME:-unknown}" \
+				"$(jq -r '.error_kind // "bail"' <<< "$stage_result")"
+			printf '%s\n' "$stage_result"
+			return 1
+			;;
+		escalate)
+			# Emit stage_result as-is; run_stage reads the action and drives
+			# model escalation via the escalation-policy skill.
+			printf '%s\n' "$stage_result"
+			return 0
+			;;
+		retry_same)
+			# Emit stage_result as-is; run_stage reads the action and drives
+			# the retry loop (same model) via the escalation-policy skill.
+			printf '%s\n' "$stage_result"
+			return 0
+			;;
+		*)
+			log_error "_apply_stage_action: unknown action '$action'"
+			set_stage_failed \
+				"${_RUN_STAGE_NAME:-unknown}" \
+				"unknown_action"
+			printf '%s\n' "$stage_result"
+			return 1
+			;;
+	esac
+}
+
+# =============================================================================
+# STAGE RUNNERS
+# =============================================================================
+
+run_stage() {
+    local stage_name="$1"
+    local prompt="$2"
+    local schema_file="$3"
+    local agent="${4:-}"        # empty string or "default" omits --agent flag
+    local complexity="${5:-}"
+    local timeout_override="${6:-}"   # optional: override stage timeout (seconds)
+    local model_override="${7:-}"    # optional: override model (haiku|sonnet|opus)
+
+    # Track stage in a global so handle_rate_limit() (called from inside this
+    # function) can attribute its rate_limit_hit event to the right stage.
+    _RUN_STAGE_NAME="$stage_name"
+
+    local stage_log="$LOG_BASE/stages/$(next_stage_log "$stage_name")"
+
+    # Stage result accumulator — every exit point funnels through
+    # _emit_stage_result so callers receive a uniform stage_result envelope.
+    # See schemas/stage-result.json. result_model tracks the model that
+    # produced the final output (escalation paths reassign it).
+    local result_start_ms result_model=""
+    result_start_ms=$(_epoch_ms)
+
+    # Validate schema file exists
+    if [[ ! -f "$SCHEMA_DIR/$schema_file" ]]; then
+        log_error "Schema file not found: $SCHEMA_DIR/$schema_file"
+        emit_event "schema_validation_fail" \
+            "stage=$stage_name" \
+            "reason=schema_not_found" \
+            "schema=$schema_file" \
+            "errors:=[]"
+        _CONSECUTIVE_TIMEOUTS=0
+        _TIMED_OUT_STAGE_NAMES=""
+        local _sr
+        _sr=$(_emit_stage_result \
+            "error" "null" "" "[]" \
+            "$result_model" '"schema_not_found"' \
+            "$(( $(_epoch_ms) - result_start_ms ))" \
+            "" "${complexity:-}")
+        _apply_stage_action "$_sr" "bail" "schema_not_found"
+        return $?
+    fi
+
+    local schema
+    schema=$(jq -c . "$SCHEMA_DIR/$schema_file")
+
+    # Resolve model and fallback. model_override (e.g. PR stage pinned to opus)
+    # bypasses usage gating — explicit caller intent overrides the auto-skip.
+    local model fallback_model
+    if [[ -n "$model_override" ]]; then
+        model="$model_override"
+        fallback_model=$(_next_model_up "$model")
+    else
+        model=$(effective_model "$stage_name" "$complexity")
+        fallback_model=$(effective_fallback "$model")
+    fi
+
+    # Track final model for stage_result envelope. Reassigned by escalation
+    # branches when they produce output via a different model.
+    result_model="$model"
+
+    # Record resolved model in status.json stage entry for export_metrics()
+    if [[ -f "$STATUS_FILE" ]]; then
+        local stage_key="${stage_name//-/_}"
+        jq --arg stage "$stage_key" --arg model "$model" \
+           '.stages[$stage].model = $model' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    fi
+
+    log "Running stage: $stage_name"
+    log "  Schema: $schema_file"
+    log "  Agent: ${agent:-default}"
+    log "  Model: $model (fallback: $fallback_model)"
+    if [[ -n "$complexity" ]]; then
+        log "  Complexity: $complexity"
+    fi
+    log "  Log: $stage_log"
+
+    emit_event "model_call" \
+        "stage=$stage_name" \
+        "model=$model" \
+        "fallback_model=$fallback_model" \
+        "agent=${agent:-default}" \
+        "schema=$schema_file" \
+        "complexity=${complexity:-}" \
+        "stage_attempt:=1"
+
+    local -a agent_args=()
+    if [[ -n "$agent" && "$agent" != "$_AGENT_SENTINEL_DEFAULT" ]]; then
+        agent_args=(--agent "$agent")
+    fi
+
+    local stage_timeout
+    if [[ -n "$timeout_override" ]]; then
+        stage_timeout="$timeout_override"
+    else
+        stage_timeout=$(get_stage_timeout "$stage_name" "$complexity")
+    fi
+    log "  Timeout: ${stage_timeout}s"
+
+    # Pass --fallback-model for resilience (skip if same as primary — CLI rejects duplicates)
+    local -a fallback_args=()
+    if [[ "$fallback_model" != "$model" ]]; then
+        fallback_args=(--fallback-model "$fallback_model")
+    fi
+
+    # Cap exploration for inherently light-tier stages (parse, complete, docs, etc.)
+    # These are mechanical and should complete in a few turns.
+    # Do NOT cap implement/review/fix stages that use haiku via S-complexity override —
+    # those still need enough turns to read files, make edits, and produce output.
+    #
+    # PR creation gets a separate cap — it only needs to run glab/gh mr create,
+    # push if needed, and format a description. 5 turns is plenty.
+    #
+    # simplify-* gets a dedicated haiku cap (env: MAX_TURNS_SIMPLIFY, default 12) —
+    # targeted TypeScript edits; more scope than parse but less than full implement.
+    #
+    # fix/fix-review-* gets a dedicated sonnet cap (env: MAX_TURNS_FIX_REVIEW,
+    # default 20) — targeted corrections, less scope than implement/review.
+    # pr/pr-review/research turn limits are unchanged.
+    local -a turns_args=()
+    local _matched_prefix _inherent_tier
+    _matched_prefix=$(_match_stage_prefix "$stage_name") || true
+    _inherent_tier=$(_stage_to_tier "${_matched_prefix:-}")
+    if [[ "${_matched_prefix:-}" == "pr" && "${_matched_prefix:-}" != "pr-review" && "${_matched_prefix:-}" != "pr-fix" ]]; then
+        local _max_pr="${MAX_TURNS_PR:-10}"
+        turns_args=(--max-turns "$_max_pr")
+        log "  Max turns: $_max_pr (PR creation — push + create MR, env: MAX_TURNS_PR)"
+    elif [[ "${_matched_prefix:-}" == "pr-review" ]]; then
+        turns_args=(--max-turns 10)
+        log "  Max turns: 10 (PR review — focused diff analysis)"
+    elif [[ "${_matched_prefix:-}" == "simplify" && "$model" == "haiku" ]]; then
+        local _max_simplify="${MAX_TURNS_SIMPLIFY:-15}"
+        turns_args=(--max-turns "$_max_simplify")
+        log "  Max turns: $_max_simplify (simplify haiku — targeted edits, env: MAX_TURNS_SIMPLIFY)"
+    elif [[ "${_matched_prefix:-}" == "fix" && "$model" == "sonnet" ]]; then
+        local _max_fix_review="${MAX_TURNS_FIX_REVIEW:-30}"
+        turns_args=(--max-turns "$_max_fix_review")
+        log "  Max turns: $_max_fix_review (fix/fix-review sonnet — targeted fix, env: MAX_TURNS_FIX_REVIEW)"
+    elif [[ "$model" == "haiku" && "$_inherent_tier" == "light" ]]; then
+        turns_args=(--max-turns 10)
+        log "  Max turns: 10 (inherently light stage)"
+    elif [[ "$model" == "haiku" ]]; then
+        turns_args=(--max-turns 15)
+        log "  Max turns: 15 (haiku via complexity override)"
+    elif [[ "$model" == "sonnet" ]]; then
+        if [[ "$complexity" == "M" || "$complexity" == "L" ]]; then
+            turns_args=(--max-turns 40)
+            log "  Max turns: 40 (sonnet with M/L complexity)"
+        else
+            turns_args=(--max-turns 25)
+            log "  Max turns: 25 (sonnet with S/empty complexity)"
+        fi
+    fi
+
+    local output
+    local exit_code=0
+
+    # Capture stage output to a temp file so we can install a
+    # parent-side watchdog that enforces stage_timeout independently
+    # of the inner timeout(1) wrapper.  If the wrapper dies while the
+    # CLI is still running the parent would otherwise block forever on
+    # the command-substitution pipe; the file + background approach
+    # eliminates that stall and lets the watchdog cancel the run.
+    local _stage_out_tmp
+    _stage_out_tmp=$(mktemp 2>/dev/null) \
+        || _stage_out_tmp="${TMPDIR:-/tmp}/stage-out-$$.tmp"
+
+    (
+        trap - TERM
+        timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
+            -p "$prompt" \
+            ${agent_args[@]+"${agent_args[@]}"} \
+            --model "$model" \
+            ${fallback_args[@]+"${fallback_args[@]}"} \
+            ${turns_args[@]+"${turns_args[@]}"} \
+            --dangerously-skip-permissions \
+            --output-format json \
+            --json-schema "$schema" \
+            2>&1
+    ) > "$_stage_out_tmp" 3>&- &
+    local _stage_pid=$!
+
+    # Parent-side watchdog: SIGTERM the stage subshell if it outlives
+    # stage_timeout, even if the inner timeout(1) wrapper has already
+    # died without propagating the signal to the CLI.
+    #
+    # Poll in 1s steps instead of one long `sleep $stage_timeout`.  A
+    # single long sleep gets orphaned whenever the parent cancels the
+    # watchdog between spawning it and the sleep being reaped, leaving a
+    # multi-minute process behind; polling means a cancel can strand at
+    # most a sub-second sleep.  The loop also self-terminates the moment
+    # the stage exits (kill -0 fails), so a normal completion leaves
+    # nothing running.
+    #
+    # Redirect all std fds to /dev/null and close fd 3 so neither the
+    # watchdog nor its sleep child inherits run_stage's stdout (the
+    # capture pipe under $(run_stage ...)) or the fd 3 BATS uses to
+    # detect lingering background processes — either would stall the
+    # caller until the watchdog exited.
+    (
+        local _waited=0
+        while (( _waited < stage_timeout )); do
+            kill -0 "$_stage_pid" 2>/dev/null || exit 0
+            sleep 1
+            _waited=$(( _waited + 1 ))
+        done
+        kill "$_stage_pid" 2>/dev/null
+    ) </dev/null >/dev/null 2>&1 3>&- &
+    local _stage_watchdog_pid=$!
+
+    # Guard the wait with `|| exit_code=$?` so a non-zero stage status
+    # (e.g. 124 on timeout) is captured rather than tripping errexit in
+    # any caller that runs with `set -e` — without the guard the
+    # function would abort here and never reach the timeout-recovery
+    # path below.  exit_code is pre-initialised to 0 above.
+    wait "$_stage_pid" 2>/dev/null || exit_code=$?
+
+    # Cancel the watchdog; a no-op if it already fired or self-exited.
+    # Because it only ever sleeps in 1s steps, this can strand at most a
+    # sub-second sleep — never a multi-minute one.
+    kill "$_stage_watchdog_pid" 2>/dev/null || true
+    wait "$_stage_watchdog_pid" 2>/dev/null || true
+
+    # The watchdog kills with SIGTERM (exit 143 = 128 + 15); map to
+    # the standard timeout exit code (124) so the handling below
+    # works unchanged.
+    if (( exit_code == 143 )); then
+        exit_code=124
+    fi
+
+    output=$(< "$_stage_out_tmp")
+    rm -f "$_stage_out_tmp"
+
+    printf '%s\n' "=== $stage_name output ===" >> "$stage_log"
+    printf '%s\n' "$output" >> "$stage_log"
+    printf '%s\n' "=== exit code: $exit_code ===" >> "$stage_log"
+
+    # Parse token usage and reported cost from the CLI's JSON envelope
+    # alongside the existing structured-output extraction below. Every
+    # field is `// 0` guarded (see _extract_usage) so a missing/null usage
+    # block degrades to zero. Threaded into the stage_result envelope by
+    # _emit_stage_result (issue #580).
+    local _stage_usage
+    _stage_usage=$(_extract_usage "$output")
+
+    # Check timeout — but still try to extract structured output first.
+    # The agent may have produced valid output before the timeout killed the CLI.
+    if (( exit_code == 124 )); then
+        local timeout_structured
+        timeout_structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
+        if [[ -n "$timeout_structured" ]]; then
+            log "WARN: Stage $stage_name timed out after ${stage_timeout}s but produced structured output — using it"
+            local _sr
+            _sr=$(_emit_stage_result \
+                "success" "$timeout_structured" "$output" \
+                "$(_extract_denials "$output")" \
+                "$result_model" "null" \
+                "$(( $(_epoch_ms) - result_start_ms ))" \
+                "$_stage_usage" "${complexity:-}")
+            _apply_stage_action "$_sr" "accept"
+            return $?
+        fi
+
+        # Fallback: if no structured output, try .result text wrapping
+        # (same pattern as lines 936-944)
+        local timeout_fallback_result
+        timeout_fallback_result=$(printf '%s' "$output" | jq -c '
+            select(.is_error == false and .result != null) |
+            {status: "success", summary: .result}
+        ' 2>/dev/null)
+
+        if [[ -n "$timeout_fallback_result" ]]; then
+            log "WARN: Stage $stage_name timed out after ${stage_timeout}s but produced .result — using fallback"
+            local _sr
+            _sr=$(_emit_stage_result \
+                "success" "$timeout_fallback_result" "$output" \
+                "$(_extract_denials "$output")" \
+                "$result_model" "null" \
+                "$(( $(_epoch_ms) - result_start_ms ))" \
+                "$_stage_usage" "${complexity:-}")
+            _apply_stage_action "$_sr" "accept"
+            return $?
+        fi
+
+        # Retry with a 20% longer timeout before giving up
+        local retry_timeout
+        retry_timeout=$(( stage_timeout + stage_timeout / 5 ))
+        log "WARN: Stage $stage_name timed out after ${stage_timeout}s — retrying with ${retry_timeout}s timeout"
+        printf '%s\n' "=== $stage_name timeout retry (${retry_timeout}s) ===" >> "$stage_log"
+
+        emit_event "retry" \
+            "stage=$stage_name" \
+            "reason=timeout" \
+            "attempt:=2" \
+            "max_attempts:=2" \
+            "model=$model" \
+            "previous_timeout=$stage_timeout" \
+            "retry_timeout=$retry_timeout"
+        emit_event "model_call" \
+            "stage=$stage_name" \
+            "model=$model" \
+            "fallback_model=$fallback_model" \
+            "agent=${agent:-default}" \
+            "schema=$schema_file" \
+            "complexity=${complexity:-}" \
+            "stage_attempt:=2"
+
+        exit_code=0
+        local _retry_out_tmp
+        _retry_out_tmp=$(mktemp 2>/dev/null) \
+            || _retry_out_tmp="${TMPDIR:-/tmp}/stage-retry-out-$$.tmp"
+
+        # Use the same background-subshell + temp-file + polling-watchdog
+        # pattern as the initial invocation: if timeout(1) fires but the
+        # CLI ignores SIGTERM, the pipe in a plain $(timeout ...) would
+        # stay open and block run_stage indefinitely.  The watchdog
+        # enforces retry_timeout independently and kills the subshell.
+        (
+            trap - TERM
+            timeout "$retry_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
+                -p "$prompt" \
+                ${agent_args[@]+"${agent_args[@]}"} \
+                --model "$model" \
+                ${fallback_args[@]+"${fallback_args[@]}"} \
+                ${turns_args[@]+"${turns_args[@]}"} \
+                --dangerously-skip-permissions \
+                --output-format json \
+                --json-schema "$schema" \
+                2>&1
+        ) > "$_retry_out_tmp" 3>&- &
+        local _retry_pid=$!
+
+        (
+            local _waited=0
+            while (( _waited < retry_timeout )); do
+                kill -0 "$_retry_pid" 2>/dev/null || exit 0
+                sleep 1
+                _waited=$(( _waited + 1 ))
+            done
+            kill "$_retry_pid" 2>/dev/null
+        ) </dev/null >/dev/null 2>&1 3>&- &
+        local _retry_watchdog_pid=$!
+
+        wait "$_retry_pid" 2>/dev/null || exit_code=$?
+
+        kill "$_retry_watchdog_pid" 2>/dev/null || true
+        wait "$_retry_watchdog_pid" 2>/dev/null || true
+
+        if (( exit_code == 143 )); then
+            exit_code=124
+        fi
+
+        output=$(< "$_retry_out_tmp")
+        rm -f "$_retry_out_tmp"
+
+        # Re-extract usage — output now reflects the retry attempt, not the
+        # original (likely-zeroed) timed-out attempt captured above.
+        _stage_usage=$(_extract_usage "$output")
+
+        printf '%s\n' "$output" >> "$stage_log"
+        printf '%s\n' "=== timeout retry exit code: $exit_code ===" >> "$stage_log"
+
+        if (( exit_code == 124 )); then
+            # Second timeout at same model tier — fall through to the
+            # consolidated decide-action.sh call below.
+            _TIMED_OUT_STAGE_NAMES="${_TIMED_OUT_STAGE_NAMES:+$_TIMED_OUT_STAGE_NAMES, }$stage_name"
+            (( _CONSECUTIVE_TIMEOUTS++ )) || true
+            if (( _CONSECUTIVE_TIMEOUTS >= 2 )); then
+                log_warn "Cascade timeout detected: $_CONSECUTIVE_TIMEOUTS consecutive stage(s)" \
+                    "timed out: $_TIMED_OUT_STAGE_NAMES. Consider increasing timeout or reducing complexity."
+            fi
+            log "WARN: Stage $stage_name timed out twice with $model — deferring to decide-action.sh"
+            printf '%s\n' "=== $stage_name double timeout ===" >> "$stage_log"
+        fi
+    fi
+
+    # =========================================================================
+    # CONSOLIDATED ESCALATION DECISION via decide-action.sh
+    # =========================================================================
+    # Determine error_kind from the run outcome; build a stage_result envelope;
+    # call decide-action.sh exactly once (AC1); execute the returned action.
+    # _apply_stage_action is always called with the action decide-action.sh
+    # returned (AC2).  ESCALATION_POLICY_BACKEND=bash is honoured inside
+    # decide-action.sh itself (AC3).
+
+    # Detect max-turns exhaustion
+    local output_subtype
+    output_subtype=$(printf '%s' "$output" | jq -r '.subtype // empty' 2>/dev/null)
+
+    # Detect permission denials early (needed for structured-error classification)
+    # Produces a comma-joined string for human-readable log_warn messages below.
+    local _permission_denials
+    _permission_denials=$(_extract_denials "$output" \
+        | jq -r 'select(length > 0) | join(", ")' 2>/dev/null || true)
+
+    # Extract structured output from the run
+    local structured
+    structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
+
+    # .result fallback — build (with field extraction) when .structured_output
+    # is absent but the CLI returned a text result.
+    local _fallback_result=""
+    if [[ -z "$structured" ]]; then
+        local _basic_fallback
+        _basic_fallback=$(printf '%s' "$output" | jq -c '
+            select(.is_error == false and .result != null) |
+            {status: "success", summary: .result}
+        ' 2>/dev/null)
+
+        if [[ -n "$_basic_fallback" ]]; then
+            log "WARNING: No .structured_output from $stage_name — using .result fallback"
+            local result_text
+            result_text=$(printf '%s' "$output" \
+                | jq -r '.result // empty' 2>/dev/null)
+
+            _fallback_result="$_basic_fallback"
+            if [[ -n "$result_text" ]]; then
+                # Extract pr_number from "PR #N", "MR #N", or "!N"
+                # Deliberately omits bare "#N" — too ambiguous (issue refs,
+                # step counts, commit hashes) and would produce wrong PR nums.
+                local pr_re='[PpMm][Rr] *#([0-9]+)'
+                local bang_re='!([0-9]+)'
+                if [[ "$result_text" =~ $pr_re ]] \
+                    || [[ "$result_text" =~ $bang_re ]]; then
+                    local pr_num="${BASH_REMATCH[1]}"
+                    _fallback_result=$(printf '%s' "$_fallback_result" \
+                        | jq -c --argjson n "$pr_num" \
+                            '.pr_number = $n')
+                fi
+
+                # Extract branch from common patterns
+                local branch_re='[Bb]ranch[: ]+([a-zA-Z0-9/_.-]+)'
+                if [[ "$result_text" =~ $branch_re ]]; then
+                    local br="${BASH_REMATCH[1]}"
+                    _fallback_result=$(printf '%s' "$_fallback_result" \
+                        | jq -c --arg b "$br" \
+                            '.branch = $b')
+                fi
+
+                # Extract tasks JSON array embedded in text using a
+                # balanced-bracket parser so nested arrays (e.g. a
+                # "dependencies" field) are not truncated at their first ']'.
+                local tasks_match
+                tasks_match=$(python3 -c "
+import sys, re
+t = sys.stdin.read()
+for m in re.finditer(r'\[\s*\{', t):
+    s = m.start()
+    d = 0
+    for i, c in enumerate(t[s:], s):
+        if c == '[': d += 1
+        elif c == ']':
+            d -= 1
+            if d == 0:
+                print(t[s:i+1])
+                break
+    break" <<< "$result_text" 2>/dev/null)
+                if [[ -n "$tasks_match" ]]; then
+                    local valid_tasks
+                    valid_tasks=$(printf '%s' "$tasks_match" \
+                        | jq -c 'if type == "array" then . else empty end' \
+                            2>/dev/null)
+                    if [[ -n "$valid_tasks" ]]; then
+                        _fallback_result=$(printf '%s' "$_fallback_result" \
+                            | jq -c --argjson t "$valid_tasks" \
+                                '.tasks = $t')
+                    fi
+                fi
+            fi
+        fi
+    fi
+
+    # Classify error_kind based on the run outcome
+    local _error_kind="null"
+
+    if (( exit_code == 124 )); then
+        # Timed out even after same-model retry — classify as double_timeout
+        # so downstream (decide-action.sh) can distinguish a single first-pass
+        # timeout (which never reaches here) from a repeated timeout.
+        _error_kind="double_timeout"
+    elif [[ "$output_subtype" == "error_max_turns" ]]; then
+        if [[ "$(effective_fallback "$model")" == "$model" ]]; then
+            log_error "Stage $stage_name hit max turns with $model (ceiling) — cannot escalate"
+            _error_kind="max_turns_exhausted_at_ceiling"
+        else
+            _error_kind="max_turns_exhausted"
+        fi
+    elif printf '%s' "$output" \
+        | grep -qE -- "--agent '[^']+' not found"; then
+        local _agent_name
+        _agent_name=$(printf '%s' "$output" \
+            | sed -n "s/.*--agent '\\([^']*\\)' not found.*/\\1/p" \
+            | head -1)
+        log_error "Stage $stage_name — agent not found: ${_agent_name:-unknown}"
+        _error_kind="agent_not_found"
+    elif detect_rate_limit "$output"; then
+        handle_rate_limit "$output" "$model"
+        _error_kind="rate_limit"
+    elif [[ -z "$structured" && -z "$_fallback_result" ]]; then
+        # No parseable output of any kind
+        local output_byte_count output_preview
+        output_byte_count=$(printf '%s' "$output" | wc -c)
+        output_preview="${output:0:500}"
+        log "Diagnostic fallback failure — Output byte count: $output_byte_count"
+        log "Diagnostic fallback failure — First 500 characters: $output_preview"
+        emit_event "schema_validation_fail" \
+            "stage=$stage_name" \
+            "reason=no_structured_output" \
+            "model=$model" \
+            "schema=$schema_file" \
+            "errors:=[]"
+        _error_kind="no_structured_output"
+    else
+        # We have some output — check for a structured error status
+        local _structured_status=""
+        _structured_status=$(printf '%s' "${structured:-$_fallback_result}" \
+            | jq -r '.status // empty' 2>/dev/null)
+        if [[ "$_structured_status" == "error" ]]; then
+            if [[ -n "$_permission_denials" ]]; then
+                log "WARN: $stage_name blocked by permission hook" \
+                    "(tools: $_permission_denials) — bailing"
+                _error_kind="permission_denied"
+            else
+                _error_kind="structured_error"
+            fi
+        fi
+    fi
+
+    # Build the interim stage_result that decide-action.sh will inspect
+    local _interim_status _interim_structured _error_kind_json
+    if [[ "$_error_kind" == "null" ]]; then
+        _interim_status="success"
+        _interim_structured="${structured:-$_fallback_result}"
+        _error_kind_json="null"
+    else
+        _interim_status="error"
+        _interim_structured="null"
+        _error_kind_json="\"${_error_kind}\""
+    fi
+
+    local _sr_interim
+    _sr_interim=$(_emit_stage_result \
+        "$_interim_status" "${_interim_structured}" "$output" \
+        "$(_extract_denials "$output")" \
+        "$result_model" "$_error_kind_json" \
+        "$(( $(_epoch_ms) - result_start_ms ))" \
+        "$_stage_usage" "${complexity:-}")
+
+    # Escalation history from status file
+    local _history="[]"
+    if [[ -f "$STATUS_FILE" ]]; then
+        _history=$(jq -c '.escalations // []' "$STATUS_FILE" 2>/dev/null \
+            || printf '[]')
+    fi
+
+    # ── Single decide-action.sh call (AC1) ───────────────────────────────────
+    local _da_json _da_action _da_target_model _da_reason
+    _da_json=$(bash "$SCRIPT_DIR/decide-action.sh" \
+        "$_sr_interim" "$_history" 2>/dev/null) \
+        || _da_json='{"action":"bail","reason":"decide-action.sh invocation failed"}'
+    _da_action=$(printf '%s' "$_da_json" \
+        | jq -r '.action // "bail"' 2>/dev/null)
+    _da_target_model=$(printf '%s' "$_da_json" \
+        | jq -r '.model // empty' 2>/dev/null)
+    _da_reason=$(printf '%s' "$_da_json" \
+        | jq -r '.reason // ""' 2>/dev/null)
+
+    log "decide-action.sh → action=$_da_action${_da_target_model:+ model=$_da_target_model}"
+
+    # ── Dispatch: _apply_stage_action called with the action returned by ──────
+    # ── decide-action.sh (AC2)                                           ──────
+    case "$_da_action" in
+        accept)
+            _CONSECUTIVE_TIMEOUTS=0
+            _TIMED_OUT_STAGE_NAMES=""
+            local _sr_accept
+            _sr_accept=$(_emit_stage_result \
+                "success" "$_interim_structured" "$output" \
+                "$(_extract_denials "$output")" \
+                "$result_model" "null" \
+                "$(( $(_epoch_ms) - result_start_ms ))" \
+                "$_stage_usage" "${complexity:-}")
+            _apply_stage_action "$_sr_accept" "accept"
+            return $?
+            ;;
+        bail)
+            # Preserve the cascade counter on a definitive (double) timeout —
+            # it was just incremented above and must survive across stages so
+            # consecutive timeouts can be detected.  Any other error breaks the
+            # consecutive-timeout streak, so reset it.
+            if [[ "$_error_kind" != "double_timeout" ]]; then
+                _CONSECUTIVE_TIMEOUTS=0
+                _TIMED_OUT_STAGE_NAMES=""
+            fi
+            _apply_stage_action "$_sr_interim" "bail" "$_da_reason"
+            return $?
+            ;;
+        escalate)
+            # Issue #583: check the run budget BEFORE spending on the pricier
+            # escalated model.  The post-dispatch check in _apply_stage_action
+            # runs only AFTER the extra CLI call, so without this pre-check the
+            # escalation would already have spent by the time the ceiling fires.
+            # On a HARD breach, halt cleanly WITHOUT making the escalated call:
+            # record the terminal budget_exceeded state and emit the interim
+            # result unchanged (the parent-shell _halt_if_budget_exceeded guard
+            # finalizes + exits).  This satisfies "must NOT trigger escalation".
+            if ! check_run_budget; then
+                set_run_budget_exceeded \
+                    "$stage_name" \
+                    "run token/cost ceiling exceeded (escalation suppressed)"
+                printf '%s\n' "$_sr_interim"
+                return 1
+            fi
+
+            # Re-run with the model decide-action.sh selected
+            local _esc_model="${_da_target_model:-$(effective_fallback "$model")}"
+            local _esc_fallback
+            _esc_fallback=$(effective_fallback "$_esc_model")
+            local -a _esc_fallback_args=()
+            if [[ "$_esc_fallback" != "$_esc_model" ]]; then
+                _esc_fallback_args=(--fallback-model "$_esc_fallback")
+            fi
+
+            log "WARN: Stage $stage_name $_da_reason — escalating $model → $_esc_model"
+            printf '%s\n' \
+                "=== $stage_name escalation: $model → $_esc_model ===" >> "$stage_log"
+            record_escalation "$stage_name" "$model" "$_esc_model" "$_da_reason"
+
+            emit_event "model_call" \
+                "stage=$stage_name" \
+                "model=$_esc_model" \
+                "fallback_model=$_esc_fallback" \
+                "agent=${agent:-default}" \
+                "schema=$schema_file" \
+                "complexity=${complexity:-}" \
+                "stage_attempt:=2"
+
+            # For max_turns escalation, omit --max-turns so the escalated
+            # model can complete without an artificial turn cap.
+            local -a _esc_turns_args=()
+            if [[ "$_error_kind" != "max_turns_exhausted" ]]; then
+                _esc_turns_args=("${turns_args[@]+"${turns_args[@]}"}")
+            fi
+
+            # _esc_exit_code is captured to preserve the raw CLI exit code for
+            # the stage log.  Flow control is handled via structured output
+            # extraction below, not via this value.
+            local _esc_exit_code=0
+            # Temp-file capture (see run_stage's primary launch) — avoids the
+            # command-substitution pipe-wedge when the CLI leaves a lingering child.
+            local _esc_raw; _esc_raw=$(mktemp)
+            timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
+                -p "$prompt" \
+                ${agent_args[@]+"${agent_args[@]}"} \
+                --model "$_esc_model" \
+                ${_esc_fallback_args[@]+"${_esc_fallback_args[@]}"} \
+                ${_esc_turns_args[@]+"${_esc_turns_args[@]}"} \
+                --dangerously-skip-permissions \
+                --output-format json \
+                --json-schema "$schema" \
+                > "$_esc_raw" 2>&1 || _esc_exit_code=$?
+            output=$(cat "$_esc_raw"); rm -f "$_esc_raw"
+
+            # Re-extract usage — output now reflects the escalated (pricier)
+            # model's attempt, so its tokens/cost must replace the original
+            # pre-escalation usage in the emitted envelope (issue #580).
+            _stage_usage=$(_extract_usage "$output")
+
+            result_model="$_esc_model"
+            printf '%s\n' "=== $stage_name escalation output ===" >> "$stage_log"
+            printf '%s\n' "$output" >> "$stage_log"
+            printf '%s\n' \
+                "=== escalation exit code: $_esc_exit_code ===" >> "$stage_log"
+            (( _esc_exit_code != 0 )) && \
+                log_warn "escalation CLI exited $_esc_exit_code"
+
+            # Extract output from the escalated run
+            local _esc_structured
+            _esc_structured=$(printf '%s' "$output" \
+                | jq -c '.structured_output // empty' 2>/dev/null)
+            if [[ -z "$_esc_structured" ]]; then
+                _esc_structured=$(printf '%s' "$output" | jq -c '
+                    select(.is_error == false and .result != null) |
+                    {status: "success", summary: .result}
+                ' 2>/dev/null)
+            fi
+
+            # Preserve the cascade counter on a definitive (double) timeout so
+            # consecutive timeouts accumulate across stages; reset for any other
+            # error that breaks the consecutive-timeout streak.
+            if [[ "$_error_kind" != "double_timeout" ]]; then
+                _CONSECUTIVE_TIMEOUTS=0
+                _TIMED_OUT_STAGE_NAMES=""
+            fi
+            local _sr_esc
+            if [[ -n "$_esc_structured" ]]; then
+                _sr_esc=$(_emit_stage_result \
+                    "success" "$_esc_structured" "$output" \
+                    "$(_extract_denials "$output")" \
+                    "$result_model" "null" \
+                    "$(( $(_epoch_ms) - result_start_ms ))" \
+                    "$_stage_usage" "${complexity:-}")
+            else
+                emit_event "schema_validation_fail" \
+                    "stage=$stage_name" \
+                    "reason=no_structured_output_after_escalation" \
+                    "model=$_esc_model" \
+                    "schema=$schema_file" \
+                    "errors:=[]"
+                log_error "No structured output from $stage_name after escalation"
+                _sr_esc=$(_emit_stage_result \
+                    "error" "null" "$output" \
+                    "$(_extract_denials "$output")" \
+                    "$result_model" '"no_structured_output"' \
+                    "$(( $(_epoch_ms) - result_start_ms ))" \
+                    "$_stage_usage" "${complexity:-}")
+            fi
+            _apply_stage_action "$_sr_esc" "escalate" "$_da_reason"
+            return $?
+            ;;
+        retry_same)
+            # Issue #583: check the run budget BEFORE spending on the retry.
+            # Same rationale as the escalate branch — the post-dispatch check in
+            # _apply_stage_action runs only AFTER the retry CLI call.  On a HARD
+            # breach, halt WITHOUT retrying: record budget_exceeded and emit the
+            # interim result (the parent-shell guard finalizes + exits).  This
+            # satisfies "must NOT trigger retry".
+            if ! check_run_budget; then
+                set_run_budget_exceeded \
+                    "$stage_name" \
+                    "run token/cost ceiling exceeded (retry suppressed)"
+                printf '%s\n' "$_sr_interim"
+                return 1
+            fi
+
+            # handle_rate_limit() was already called during error_kind
+            # classification above; emit the retry/model_call events now.
+            emit_event "retry" \
+                "stage=$stage_name" \
+                "reason=rate_limit" \
+                "attempt:=2" \
+                "max_attempts:=2" \
+                "model=$model"
+            emit_event "model_call" \
+                "stage=$stage_name" \
+                "model=$model" \
+                "fallback_model=$fallback_model" \
+                "agent=${agent:-default}" \
+                "schema=$schema_file" \
+                "complexity=${complexity:-}" \
+                "stage_attempt:=2"
+
+            local _retry_exit_code=0
+            # Temp-file capture (see run_stage's primary launch) — avoids the
+            # command-substitution pipe-wedge when the CLI leaves a lingering child.
+            local _retry_raw; _retry_raw=$(mktemp)
+            timeout "$stage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
+                -p "$prompt" \
+                ${agent_args[@]+"${agent_args[@]}"} \
+                --model "$model" \
+                ${fallback_args[@]+"${fallback_args[@]}"} \
+                ${turns_args[@]+"${turns_args[@]}"} \
+                --dangerously-skip-permissions \
+                --output-format json \
+                --json-schema "$schema" \
+                > "$_retry_raw" 2>&1 || _retry_exit_code=$?
+            output=$(cat "$_retry_raw"); rm -f "$_retry_raw"
+
+            # Re-extract usage — output now reflects the retry attempt, not the
+            # rate-limited original, so the emitted envelope carries the retry's
+            # tokens/cost (issue #580).
+            _stage_usage=$(_extract_usage "$output")
+
+            printf '%s\n' "=== $stage_name retry output ===" >> "$stage_log"
+            printf '%s\n' "$output" >> "$stage_log"
+            printf '%s\n' \
+                "=== retry exit code: $_retry_exit_code ===" >> "$stage_log"
+
+            local _retry_structured
+            _retry_structured=$(printf '%s' "$output" \
+                | jq -c '.structured_output // empty' 2>/dev/null)
+            if [[ -z "$_retry_structured" ]]; then
+                _retry_structured=$(printf '%s' "$output" | jq -c '
+                    select(.is_error == false and .result != null) |
+                    {status: "success", summary: .result}
+                ' 2>/dev/null)
+            fi
+
+            _CONSECUTIVE_TIMEOUTS=0
+            _TIMED_OUT_STAGE_NAMES=""
+            local _sr_retry
+            if [[ -n "$_retry_structured" ]]; then
+                _sr_retry=$(_emit_stage_result \
+                    "success" "$_retry_structured" "$output" \
+                    "$(_extract_denials "$output")" \
+                    "$result_model" "null" \
+                    "$(( $(_epoch_ms) - result_start_ms ))" \
+                    "$_stage_usage" "${complexity:-}")
+            else
+                _sr_retry=$(_emit_stage_result \
+                    "error" "null" "$output" \
+                    "$(_extract_denials "$output")" \
+                    "$result_model" '"no_structured_output"' \
+                    "$(( $(_epoch_ms) - result_start_ms ))" \
+                    "$_stage_usage" "${complexity:-}")
+            fi
+            _apply_stage_action "$_sr_retry" "retry_same" "$_da_reason"
+            return $?
+            ;;
+        *)
+            log_error "decide-action.sh returned unknown action '$_da_action'"
+            _apply_stage_action "$_sr_interim" "bail" "unknown_action_from_decide"
+            return $?
+            ;;
+    esac
+}
+
+# =============================================================================
+# TRIAGE STAGE
+# =============================================================================
+#
+# Classify the issue into "fast-path" (surgical, test-only, well-specified) or
+# "full" (default verification pipeline). Conservative — biases hard toward
+# "full" whenever uncertain. See plugins/pipeline-core/skills/handle-issues/SKILL.md for the
+# six criteria and .claude/scripts/triage-validate.sh for prompt-quality tests.
+#
+# Arguments:
+#   $1 - optional path to issue body markdown (defaults to context/issue-body.md)
+#
+# Side effects:
+#   - Writes $LOG_BASE/triage.json artifact
+#   - Updates status.json: stages.triage.* and top-level .route
+#   - Sets current_stage to "triage"
+#
+# Output (stdout):
+#   - The final route string ("fast-path" or "full")
+
+# build_triage_prompt is a thin wrapper around build_prompt() sourced from
+# prompts/triage-prompt.sh. The sourced build_prompt() is the single source
+# of truth for the triage classifier prompt and is shared with
+# triage-validate.sh's golden tests.
+build_triage_prompt() {
+    build_prompt "$@"
+}
+
+# _run_triage_composition — invoke the triage-classify skill as a standard
+# (non-isolated) subprocess, following the dispatch_composition(isolated=false)
+# pattern from batch-orchestrator.sh.  Triage is a pure classification task;
+# it requires no file-system writes so --dangerously-skip-permissions is
+# omitted.
+#
+# Usage: _run_triage_composition <prompt> [extra claude args...]
+_run_triage_composition() {
+    local prompt="$1"
+    shift
+    local triage_timeout
+    triage_timeout=$(get_stage_timeout "triage" "")
+    log "Composition dispatch → standard (triage-classify)"
+    timeout "$triage_timeout" env -u CLAUDECODE "$CLAUDE_CLI" \
+        -p "$prompt" \
+        "$@" \
+        2>&1
+}
+
+run_triage_stage() {
+    local issue_body_file="${1:-$LOG_BASE/context/issue-body.md}"
+
+    # Kill switch: DISABLE_SURGICAL_FAST_PATH bypasses triage entirely,
+    # forces full route, and writes kill_switch_engaged:true to triage.json.
+    if [[ -n "${DISABLE_SURGICAL_FAST_PATH:-}" ]]; then
+        log "Triage: DISABLE_SURGICAL_FAST_PATH set — forcing full route"
+        jq -n '{
+            route: "full",
+            kill_switch_engaged: true,
+            timestamp: (now | todate)
+        }' > "$LOG_BASE/triage.json"
+        set_stage_started "triage"
+        update_stage triage completed route full
+        printf 'full\n'
+        return 0
+    fi
+
+    set_stage_started "triage"
+
+    if [[ ! -f "$issue_body_file" ]]; then
+        log_error "Triage: issue body file not found: $issue_body_file"
+        # Fail safe: write minimal triage.json marking full route.
+        jq -n '{
+            route: "full",
+            confidence: "low",
+            disqualifying_criterion: "issue_body_missing",
+            timestamp: (now | todate)
+        }' > "$LOG_BASE/triage.json"
+        update_stage triage completed route full
+        printf 'full\n'
+        return 0
+    fi
+
+    local issue_body prompt
+    issue_body=$(< "$issue_body_file")
+    prompt=$(build_triage_prompt "$issue_body")
+
+    # Resolve model. TRIAGE_MODEL env var allows operator override; default
+    # falls through to model-config.sh (triage stage maps to "haiku" tier).
+    local triage_model="${TRIAGE_MODEL:-}"
+    local -a model_args=()
+    if [[ -n "$triage_model" ]]; then
+        model_args=(--model "$triage_model")
+    fi
+
+    local schema
+    schema=$(jq -c . "$SCHEMA_DIR/implement-issue-triage.json")
+
+    local triage_log="$LOG_BASE/stages/$(next_stage_log "triage")"
+
+    # Invoke the triage-classify skill via a standard (non-isolated)
+    # subprocess — the dispatch_composition(isolated=false) pattern from
+    # batch-orchestrator.sh.  No --dangerously-skip-permissions needed.
+    local raw exit_code=0
+    raw=$(_run_triage_composition "$prompt" \
+        ${model_args[@]+"${model_args[@]}"} \
+        --output-format json \
+        --json-schema "$schema") || exit_code=$?
+
+    printf '%s\n' "=== triage output ===" >> "$triage_log"
+    printf '%s\n' "$raw" >> "$triage_log"
+    printf '%s\n' "=== exit code: $exit_code ===" >> "$triage_log"
+
+    # Parse {route, confidence, disqualifying_criterion} from skill output.
+    # Default to full/low on any parse failure.
+    local route confidence dq
+    route=$(printf '%s' "$raw" \
+        | jq -r '.structured_output.route // "full"' 2>/dev/null)
+    confidence=$(printf '%s' "$raw" \
+        | jq -r '.structured_output.confidence // "low"' 2>/dev/null)
+    dq=$(printf '%s' "$raw" \
+        | jq -r \
+            '.structured_output.disqualifying_criterion // empty' \
+            2>/dev/null)
+
+    # Write triage.json artifact (auditable record for both routes).
+    local artifact="$LOG_BASE/triage.json"
+    jq -n \
+        --arg route "$route" \
+        --arg confidence "$confidence" \
+        --arg dq "${dq:-}" \
+        '{
+            route: $route,
+            confidence: $confidence,
+            disqualifying_criterion: (if $dq == "" then null else $dq end),
+            timestamp: (now | todate)
+        }' > "$artifact"
+
+    # Update status.json: triage stage details + top-level route field.
+    jq --arg route "$route" \
+       --arg confidence "$confidence" \
+       --arg dq "${dq:-}" \
+       '.stages.triage.route = $route |
+        .stages.triage.confidence = $confidence |
+        .stages.triage.disqualifying_criterion =
+            (if $dq == "" then null else $dq end) |
+        .route = $route |
+        .last_update = (now | todate)' \
+       "$STATUS_FILE" > "${STATUS_FILE}.tmp" \
+       && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+
+    set_stage_completed "triage"
+    log "Triage complete. Route: $route" \
+        "(confidence: $confidence, dq: ${dq:-none})"
+
+    printf '%s\n' "$route"
+}
+
+# =============================================================================
+# QUALITY LOOP HELPER
+# =============================================================================
+
+# Run the quality loop (simplify -> review -> fix, repeat)
+# Note: Testing is handled separately by run_test_loop after all tasks complete
+# Arguments:
+#   $1 - working directory
+#   $2 - branch name
+#   $3 - stage prefix for logging (e.g., "task-1" or "pr-fix")
+#   $4 - agent to use for fix stages (optional, falls back to global $AGENT)
+#   $5 - max iterations override (optional, defaults to MAX_QUALITY_ITERATIONS)
+#   $6 - complexity hint for model selection (S/M/L, optional)
+# Returns:
+#   0 on success (approved)
+#   0 on max iterations exceeded (soft-fail, adds to DEGRADED_STAGES)
+run_quality_loop() {
+    local loop_dir="$1"
+    local loop_branch="$2"
+    local stage_prefix="${3:-main}"
+    local loop_agent="${4:-$AGENT}"
+    local max_iterations="${5:-$MAX_QUALITY_ITERATIONS}"
+    local loop_complexity="${6:-}"
+    local loop_model_override=""
+
+    local loop_approved=false
+    local loop_iteration=0  # Per-loop counter (resets each call)
+    local skip_simplify=false  # Set when prior simplify reported no changes; reset after any fix
+
+    while [[ "$loop_approved" != "true" ]]; do
+        loop_iteration=$((loop_iteration + 1))
+        increment_quality_iteration  # Global counter for status tracking
+
+        if ! check_wall_timeout; then
+            log_warn "Wall-clock timeout in quality loop at iteration $loop_iteration"
+            set_final_state "wall_timeout_quality"
+            DEGRADED_STAGES+=("quality:wall_timeout:iter=$loop_iteration")
+            loop_approved=true
+            break
+        fi
+
+        if (( loop_iteration > max_iterations )); then
+            log_warn "Quality loop for $stage_prefix exceeded max iterations ($max_iterations). Soft-failing and continuing."
+            set_final_state "max_iterations_quality"
+            DEGRADED_STAGES+=("quality:max_iterations:$stage_prefix:iter=$loop_iteration")
+            loop_approved=true
+            break
+        fi
+
+        log "Quality loop iteration $loop_iteration/$max_iterations (prefix: $stage_prefix)"
+
+        # -------------------------------------------------------------------------
+        # SIMPLIFY
+        # -------------------------------------------------------------------------
+        local simplify_summary="No changes"
+
+        if [[ "$skip_simplify" == "true" ]]; then
+            log "Skipping simplify for $stage_prefix iter $loop_iteration (prior iteration reported no changes)"
+        else
+            # Pre-compute modified TypeScript/React files (three-dot merge-base diff)
+            # before simplify stage. Recomputed each iteration since fix stages may add commits.
+            local simplify_changed_files_raw simplify_changed_files
+            simplify_changed_files_raw=$(git -C "$loop_dir" diff "$BASE_BRANCH"...HEAD --name-only -- '*.ts' '*.tsx' 2>/dev/null || true)
+            simplify_changed_files=$(printf '%s\n' "$simplify_changed_files_raw" | grep -v -E '^$' || true)
+
+            local simplify_prompt="Simplify modified TypeScript/React files in the current branch in working directory $loop_dir on branch $loop_branch.
+
+IMPORTANT SCOPE CONSTRAINT: This is for issue #$ISSUE_NUMBER. Only simplify code that is directly related to the issue's goals. Do NOT apply unrelated refactoring to files that were only incidentally touched or are outside the issue's focus area.
+
+MODIFIED TYPESCRIPT/REACT FILES:
+$simplify_changed_files
+
+If no TypeScript/React files were modified as part of this issue's implementation, make no changes and report 'No changes to simplify'.
+
+Simplify code for clarity and consistency without changing functionality.
+When committing: run 'git diff --name-only' to list the files
+you changed, then 'git add' only those specific files. Never
+use 'git add -A' or 'git add .' — only stage files the task
+actually modified.
+Output a summary of changes made."
+
+            local simplify_stage_name="simplify-${stage_prefix}-iter-$loop_iteration"
+            set_stage_started "$simplify_stage_name"
+            local simplify_result
+            local simplify_head_before
+            simplify_head_before=$(git -C "$loop_dir" rev-parse HEAD \
+                2>/dev/null || true)
+            simplify_result=$(run_stage "$simplify_stage_name" "$simplify_prompt" "implement-issue-simplify.json" "" "$loop_complexity")
+            _halt_if_budget_exceeded
+            local simplify_status
+            simplify_status=$(printf '%s' "$simplify_result" | jq -r '.status // "success"')
+            if [[ "$simplify_status" != "error" ]]; then
+                set_stage_completed "$simplify_stage_name"
+            fi
+
+            # Guard: verify any new simplify commit against path allowlist
+            local simplify_head_after
+            simplify_head_after=$(git -C "$loop_dir" rev-parse HEAD \
+                2>/dev/null || true)
+            if [[ "$simplify_head_after" != "$simplify_head_before" ]]; then
+                guard_commit_path_allowlist "$loop_dir" || {
+                    log_error \
+                        "$simplify_stage_name: committed paths outside" \
+                        "the code/tests allowlist — aborting quality loop"
+                    break
+                }
+            fi
+
+            simplify_summary=$(printf '%s' "$simplify_result" | jq -r '.output.summary // "No changes"')
+
+            # If simplify reported no changes, skip it on the next iteration until a
+            # fix stage runs (which may introduce new simplification opportunities).
+            if echo "$simplify_summary" | grep -qi "no changes"; then
+                skip_simplify=true
+                log "Simplify reported no changes — will skip simplify on next iteration"
+            else
+                skip_simplify=false
+            fi
+        fi
+
+        # -------------------------------------------------------------------------
+        # REVIEW
+        # -------------------------------------------------------------------------
+
+        # Build cumulative context from prior iterations
+        local prior_context=""
+        local review_history_file="$LOG_BASE/context/review-history-${stage_prefix}.json"
+        if [[ -f "$review_history_file" ]] && (( loop_iteration > 1 )); then
+            prior_context=$(jq -r '
+                [.[] | "Iteration \(.iteration): \(.issues | length) issues - \(.issues | map(.description) | join("; "))"] | join("\n")
+            ' "$review_history_file" 2>/dev/null || printf '')
+        fi
+
+        # Pre-compute modified files (three-dot merge-base diff) for review stage
+        local review_changed_files_raw review_changed_files
+        review_changed_files_raw=$(git -C "$loop_dir" diff "$BASE_BRANCH"...HEAD --name-only 2>/dev/null || true)
+        review_changed_files=$(printf '%s\n' "$review_changed_files_raw" | grep -v -E '^$' || true)
+
+        local review_prompt="${PLATFORM_PATTERNS_PREFIX}Review the code changes for task scope '$stage_prefix' in working directory $loop_dir on branch $loop_branch.
+
+IMPORTANT: This is a task-level quality check within the implementation workflow, NOT a full PR review.
+Your job is to verify code quality for the changes made in this task only.
+
+Check:
+- Code patterns and standards
+- Consistency with codebase conventions
+- Potential bugs or issues
+- Security concerns
+- If any \$queryRaw or raw SQL strings are present, cross-reference them against existing similar queries in the codebase to verify table names and query patterns are consistent
+
+Checklist (verify each item explicitly):
+1. Response schemas declared for all routes
+2. Auth middleware applied to all protected routes
+3. No unbounded queries without \`take\` (pagination limit)
+4. No N+1 patterns (all related data fetched in a single query or batched)
+5. No hollow test assertions (every assertion checks a meaningful value)
+
+FILES CHANGED:
+$review_changed_files
+
+$(if [[ -n "$prior_context" ]]; then
+    printf '\n'
+    printf 'PRIOR ITERATION FINDINGS (verify if these were fixed — do NOT re-report fixed issues):\n'
+    printf '%s\n' "$prior_context"
+    printf '\n'
+    printf 'Focus on: (1) verifying prior issues were actually fixed, (2) finding NEW issues only.\n'
+fi)
+
+DO NOT recommend 'approve and merge' - this is not a PR review.
+Simply output 'approved' if code quality is acceptable, or 'changes_requested' with specific issues to fix."
+
+        local review_stage_name="review-${stage_prefix}-iter-$loop_iteration"
+        set_stage_started "$review_stage_name"
+        local review_result
+        review_result=$(run_stage "$review_stage_name" "$review_prompt" "implement-issue-review.json" "code-reviewer" "$loop_complexity")
+        _halt_if_budget_exceeded
+        local review_run_status
+        review_run_status=$(printf '%s' "$review_result" | jq -r '.status // "success"')
+        if [[ "$review_run_status" != "error" ]]; then
+            set_stage_completed "$review_stage_name"
+        fi
+
+        # Handle timeout: skip result inspection and retry on next iteration
+        if is_stage_timeout "$review_result"; then
+            log_warn "Review stage timed out on iteration $loop_iteration — retrying next iteration"
+            continue
+        fi
+
+        local review_verdict review_summary verdict_source
+        review_summary=$(printf '%s' "$review_result" | jq -r '.output.summary // "Review completed"')
+        local has_result_field
+        has_result_field=$(printf '%s' "$review_result" | jq '.output | has("result")' 2>/dev/null)
+
+        if [[ "$has_result_field" == "true" ]]; then
+            # Structured output available: extract verdict from .output.result field
+            review_verdict=$(printf '%s' "$review_result" | jq -r '.output.result')
+            verdict_source="structured output"
+            log "Verdict extracted from structured output: $review_verdict"
+        else
+            # Fallback: parse verdict from summary text
+            verdict_source="fallback text"
+            local summary_lower
+            summary_lower=$(printf '%s' "$review_summary" | tr '[:upper:]' '[:lower:]')
+
+            # Check for approval keywords
+            if grep -qiE '(approved|lgtm|looks good|no issues)' <<< "$summary_lower"; then
+                review_verdict="approved"
+                log "Verdict parsed from fallback text: approved (matched approval keywords)"
+            # Check for rejection keywords
+            elif grep -qiE '(changes requested|request changes|must fix|blocking|critical)' <<< "$summary_lower"; then
+                review_verdict="changes_requested"
+                log "Verdict parsed from fallback text: changes_requested (matched rejection keywords)"
+            else
+                # Default to changes_requested if ambiguous
+                review_verdict="changes_requested"
+                log "Verdict parsed from fallback text: changes_requested (ambiguous/default)"
+            fi
+        fi
+
+        # Append current iteration findings to review history
+        local current_issues
+        current_issues=$(printf '%s' "$review_result" | jq -c "{iteration: $loop_iteration, issues: (.output.issues // []), result: (.output.result // .output.status // \"unknown\")}" 2>/dev/null)
+        if [[ -n "$current_issues" ]]; then
+            if [[ -f "$review_history_file" ]]; then
+                local existing
+                existing=$(< "$review_history_file")
+                printf '%s' "$existing" | jq --argjson new "$current_issues" '. + [$new]' > "$review_history_file"
+            else
+                printf '[%s]' "$current_issues" > "$review_history_file"
+            fi
+        fi
+
+        # Convergence detection: check if >50% of issues are repeats from prior iterations
+        if [[ -f "$review_history_file" ]] && (( loop_iteration > 1 )); then
+            local repeat_ratio repeat_issues
+            repeat_ratio=$(printf '%s' "$review_result" | jq -r --slurpfile history "$review_history_file" '
+                . as $root |
+                ($root.output.issues // []) | length as $current_count |
+                if $current_count == 0 then 0
+                else
+                    [$root.output.issues[] | .description] as $current |
+                    [$history[0][] | .issues[]? | .description] as $prior |
+                    [$current[] | select(. as $c | $prior | any(. == $c))] as $repeats |
+                    ($repeats | length * 100 / $current_count)
+                end
+            ' 2>/dev/null || echo 0)
+            repeat_issues=$(printf '%s' "$review_result" | jq -r --slurpfile history "$review_history_file" '
+                . as $root |
+                ($root.output.issues // []) | length as $current_count |
+                if $current_count == 0 then ""
+                else
+                    [$root.output.issues[] | .description] as $current |
+                    [$history[0][] | .issues[]? | .description] as $prior |
+                    [$current[] | select(. as $c | $prior | any(. == $c))] as $repeats |
+                    ($repeats | join("\n- "))
+                end
+            ' 2>/dev/null || echo '')
+
+            if (( repeat_ratio > 33 )); then
+                log_warn "Quality loop convergence failure: ${repeat_ratio}% of issues are repeats from prior iterations. Exiting loop.${repeat_issues:+ Repeating: ${repeat_issues}}"
+
+                local convergence_body="⚠️ Quality loop convergence failure: ${repeat_ratio}% of issues are repeats from prior iterations. Breaking loop to prevent waste."
+                if [[ -n "$repeat_issues" ]]; then
+                    convergence_body+="
+
+**Repeating Issues:**
+- $repeat_issues"
+                fi
+
+                comment_issue "Quality Loop: Convergence Failure ($stage_prefix)" "$convergence_body" "code-reviewer"
+                DEGRADED_STAGES+=("quality:convergence_failure:$stage_prefix:iter=$loop_iteration")
+                set_final_state "convergence_failure_quality"
+
+                # Persist a merge-block reason so both the orchestrator merge
+                # stage and a standalone process-pr run will refuse to auto-merge
+                # this PR — convergence failure means the reviewer kept flagging
+                # the same likely-real feedback, so a human should look first.
+                local block_reason
+                block_reason="Quality loop convergence failure: ${repeat_ratio}% of issues repeating at $stage_prefix (iter=$loop_iteration)"
+                if [[ -n "$repeat_issues" ]]; then
+                    block_reason+="
+Repeating issues:
+- $repeat_issues"
+                fi
+                if [[ -f "$STATUS_FILE" ]]; then
+                    local degraded_json
+                    degraded_json=$(printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" | jq -R . | jq -s .)
+                    jq --arg reason "$block_reason" \
+                       --argjson stages "$degraded_json" \
+                       '.merge_blocked_reason = $reason | .degraded_stages = $stages | .last_update = (now | todate)' \
+                       "$STATUS_FILE" > "${STATUS_FILE}.tmp" \
+                       && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+                    sync_status_to_log
+                fi
+
+                loop_approved=true
+                break
+            fi
+        fi
+
+        # Oscillation detection: check for A→B→A cycling pattern
+        if [[ -f "$review_history_file" ]] && (( loop_iteration > 2 )); then
+            local oscillation_detected
+            oscillation_detected=$(jq '
+                length as $len |
+                if $len >= 3 then
+                    (.[$len-1] | [.issues[]?.description] | sort) as $current |
+                    (.[$len-3] | [.issues[]?.description] | sort) as $two_ago |
+                    if $current == $two_ago then true else false end
+                else false end
+            ' "$review_history_file" 2>/dev/null || echo false)
+
+            if [[ "$oscillation_detected" == "true" ]]; then
+                log_warn "Quality loop oscillation detected: issues cycling A→B→A. Exiting loop."
+                comment_issue "Quality Loop: Oscillation Detected ($stage_prefix)" "⚠️ Quality loop oscillation detected: fix suggestions are cycling (A→B→A pattern). Breaking loop to prevent waste." "code-reviewer"
+                DEGRADED_STAGES+=("quality:oscillation:$stage_prefix:iter=$loop_iteration")
+                loop_approved=true
+                break
+            fi
+        fi
+
+        # MAJOR-ISSUE OVERRIDE: same logic as PR review (claude-pipeline#25)
+        local major_issue_override=false
+        if [[ "$review_verdict" == "approved" ]]; then
+            local major_issue_count
+            major_issue_count=$(printf '%s' "$review_result" | jq '[.output.issues // [] | .[] | select(.severity == "major")] | length' 2>/dev/null || echo "0")
+            if (( major_issue_count > 0 )); then
+                log_warn "Quality review for $stage_prefix approved but $major_issue_count major issue(s) found — overriding to changes_requested"
+                review_verdict="changes_requested"
+                major_issue_override=true
+            fi
+        fi
+
+        if [[ "$review_verdict" == "approved" ]]; then
+            loop_approved=true
+            log "Quality loop for $stage_prefix approved on iteration $loop_iteration"
+        else
+            local review_comments
+            if $major_issue_override; then
+                # Filter to include only major-severity issues
+                review_comments=$(printf '%s' "$review_result" | jq -r '[.output.issues // [] | .[] | select(.severity == "major") | .description] | join("\n- ")')
+            else
+                review_comments=$(printf '%s' "$review_result" | jq -r '.output.comments // "No comments"')
+            fi
+            printf '%s\n' "$review_comments" >> "$LOG_BASE/context/review-comments.json"
+
+            local cumulative_findings=""
+            if [[ -f "$review_history_file" ]]; then
+                if $major_issue_override; then
+                    # Filter to include only major-severity issues
+                    cumulative_findings=$(jq -r '
+                        [.[-2:] | .[] | .issues[]? | select(.severity == "major") | .description] | unique | join("\n- ")
+                    ' "$review_history_file" 2>/dev/null || printf '')
+                else
+                    cumulative_findings=$(jq -r '
+                        [.[-2:] | .[] | .issues[]? | .description] | unique | join("\n- ")
+                    ' "$review_history_file" 2>/dev/null || printf '')
+                fi
+            fi
+
+            local fix_prompt="${PLATFORM_PATTERNS_PREFIX}Address code review feedback in working directory $loop_dir on branch $loop_branch.
+
+SCOPE: Fix ONLY items under '## Blocking Issues — Fix Before Merge'.
+Do NOT fix or commit anything under
+'## Follow-up Only — Do Not Fix In This PR' — those items are
+intentionally deferred and must not be touched in this PR.
+
+Current iteration findings:
+$review_comments
+
+$(if [[ -n "$cumulative_findings" ]]; then
+    printf 'Cumulative findings across all iterations (ensure ALL are addressed):\n'
+    printf -- '- %s\n' "$cumulative_findings"
+fi)
+
+When committing: run 'git diff --name-only' to list the files
+you changed, then 'git add' only those specific files. Never
+use 'git add -A' or 'git add .' — only stage files the task
+actually modified.
+Fix only the blocking issues and commit. Output a summary of fixes applied."
+
+            verify_on_feature_branch "$loop_branch" || true
+
+            local pre_fix_commits
+            pre_fix_commits=$(git rev-list --count "${BASE_BRANCH}..${loop_branch}" 2>/dev/null || echo "0")
+
+            # Pass loop_complexity so run_stage can route model selection by task
+            # size: S→sonnet, M→sonnet, L→opus (via resolve_model in run_stage).
+            # Pass loop_model_override (arg 7) so an escalated model takes effect
+            # on subsequent iterations after stall detection.
+            local fix_stage_name="fix-review-${stage_prefix}-iter-$loop_iteration"
+            set_stage_started "$fix_stage_name"
+            local fix_result
+            fix_result=$(run_stage "$fix_stage_name" "$fix_prompt" "implement-issue-fix.json" "$loop_agent" "$loop_complexity" "" "${loop_model_override:-}")
+            _halt_if_budget_exceeded
+            local fix_status
+            fix_status=$(printf '%s' "$fix_result" | jq -r '.status // "success"')
+            if [[ "$fix_status" != "error" ]]; then
+                set_stage_completed "$fix_stage_name"
+            fi
+
+            local fix_summary
+            fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
+
+            # Stall detection: if the fix stage did not produce any new commits
+            # and we are at least on iteration 2, escalate via decide-action.sh.
+            local current_fix_model post_fix_commits
+            current_fix_model=$(printf '%s' "$fix_result" | jq -r '.model // "sonnet"')
+            post_fix_commits=$(git rev-list --count "${BASE_BRANCH}..${loop_branch}" 2>/dev/null || echo "0")
+
+            # Guard: verify any new fix-review commit against path allowlist
+            if (( post_fix_commits > pre_fix_commits )); then
+                guard_commit_path_allowlist "$loop_dir" || {
+                    log_error \
+                        "$fix_stage_name: committed paths outside" \
+                        "the code/tests allowlist — aborting quality loop"
+                    break
+                }
+            fi
+
+            if (( post_fix_commits <= pre_fix_commits )) && (( loop_iteration >= 2 )); then
+                log_warn "Quality loop stall detected on iteration $loop_iteration: fix produced no new commits (pre=$pre_fix_commits post=$post_fix_commits)"
+
+                local _stall_history="[]"
+                if [[ -f "$STATUS_FILE" ]]; then
+                    _stall_history=$(jq -c '.escalations // []' "$STATUS_FILE" 2>/dev/null || printf '[]')
+                fi
+
+                local stall_sr
+                stall_sr=$(jq -nc \
+                    --arg model "$current_fix_model" \
+                    '{status:"error", output:null, raw:"", denials:[], model:$model, error_kind:"quality_stall", elapsed_ms:0}')
+
+                local _stall_da_json _stall_action _stall_target_model _stall_reason
+                local exit_code
+                _stall_da_json=$(bash "$SCRIPT_DIR/decide-action.sh" \
+                    "$stall_sr" "$_stall_history" \
+                    2>>"${LOG_BASE:-/tmp}/orchestrator.log")
+                exit_code=$?
+                if ((exit_code != 0)); then
+                    log_warn "stall decide-action.sh exited non-zero ($exit_code) — falling back to retry_same"
+                    _stall_da_json='{"action":"retry_same","reason":"decide-action.sh invocation failed"}'
+                fi
+                _stall_action=$(printf '%s' "$_stall_da_json" | jq -r '.action // "retry_same"')
+                _stall_target_model=$(printf '%s' "$_stall_da_json" | jq -r '.model // empty' 2>/dev/null)
+                _stall_reason=$(printf '%s' "$_stall_da_json" | jq -r '.reason // ""')
+
+                log "Stall decide-action.sh → action=$_stall_action${_stall_target_model:+ model=$_stall_target_model}"
+
+                if [[ "$_stall_action" == "escalate" ]]; then
+                    local _esc_model="${_stall_target_model:-$(effective_fallback "$current_fix_model")}"
+                    loop_model_override="$_esc_model"
+                    record_escalation "fix-review-${stage_prefix}-stall-iter-$loop_iteration" "$current_fix_model" "$_esc_model" "${_stall_reason:-quality_stall}"
+                    log "Quality loop stall: escalating fix model $current_fix_model → $_esc_model for next iteration"
+                elif [[ "$_stall_action" == "bail" ]]; then break
+                fi
+            fi
+
+            # Fix stage introduced new changes — simplify should run next iteration.
+            skip_simplify=false
+        fi
+    done
+
+    return 0
+}
+
+# Determines whether the docs stage should run for a given change scope.
+# Arguments:
+#   $1 - scope: typescript | bash | config | mixed
+# Returns:
+#   0 if docs stage should run (typescript or mixed scope)
+#   1 if docs stage should be skipped (bash or config — no TS files changed)
+should_run_docs_stage() {
+    local scope="$1"
+    case "$scope" in
+        bash|config) return 1 ;;
+        *)            return 0 ;;
+    esac
+}
+
+# Determines whether the deploy_verify stage should run.
+# Gate conditions (both must be true):
+#   (a) DEPLOY_VERIFY_CMD is configured in platform.sh
+#   (b) Issue has env:test/env:nas/env:staging label OR issue body
+#       contains a "## Deploy Verification" section
+# Arguments:
+#   $1 - issue number
+# Returns:
+#   0 if deploy_verify stage should run
+#   1 if it should be skipped
+should_run_deploy_verify() {
+    local issue_number="$1"
+
+    # Fast-path gate: triage-classified fast-path issues are handled by
+    # surgical-fast-path.sh; deploy-verify is a full-pipeline stage and
+    # must be skipped when .route is "fast-path".
+    local route
+    route=$(jq -r '.route // "full"' "$STATUS_FILE" 2>/dev/null || true)
+    if [[ "$route" == "fast-path" ]]; then
+        log "Skipping deploy_verify stage: fast-path route"
+        return 1
+    fi
+
+    # Gate (a): DEPLOY_VERIFY_CMD must be configured
+    if [[ -z "${DEPLOY_VERIFY_CMD:-}" ]]; then
+        return 1
+    fi
+
+    # Gate (b): check labels first, then fall back to issue body
+    local labels
+    case "${TRACKER:-github}" in
+        github)
+            labels=$(gh issue view "$issue_number" \
+                --json labels -q '.labels[].name' 2>/dev/null || true)
+            ;;
+        jira)
+            labels=$(acli jira workitem view "$issue_number" \
+                --fields labels --json 2>/dev/null \
+                | jq -r '.fields.labels[]?' 2>/dev/null || true)
+            ;;
+    esac
+
+    # Check for env:test, env:nas, or env:staging labels
+    if printf '%s\n' "$labels" | grep -qE '^env:(test|nas|staging)$'; then
+        return 0
+    fi
+
+    # Check for ## Deploy Verification section with non-empty
+    # **Verification command:** line; heading alone is not enough.
+    # Use [*] instead of \* — BSD awk on macOS does not honour the
+    # backslash escape for * in ERE the same way gawk does.
+    local issue_body_file="$LOG_BASE/context/issue-body.md"
+    if [[ -f "$issue_body_file" ]]; then
+        local ver_cmd_pat
+        ver_cmd_pat='^[*][*]Verification command:[*][*][[:space:]]*[^[:space:]]'
+        if awk -v pat="$ver_cmd_pat" '
+            /^## Deploy Verification/ { in_section=1; next }
+            in_section && /^## /     { in_section=0 }
+            in_section && $0 ~ pat   { found=1; exit }
+            END                      { exit !found }
+        ' "$issue_body_file"; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+# Poll a health URL until a 2xx response is received or max_retries are exhausted.
+# Returns 0 on success (2xx received, or URL is empty — skip means healthy).
+# Returns 1 when all retries are exhausted without a 2xx.
+#
+# Arguments:
+#   $1 - health URL (empty string = skip poll, return 0 immediately)
+#   $2 - max retries (default: 90)
+#   $3 - poll interval in seconds (default: 10)
+poll_health_url() {
+    local url="$1"
+    local max_retries="${2:-90}"
+    local poll_interval="${3:-10}"
+
+    # Empty URL means no health check configured — treat as healthy
+    if [[ -z "$url" ]]; then
+        return 0
+    fi
+
+    local attempt=0
+    while ((attempt < max_retries)); do
+        ((attempt++))
+        local http_code
+        http_code=$(curl -s -o /dev/null -w '%{http_code}' \
+            --max-time 10 \
+            "$url" 2>/dev/null || printf '%s' "000")
+
+        if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+            log "Health check passed (HTTP $http_code) on attempt $attempt"
+            return 0
+        fi
+
+        if ((attempt % 6 == 0)); then
+            log "Health poll attempt $attempt/$max_retries — HTTP $http_code"
+        fi
+
+        sleep "$poll_interval"
+    done
+
+    return 1
+}
+
+# Selects the deploy command based on the set of changed files in the merged
+# commit.  Three-tier selection (evaluated top-to-bottom):
+#   0. Empty diff (git failed or commit was truly empty) → full DEPLOY_VERIFY_CMD
+#      Fail-safe: never silently downgrade on unknown scope.
+#   1. No apps/backend or packages/ files changed → DEPLOY_VERIFY_CMD --health-only
+#      Frontend-only change: skip rebuild, just poll the health endpoint.
+#   2. Backend changes with migration/schema/env files → DEPLOY_LOCAL_CMD && DEPLOY_VERIFY_CMD
+#      Local build catches app-level failures fast; NAS deploy runs migrations on real DB.
+#   3. Backend logic-only change, DEPLOY_LOCAL_CMD set → DEPLOY_LOCAL_CMD
+#      No migration risk: local Docker build gives same confidence in a fraction
+#      of the time (~5-10 min vs 60-120 min NAS deploy).
+# Arguments:
+#   $1 - newline-separated list of changed files (may be empty)
+# Outputs:
+#   The deploy command string to execute (stdout only)
+# Side-effects:
+#   Writes tier-selection log lines via log() (stderr)
+_select_deploy_cmd() {
+    local changed_files="$1"
+
+    # Tier 0 (fail-safe): empty diff → full deploy
+    if [[ -z "$changed_files" ]]; then
+        log "Scope gate: empty diff HEAD~1..HEAD —" \
+            "defaulting to full deploy"
+        printf '%s\n' "${DEPLOY_VERIFY_CMD}"
+        return 0
+    fi
+
+    # Tier 1: no backend or packages changes → health-only
+    if ! grep -qE '^(apps/backend|packages)/' <<< "$changed_files"; then
+        log "No backend changes detected —" \
+            "downgrading deploy-verify to health-check-only."
+        printf '%s\n' "${DEPLOY_VERIFY_CMD} --health-only"
+        return 0
+    fi
+
+    # Backend changes present.  Check for migration/schema/env files.
+    local has_migration=false
+    if [[ -n "${MIGRATION_PATH_PATTERNS:-}" ]]; then
+        local file
+        local IFS='|'
+        while IFS= read -r file; do
+            local pattern
+            for pattern in $MIGRATION_PATH_PATTERNS; do
+                # shellcheck disable=SC2254
+                case "$file" in
+                    $pattern) has_migration=true; break 2 ;;
+                esac
+            done
+        done <<< "$changed_files"
+    fi
+
+    # Tier 2: migration detected → local first, then full NAS deploy
+    if $has_migration; then
+        if [[ -n "${DEPLOY_LOCAL_CMD:-}" ]]; then
+            log "Migration files detected —" \
+                "running local deploy first, then full NAS deploy."
+            printf '%s\n' "${DEPLOY_LOCAL_CMD} && ${DEPLOY_VERIFY_CMD}"
+        else
+            log "Migration files detected, DEPLOY_LOCAL_CMD not set —" \
+                "using full NAS deploy."
+            printf '%s\n' "${DEPLOY_VERIFY_CMD}"
+        fi
+        return 0
+    fi
+
+    # Tier 3: backend logic-only, DEPLOY_LOCAL_CMD set → local deploy
+    if [[ -n "${DEPLOY_LOCAL_CMD:-}" ]]; then
+        log "Backend logic-only change —" \
+            "using local deploy: $DEPLOY_LOCAL_CMD"
+        printf '%s\n' "${DEPLOY_LOCAL_CMD}"
+        return 0
+    fi
+
+    # DEPLOY_LOCAL_CMD not configured → fall through to full NAS deploy
+    log "DEPLOY_LOCAL_CMD not set —" \
+        "falling back to full NAS deploy."
+    printf '%s\n' "${DEPLOY_VERIFY_CMD}"
+    return 0
+}
+
+# Check if all tasks in status.json are S-complexity.
+# Returns:
+#   0 if all tasks are S-complexity (docs can be skipped)
+#   1 if any task is M, L, or unknown complexity
+all_tasks_s_complexity() {
+    local tasks_json
+    tasks_json=$(jq -r '.tasks[]?.description // empty' "$STATUS_FILE" 2>/dev/null)
+    [[ -z "$tasks_json" ]] && return 1
+    while IFS= read -r desc; do
+        local size
+        size=$(extract_task_size "$desc")
+        [[ "$size" != "S" ]] && return 1
+    done <<< "$tasks_json"
+    return 0
+}
+
+# Get PR review configuration based on diff size.
+# Returns JSON: { "model": "...", "timeout": N, "max_iterations": N }
+#
+# All tiers use sonnet. Haiku was tried for tiny/small diffs but in practice
+# it burns through max turns exploring the codebase (4.7M tokens for an
+# 11-line diff) then escalates to sonnet anyway — wasting ~$0.85 and ~5 min.
+# Sonnet with the diff included in the prompt finishes in 2-3 turns.
+#
+# Three tiers by diff line count:
+#   <50  lines  → sonnet, 180s timeout, 1 iteration  (small)
+#   <200 lines  → sonnet, 600s timeout, MAX_PR_REVIEW_ITERATIONS (medium)
+#   200+ lines  → sonnet, 1200s timeout, MAX_PR_REVIEW_ITERATIONS (large)
+get_pr_review_config() {
+    local diff_lines
+    diff_lines=$(get_diff_line_count "$BASE_BRANCH")
+
+    if (( diff_lines < 50 )); then
+        printf '{"model":"sonnet","timeout":360,"max_iterations":1}'
+    elif (( diff_lines < 200 )); then
+        printf '{"model":"sonnet","timeout":600,"max_iterations":%d}' "$MAX_PR_REVIEW_ITERATIONS"
+    else
+        printf '{"model":"sonnet","timeout":1200,"max_iterations":%d}' "$MAX_PR_REVIEW_ITERATIONS"
+    fi
+}
+
+# Apply pipeline profile to PR review max iterations.
+# For minimal profile, caps max_iter at 1 regardless of get_pr_review_config() output.
+# For standard and full profiles, keeps the dynamic value unchanged.
+#
+# Arguments:
+#   $1 - pipeline_profile: minimal | standard | full
+#   $2 - config_max_iter: the max_iterations value from get_pr_review_config()
+# Outputs:
+#   The effective max_iterations value (integer)
+apply_profile_to_pr_review_max_iter() {
+	local profile="$1"
+	local config_max_iter="$2"
+	if [[ "$profile" == "minimal" ]]; then
+		printf '%s' "1"
+	else
+		printf '%s' "$config_max_iter"
+	fi
+}
+
+# Applies pipeline profile to the test loop max-iterations cap.
+# For minimal profile, caps max_iter at 2 (fast feedback, avoid wasted cycles).
+# For standard and full profiles, passes the config value through unchanged.
+#
+# Arguments:
+#   $1 - pipeline_profile: minimal | standard | full
+#   $2 - config_max_iter: the base MAX_TEST_ITERATIONS value
+# Outputs:
+#   The effective max_iterations value (integer)
+apply_profile_to_test_max_iter() {
+	local profile="$1"
+	local config_max_iter="$2"
+	if [[ "$profile" == "minimal" ]]; then
+		printf '%s' "2"
+	else
+		printf '%s' "$config_max_iter"
+	fi
+}
+
+# Determines whether the quality loop should run for a given task size.
+# Arguments:
+#   $1 - task_size: S | M | L (or other/empty)
+# Returns:
+#   0 if quality loop should run (M, L, or unknown size — safe default)
+#   1 if quality loop should be skipped (S-size tasks only)
+should_run_quality_loop() {
+    local task_size="$1"
+    # Derive from get_max_review_attempts so S/M/L policy lives in one place.
+    # Skip the quality loop only when max_attempts == 1 (S-size tasks).
+    local max
+    max=$(get_max_review_attempts "$task_size")
+    if [[ "$max" -eq 1 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# Returns the maximum number of review-and-fix attempts for a given task size.
+# Arguments:
+#   $1 - task_size: S | M | L (or other/empty)
+# Outputs:
+#   1 for S-size tasks (simple — one shot)
+#   2 for M-size tasks
+#   3 for L-size tasks and unknown/empty (safe default matches legacy behaviour)
+get_max_review_attempts() {
+    local task_size="$1"
+    case "$task_size" in
+        S) echo 1 ;;
+        M) echo 2 ;;
+        L) echo 3 ;;
+        *)
+            log_warn "get_max_review_attempts: unexpected task_size '${task_size}'; defaulting to 3"
+            echo 3
+            ;;
+    esac
+}
+
+# Extract size marker (S/M/L) from a task description string.
+# Looks for the pattern **(S)**, **(M)**, or **(L)** in the description.
+# Arguments:
+#   $1 - task description string
+# Outputs:
+#   S, M, or L if found; empty string otherwise
+extract_task_size() {
+    local desc="${1:-}"
+    if [[ "$desc" =~ \*\*\(([SML])\)\*\* ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+    fi
+}
+
+# Count lines changed (added + deleted) on the current branch vs a base branch.
+# Uses three-dot diff for merge-base semantics (only branch changes, not base changes).
+# Arguments:
+#   $1 - base branch (default: main)
+# Outputs:
+#   Total number of lines changed (insertions + deletions)
+get_diff_line_count() {
+	local base_branch="${1:-main}"
+	local lines
+	lines=$(git diff --stat "${base_branch}...HEAD" 2>/dev/null \
+		| tail -1 \
+		| grep -oE '[0-9]+ insertion|[0-9]+ deletion' \
+		| grep -oE '[0-9]+' \
+		| paste -sd+ - \
+		| bc 2>/dev/null || printf '0')
+	printf '%s' "${lines:-0}"
+}
+
+# Scale quality loop iterations by diff size.
+# Tiny diffs need fewer review passes regardless of task size label.
+# Arguments:
+#   $1 - number of lines changed
+# Outputs:
+#   Max iterations (1-5) based on diff size
+get_diff_based_max_iterations() {
+	local diff_lines="${1:-0}"
+	if ((diff_lines < 20)); then
+		echo 1
+	elif ((diff_lines < 100)); then
+		echo 2
+	elif ((diff_lines < 300)); then
+		echo 3
+	else
+		echo 5
+	fi
+}
+
+# Get max quality loop iterations based on task size AND diff size.
+# Combines two signals: the task size label (S/M/L) and the actual diff
+# line count, taking the MINIMUM of both caps. This prevents unnecessary
+# review passes when a large task produces a small diff, or when a small
+# task label was applied to a large change.
+# S-size tasks skip quality loop entirely (handled by should_run_quality_loop).
+# Arguments:
+#   $1 - task description (size extracted via extract_task_size)
+#   $2 - base branch for diff comparison (default: main)
+# Outputs:
+#   Number of max iterations (1-5)
+get_max_quality_iterations() {
+	local task_desc="${1:-}"
+	local base_branch="${2:-main}"
+	local task_size
+	task_size=$(extract_task_size "$task_desc")
+
+	local size_based
+	case "$task_size" in
+		S) size_based=1 ;;
+		M) size_based=2 ;;
+		L) size_based=3 ;;
+		*) size_based=3 ;;
+	esac
+
+	local diff_lines
+	diff_lines=$(get_diff_line_count "$base_branch")
+	local diff_based
+	diff_based=$(get_diff_based_max_iterations "$diff_lines")
+
+	# Take the minimum — small diffs don't need many passes even for L tasks
+	if ((diff_based < size_based)); then
+		echo "$diff_based"
+	else
+		echo "$size_based"
+	fi
+}
+
+# =============================================================================
+# PIPELINE PROFILE CLASSIFIER
+# =============================================================================
+#
+# Classifies the pipeline complexity profile based on task sizes and diff size.
+# Called immediately after parse_issue completes so that task count and sizes
+# are known.
+#
+# Profile rules (in priority order):
+#   full     — any M or L task present
+#   minimal  — single S-task, OR current diff < 20 lines
+#   standard — all S-tasks with multiple tasks (and diff >= 20 lines)
+#
+# Arguments:
+#   $1 - tasks_json: JSON array of task objects with .description fields
+# Outputs:
+#   One of: minimal | standard | full
+#
+compute_pipeline_profile() {
+	local tasks_json="${1:-[]}"
+
+	local task_count
+	task_count=$(printf '%s' "$tasks_json" | jq 'length')
+
+	# full: any M or L task present
+	local ml_count
+	ml_count=$(printf '%s' "$tasks_json" \
+		| jq '[.[] | select(.description | test("\\*\\*\\([ML]\\)\\*\\*"))] | length')
+	if ((ml_count > 0)); then
+		printf '%s' "full"
+		return
+	fi
+
+	# minimal: single task (M/L already caught by ml_count guard above)
+	if ((task_count == 1)); then
+		printf '%s' "minimal"
+		return
+	fi
+
+	# minimal: diff < 20 lines (catches trivial resume/config-tweak scenarios)
+	local diff_lines
+	diff_lines=$(get_diff_line_count "${BASE_BRANCH:-main}")
+	if ((diff_lines < 20)); then
+		printf '%s' "minimal"
+		return
+	fi
+
+	# standard: all S-tasks, multiple tasks, diff >= 20 lines
+	printf '%s' "standard"
+}
+
+# =============================================================================
+# TASK DEPENDENCY DETECTION
+# =============================================================================
+
+#
+# Returns the canonical agent name, applying legacy→current mappings.
+# Falls back to "default" for names that have no local .md definition.
+#
+# Arguments:
+#   $1 - raw agent name extracted from a task line
+# Outputs:
+#   Normalized agent name on stdout
+#
+_normalize_agent_name() {
+	local name="$1"
+	local agents_dir="${SCRIPT_DIR}/../agents"
+
+	# Allowlist of legacy→current agent-name mappings.
+	# Add future renames here; never delete old entries so that
+	# historical issue bodies continue to parse cleanly.
+	case "$name" in
+		test-engineer) name="playwright-test-developer" ;;
+	esac
+
+	# If the (possibly remapped) name has a local definition, accept it.
+	if [[ -f "${agents_dir}/${name}.md" ]]; then
+		printf '%s' "$name"
+		return
+	fi
+
+	# Unknown name with no local definition — fall back to generic agent.
+	# Degrade to the literal "default" when _AGENT_SENTINEL_DEFAULT is not in
+	# scope (e.g. when this function is sourced in isolation by a test harness
+	# that strips module-level `readonly` declarations) so the documented
+	# fall-back contract holds in every sourcing context.
+	local fallback="${_AGENT_SENTINEL_DEFAULT:-default}"
+	log_warn "_normalize_agent_name: unknown agent '${name}' — falling back to '$fallback'"
+	printf '%s' "$fallback"
+}
+
+#
+# Infers an agent name from a file extension or path.
+# Maps common extensions to specialist agents, disambiguating JS/TS
+# frontend vs backend via FRONTEND_PATH_PATTERNS (pipe-separated globs
+# from config/platform.sh, used by _matches_frontend_pattern()).
+#
+# All candidates are validated through _normalize_agent_name(), which
+# falls back to "default" when the inferred agent has no local .md
+# definition — guaranteeing graceful degradation on any consumer project.
+#
+# Arguments:
+#   $1 - file path (empty string → returns "default")
+# Outputs:
+#   Validated agent name on stdout (always a defined agent or "default")
+#
+_infer_agent_from_path() {
+	local file_path="${1:-}"
+	local candidate
+
+	if [[ -z "$file_path" ]]; then
+		printf '%s' "default"
+		return
+	fi
+
+	# Strip the longest prefix up to the last dot to get the extension.
+	local ext="${file_path##*.}"
+
+	case "$ext" in
+		sh|bats|bash)
+			candidate="bash-script-craftsman"
+			;;
+		ts|tsx|js|jsx|mjs|cjs)
+			# Disambiguate frontend vs backend via FRONTEND_PATH_PATTERNS.
+			#   Patterns set + path matches  → frontend specialist
+			#   Patterns set + no match      → backend specialist
+			#   Patterns unset               → ambiguous → default
+			if _matches_frontend_pattern "$file_path"; then
+				candidate="react-frontend-developer"
+			elif [[ -n "${FRONTEND_PATH_PATTERNS:-}" ]]; then
+				candidate="fastify-backend-developer"
+			else
+				candidate="default"
+			fi
+			;;
+		*)
+			candidate="default"
+			;;
+	esac
+
+	# "default" is the terminal fallback — no .md definition exists for it
+	# and passing it through _normalize_agent_name() would emit a spurious
+	# log_warn.  Specialist candidates are validated so they degrade cleanly
+	# on consumer projects that lack a particular agent definition.
+	if [[ "$candidate" == "default" ]]; then
+		printf '%s' "default"
+	else
+		_normalize_agent_name "$candidate"
+	fi
+}
+
+#
+# Parses task lines from a tasks section string into a JSON array.
+#
+# Handles the canonical format plus common malformations:
+#   Canonical:  - [ ] `[agent]` description
+#   Fallback 1: - [ ] [agent] description      (missing backticks)
+#   Fallback 2: * [ ] `[agent]` description     (asterisk bullet)
+#   Fallback 3:   - [ ] `[agent]` description   (leading whitespace)
+#   Fallback 4: - [ ] `agent` description        (missing square brackets)
+#
+# Fuzzy matches emit a warning on stderr so operators know the issue body
+# formatting is non-standard.  Fallback 4 (bracket-less backtick selectors)
+# is accepted silently — it is a common shorthand that requires no repair.
+#
+# Checked boxes [x] are considered already complete and skipped.
+#
+# Arguments:
+#   $1 - raw text of the tasks section (newline-separated lines)
+# Outputs:
+#   JSON array of task objects on stdout
+#   Warnings for fuzzy matches on stderr
+#
+#
+# Slice the "## Implementation Tasks" section out of an issue body — the
+# orchestrator's mirror of _issue_body_tasks_section() in issue-body-lib.sh,
+# and the SINGLE definition the PARSE ISSUE stage, the tests, and the parity
+# guard all share (no hand-copied awk literal anywhere else).
+#
+# Behaviour (kept identical to the library — see ISSUE_TASKS_HEADING_ERE):
+#   * CRLF-tolerant — strips a trailing CR before matching.
+#   * Case-insensitive heading — folds the line with tolower($0).
+#   * UNANCHORED heading — annotated headings ("## Implementation Tasks
+#     (draft)") are recognised so the per-line lint report fires (issue #584).
+#   * Section spans from the heading (any depth: ##, ###, …) to the next ## or
+#     deeper heading (or end of body).
+#
+# Arguments:
+#   $1 - issue body text
+# Outputs:
+#   Section text on stdout (empty when the heading is absent or has no lines)
+#
+_extract_tasks_section() {
+	printf '%s' "$1" | awk -v h="$ISSUE_TASKS_HEADING_ERE" '
+		{ sub(/\r$/, "") }
+		tolower($0) ~ h { found = 1; next }
+		found && /^##+[[:space:]]/ { exit }
+		found { print }
+	'
+}
+
+_parse_task_lines() {
+	local tasks_section="$1"
+
+	# Strip carriage returns so a CRLF issue body parses identically to an LF
+	# one — otherwise "\r" leaks into descriptions and defeats the $-anchored
+	# task regexes (mirrors _issue_body_tasks_section in issue-body-lib.sh).
+	tasks_section="${tasks_section//$'\r'/}"
+
+	# Strip backslash-escaped backticks (gh API returns \` instead of `)
+	tasks_section="${tasks_section//\\\`/\`}"
+
+	local task_id=0
+	local tasks_json="[]"
+
+	# Backtick-containing regex must use a variable (bash cannot escape
+	# backticks inside [[ =~ ]] inline patterns reliably).
+	local bt='`'
+	local _re_bare_agent="^- (\[ \] )?${bt}([^${bt}]+)${bt} (.+)\$"
+
+	while IFS= read -r line; do
+		# Skip empty lines
+		[[ -z "$line" ]] && continue
+
+		# Skip checked boxes [x] — already complete
+		if [[ "$line" =~ \[x\] ]]; then
+			continue
+		fi
+
+		local agent="" desc="" fuzzy=""
+
+		# Canonical: - [ ] `[agent]` description  OR  - `[agent]` description
+		if [[ "$line" =~ ^-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+
+		# Fallback 1: missing backticks — - [ ] [agent] description
+		# Agent char class excludes spaces to avoid matching the [ ] checkbox.
+		elif [[ "$line" =~ ^-\ (\[\ \]\ )?\[([^\]\ ]+)\]\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+			fuzzy="missing backticks around agent name"
+
+		# Fallback 2: asterisk bullet — * [ ] `[agent]` description
+		elif [[ "$line" =~ ^\*\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+			fuzzy="asterisk bullet instead of dash"
+
+		# Fallback 3: leading whitespace — <spaces>- [ ] `[agent]` description
+		elif [[ "$line" =~ ^[[:space:]]+-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+			fuzzy="extra leading whitespace"
+
+		# Fallback 4: missing square brackets — - [ ] `agent` description
+		# Accepted silently: bracket-less backtick selectors are common
+		# shorthand and do not indicate a formatting problem.
+		elif [[ "$line" =~ $_re_bare_agent ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+
+		else
+			# Not a task line — skip silently
+			continue
+		fi
+
+		if [[ -n "$fuzzy" ]]; then
+			log_warn "Fuzzy task parse (${fuzzy}): $line"
+		fi
+
+		# Normalize legacy agent names and fall back to "default" for
+		# names that have no local .md definition.
+		agent=$(_normalize_agent_name "$agent")
+
+		# AC2: default complexity to M when no hint present
+		if [[ ! "$desc" =~ \*\*\([SML]\)\*\* ]]; then
+			log_warn "No complexity hint in task (defaulting to M): $line"
+			desc="**(M)** $desc"
+		fi
+
+		# Warn-only mirror of assert_issue_valid criterion 7 (issue #582):
+		# a task with no recognisable file path forces the specialist to scan
+		# the codebase blind — the #1 explore-stage token sink.  This is a
+		# run-time nudge only; the hard gate lives in assert_issue_valid, so
+		# issues that bypass validation still surface the warning here.
+		if [[ -z "$(_extract_task_files_from_desc "$desc")" ]]; then
+			log_warn "No file path in task (scans codebase blind): $line"
+		fi
+
+		task_id=$((task_id + 1))
+		# Store task for now; affected_files will be attached in the second pass.
+		tasks_json=$(printf '%s' "$tasks_json" | jq \
+			--argjson id "$task_id" \
+			--arg desc "$desc" \
+			--arg agent "$agent" \
+			'. + [{id: $id, description: $desc, agent: $agent, status: "pending", review_attempts: 0, affected_files: []}]')
+
+	done <<< "$tasks_section"
+
+	# Second pass: extract "Affected files:" lines and attach to preceding task.
+	local current_task_idx=-1
+	while IFS= read -r line; do
+		# Detect task lines (same patterns as above) to track which task we're under.
+		if [[ "$line" =~ ^[-\*][[:space:]]+(\[.?\][[:space:]]*)?\`?\[? ]]; then
+			current_task_idx=$((current_task_idx + 1))
+		fi
+		# Match "Affected files:" line (case-insensitive, optional leading whitespace).
+		if [[ "$line" =~ ^[[:space:]]*[Aa]ffected[[:space:]][Ff]iles:[[:space:]]*(.+)$ ]] && (( current_task_idx >= 0 )); then
+			local files_str="${BASH_REMATCH[1]}"
+			# Split comma-separated file paths, trim whitespace, remove "(new)" annotations.
+			local files_arr
+			files_arr=$(printf '%s' "$files_str" \
+				| tr ',' '\n' \
+				| sed 's/(new)//g; s/^[[:space:]]*//; s/[[:space:]]*$//' \
+				| grep -v '^$' \
+				| jq -R '.' | jq -s '.')
+			tasks_json=$(printf '%s' "$tasks_json" | jq \
+				--argjson idx "$current_task_idx" \
+				--argjson files "$files_arr" \
+				'.[$idx].affected_files = $files')
+		fi
+	done <<< "$tasks_section"
+
+	printf '%s\n' "$tasks_json"
+}
+
+# Builds a well-formed issue body for an adjacent follow-up issue.
+# If the raw body already contains a valid ## Implementation Tasks section
+# with at least one canonical task line, it is returned unchanged.
+# Otherwise a canonical task line is appended in a new ## Implementation Tasks section.
+#
+# Arguments:
+#   $1 - raw body text from the adjacent_issue JSON
+#   $2 - issue title (used to synthesise the task description when body lacks one)
+# Outputs:
+#   validated body on stdout
+_build_adj_body() {
+	local raw_body="$1"
+	local adj_title="$2"
+
+	# Extract any existing Implementation Tasks section
+	local tasks_section
+	tasks_section=$(printf '%s' "$raw_body" \
+		| awk '/^## Implementation Tasks/{found=1; next} found && /^## /{exit} found{print}')
+
+	# Check for at least one canonical task line: - [ ] `[agent]` **(S|M|L)** description
+	local has_valid_task=false
+	if [[ -n "$tasks_section" ]]; then
+		while IFS= read -r line; do
+			[[ -z "$line" ]] && continue
+			if [[ "$line" =~ ^-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ \*\*\([SML]\)\*\*\ .+$ ]]; then
+				has_valid_task=true
+				break
+			fi
+		done <<< "$tasks_section"
+	fi
+
+	if [[ "$has_valid_task" == true ]]; then
+		printf '%s' "$raw_body"
+		return
+	fi
+
+	# Body lacks a valid Implementation Tasks section — synthesise one.
+	# Strip any existing (malformed) Implementation Tasks section, then append a canonical one.
+	local body_prefix
+	body_prefix=$(printf '%s' "$raw_body" \
+		| awk '/^## Implementation Tasks/{exit} {print}' \
+		| sed 's/[[:space:]]*$//')
+
+	# Extract file paths from title + body; take the first hit as the
+	# primary path for the task suffix and ACs.  Never fabricate a path —
+	# if nothing is recoverable, emit no suffix.
+	local primary_file=""
+	local file_candidates
+	file_candidates=$(_extract_task_files_from_desc "${adj_title} ${body_prefix}")
+	if [[ -n "$file_candidates" ]]; then
+		primary_file=$(printf '%s' "$file_candidates" | head -1)
+	fi
+
+	# Infer specialist agent from the primary file path; degrade to
+	# "default" when no path is recoverable or the inferred agent has no
+	# local .md definition.
+	local inferred_agent
+	inferred_agent=$(_infer_agent_from_path "$primary_file")
+
+	# Build the task description, appending a path suffix when a file is
+	# recoverable (never fabricate one when nothing is found).
+	local task_desc="**(M)** ${adj_title}"
+	if [[ -n "$primary_file" ]]; then
+		task_desc="${task_desc} — \`${primary_file}\`"
+	fi
+
+	printf '%s\n\n## Implementation Tasks\n\n- [ ] `[%s]` %s\n' \
+		"$body_prefix" "$inferred_agent" "$task_desc"
+
+	# Append measurable Acceptance Criteria — only when the body does not
+	# already provide an AC section.  Criteria reference the concrete
+	# path/change rather than generic boilerplate.
+	if [[ "$body_prefix" != *'## Acceptance Criteria'* ]]; then
+		if [[ -n "$primary_file" ]]; then
+			printf '\n## Acceptance Criteria\n\n- [ ] %s is implemented in `%s`\n- [ ] `%s` has test coverage verifying the change\n' \
+				"$adj_title" "$primary_file" "$primary_file"
+		else
+			printf '\n## Acceptance Criteria\n\n- [ ] %s is implemented as described\n- [ ] Implementation is covered by tests\n' \
+				"$adj_title"
+		fi
+	fi
+}
+
+
+# Known file extensions to avoid false positives when extracting bare filenames
+# (version strings v1.0, domains, etc. are excluded)
+readonly KNOWN_FILE_EXTENSIONS='sh|bats|bash|ts|tsx|js|jsx|mjs|cjs|py|go|rb|rs|java|kt|swift|json|yaml|yml|toml|sql|md|css|html|tf'
+
+#
+# Extracts candidate file paths from a task description string.
+# Matches three token shapes:
+#   1. Backtick-quoted paths:   `src/foo/bar.ts`
+#   2. Slash-separated tokens:  src/components/button
+#   3. Extension-bearing names: handler.sh, index.ts
+#
+# Arguments:
+#   $1 - task description string
+# Outputs:
+#   Newline-separated, sorted-unique file paths (empty if none found)
+#
+_extract_task_files_from_desc() {
+	local desc="$1"
+	local grep_pat
+	# Backtick tokens: only qualify when they contain '/' (path-like)
+	# or end in a known file extension — bare words are excluded.
+	grep_pat='`[a-zA-Z0-9_.-]*/[a-zA-Z0-9_./-]+`'
+	grep_pat+='|`[a-zA-Z0-9_.-]+\.'"($KNOWN_FILE_EXTENSIONS)"'`'
+	# Bare slash-separated tokens (no backticks required)
+	grep_pat+='|[a-zA-Z0-9_.-]+/[a-zA-Z0-9_./-]+'
+	# Bare extension-bearing names (no backticks required)
+	grep_pat+="|[a-zA-Z0-9_-]+\\.($KNOWN_FILE_EXTENSIONS)"
+	printf '%s' "$desc" \
+		| grep -oE "$grep_pat" \
+		| sed 's/`//g' \
+		| sort -u
+}
+
+# Groups tasks into parallelizable batches by detecting file-level conflicts.
+#
+# Tasks whose file sets do not overlap are placed in the same batch and can
+# run concurrently.  Tasks that share one or more files are placed in
+# sequential batches.
+#
+# Algorithm: greedy earliest-batch assignment (tasks processed in issue order).
+# Each task is tested against existing batches from batch 1 upward and placed
+# in the first batch that has no file conflict.
+#
+# File sets are derived from:
+#   1. Path-like tokens extracted from the task description (primary)
+#   2. Files already changed on the branch (git diff vs BASE_BRANCH) that
+#      share a path component with description-extracted tokens (secondary)
+#
+# Tasks with empty file sets (no recognisable paths in their description) are
+# always placed in batch 1 alongside other tasks — no conflict is assumed when
+# file sets cannot be determined.
+#
+# Arguments:
+#   $1 - tasks JSON array (elements must have .id and .description)
+#   $2 - base branch name (for git diff; defaults to "main")
+# Outputs:
+#   Updated tasks JSON array with a .batch integer field on each element
+#   (1-indexed; tasks sharing the same batch number can run in parallel)
+#
+compute_task_batches() {
+	local tasks_json="${1:-[]}"
+	local base_branch="${2:-main}"
+
+	local task_count
+	task_count=$(printf '%s' "$tasks_json" | jq 'length')
+
+	# Trivial cases: 0 or 1 tasks — everything is batch 1
+	if ((task_count <= 1)); then
+		printf '%s' "$tasks_json" | jq 'map(. + {batch: 1})'
+		return
+	fi
+
+	# Collect files already changed on the branch (empty on a fresh branch)
+	local -a diff_files=()
+	local diff_out
+	if diff_out=$(git diff --name-only "$base_branch" 2>/dev/null) \
+		&& [[ -n "$diff_out" ]]; then
+		while IFS= read -r f; do
+			[[ -n "$f" ]] && diff_files+=("$f")
+		done <<< "$diff_out"
+	fi
+
+	# Build file sets for each task (parallel arrays, 0-based index)
+	local -a task_files
+	local i
+	for ((i = 0; i < task_count; i++)); do
+		local desc
+		desc=$(printf '%s' "$tasks_json" | jq -r ".[$i].description")
+
+		# Primary: use explicit affected_files from task JSON if available
+		local af_json
+		af_json=$(printf '%s' "$tasks_json" | jq -r ".[$i].affected_files // [] | .[]" 2>/dev/null)
+
+		local desc_files
+		if [[ -n "$af_json" ]]; then
+			desc_files="$af_json"
+		else
+			# Fallback: extract path-like tokens from the task description
+			desc_files=$(_extract_task_files_from_desc "$desc")
+		fi
+
+		# Secondary: add diff files that share a path component with any
+		# desc_files token (augments detection when the branch already has commits)
+		local aug_files=""
+		if [[ -n "$desc_files" && ${#diff_files[@]} -gt 0 ]]; then
+			local dfile
+			for dfile in "${diff_files[@]}"; do
+				local dbase="${dfile##*/}"
+				local df
+				while IFS= read -r df; do
+					[[ -z "$df" ]] && continue
+					local dfbase="${df##*/}"
+					if [[ "$dfile" == *"$df"* \
+						|| ( -n "$dfbase" && "$dbase" == "$dfbase" ) ]]; then
+						aug_files+="${dfile}"$'\n'
+						break
+					fi
+				done <<< "$desc_files"
+			done
+		fi
+
+		# Combine and deduplicate both sources
+		local combined
+		combined=$(printf '%s\n%s' "$desc_files" "$aug_files" \
+			| sort -u | grep -v '^[[:space:]]*$')
+		task_files[$i]="$combined"
+		if [[ -n "$combined" ]]; then
+			log "  Task $((i+1)) files: $(echo "$combined" | tr '\n' ', ')"
+		else
+			log "  Task $((i+1)) files: (none detected)"
+		fi
+	done
+
+	# Greedy batch assignment
+	# batch_used_files[b] = newline-separated files claimed by batch b (0-based)
+	local -a batch_used_files
+	local -a task_batch_idx
+	for ((i = 0; i < task_count; i++)); do
+		local my_files="${task_files[$i]:-}"
+		local b=0
+		local placed=0
+		while [[ $placed -eq 0 && $b -lt 1000 ]]; do
+			local conflict=0
+			# Only check overlap when both this task and the batch have
+			# non-empty file sets; unknown sets never trigger a conflict
+			if [[ -n "$my_files" && -n "${batch_used_files[$b]:-}" ]]; then
+				local f
+				while IFS= read -r f; do
+					[[ -z "$f" ]] && continue
+					if printf '%s\n' "${batch_used_files[$b]}" \
+						| grep -qxF -- "$f"; then
+						conflict=1
+						break
+					fi
+				done <<< "$my_files"
+			fi
+
+			if [[ $conflict -eq 0 ]]; then
+				task_batch_idx[$i]=$b
+				if [[ -n "$my_files" ]]; then
+					batch_used_files[$b]+=$'\n'"$my_files"
+				fi
+				placed=1
+			else
+				((b++))
+			fi
+		done
+		# Safety fallback: loop ceiling hit without placement (defensive only;
+		# an empty batch always has no conflict so this path is unreachable in
+		# normal operation).  Assign to the current batch as a last resort.
+		if [[ $placed -eq 0 ]]; then
+			log_error "Task $i: batch-assignment loop limit exceeded;" \
+				"assigning to batch $((b + 1)) as fallback"
+			task_batch_idx[$i]=$b
+		fi
+	done
+
+	# Inject 1-based batch numbers back into tasks_json (single jq pass)
+	local batch_updates=""
+	for ((i = 0; i < task_count; i++)); do
+		local batch_num=$(( task_batch_idx[i] + 1 ))
+		batch_updates+=" | .[$i].batch = $batch_num"
+	done
+
+	printf '%s' "$tasks_json" | jq ".$batch_updates"
+}
+
+# =============================================================================
+# WORKTREE-BASED PARALLEL TASK EXECUTION
+# =============================================================================
+
+# Create a git worktree for a single task.
+#
+# Clean up stale worktree branches from previous failed runs.
+#
+# Prunes broken worktree refs and deletes any wt-i*
+# branches that no longer have active worktrees.
+#
+# Arguments:
+#   (none)
+#
+cleanup_stale_worktrees() {
+	# Prune broken worktree references
+	git worktree prune 2>&1 | while IFS= read -r line; do
+		log "worktree prune: $line"
+	done
+
+	# Collect active worktree branches
+	local -a active_wt_branches=()
+	local wt_line
+	while IFS= read -r wt_line; do
+		# git worktree list output: /path  commitsha [branchname]
+		local branch
+		branch=$(printf '%s' "$wt_line" \
+			| sed -n 's/.*\[\(.*\)\]/\1/p')
+		if [[ -n "$branch" ]]; then
+			active_wt_branches+=("$branch")
+		fi
+	done < <(git worktree list 2>/dev/null)
+
+	# Delete wt-i* branches without active worktrees
+	local branch_name
+	while IFS= read -r branch_name; do
+		[[ -z "$branch_name" ]] && continue
+		local is_active=false
+		local ab
+		for ab in "${active_wt_branches[@]+"${active_wt_branches[@]}"}"; do
+			if [[ "$ab" == "$branch_name" ]]; then
+				is_active=true
+				break
+			fi
+		done
+		if [[ "$is_active" == "false" ]]; then
+			log "Cleaning stale branch: $branch_name"
+			git branch -D "$branch_name" 2>&1 \
+				| while IFS= read -r line; do
+					log "  $line"
+				done
+		fi
+	done < <(git branch --list 'wt-i*' \
+		--format='%(refname:short)' 2>/dev/null)
+}
+
+# Arguments:
+#   $1 - worktree base directory
+#   $2 - feature branch name (source commit)
+#   $3 - task ID
+#   $4 - issue number
+# Outputs:
+#   Worktree path on stdout
+#
+create_task_worktree() {
+	local wt_base="$1"
+	local feature_branch="$2"
+	local task_id="$3"
+	local issue_num="$4"
+
+	local wt_branch="wt-i${issue_num}-t${task_id}"
+	local wt_path="${wt_base}/task-${task_id}"
+
+	mkdir -p "$wt_base"
+
+	# Idempotent branch creation: if the branch exists but
+	# has no active worktree, delete it first (stale from a
+	# prior failed run). If it has an active worktree, that
+	# indicates a parallel conflict — fail loudly.
+	if git show-ref --verify --quiet \
+		"refs/heads/$wt_branch" 2>/dev/null; then
+		local existing_wt
+		existing_wt=$(git worktree list --porcelain \
+			2>/dev/null \
+			| awk -v b="refs/heads/$wt_branch" \
+				'/^worktree /{wt=$2} /^branch /{if($2==b) print wt}')
+		if [[ -n "$existing_wt" ]] \
+			&& [[ -d "$existing_wt" ]]; then
+			log_error "Branch $wt_branch has an" \
+				"active worktree at $existing_wt" \
+				"— cannot overwrite"
+			return 1
+		fi
+		log "Removing stale branch $wt_branch" \
+			"from prior run"
+		git branch -D "$wt_branch" 2>&1 \
+			| while IFS= read -r line; do
+				log "  $line"
+			done
+	fi
+
+	# Create branch from feature branch HEAD
+	local git_err
+	if ! git_err=$(git branch "$wt_branch" \
+		"$feature_branch" 2>&1); then
+		log_error \
+			"Failed to create branch $wt_branch:" \
+			"$git_err"
+		return 1
+	fi
+
+	# Create the worktree
+	if ! git_err=$(git worktree add "$wt_path" \
+		"$wt_branch" 2>&1); then
+		log_error \
+			"Failed to create worktree at" \
+			"$wt_path: $git_err"
+		git branch -D "$wt_branch" >/dev/null 2>&1
+		return 1
+	fi
+
+	# Write stage-level excludes so agents cannot accidentally
+	# commit large binary or data files.  Uses the worktree's
+	# own info/exclude (not tracked, not committed).
+	local wt_git_dir
+	wt_git_dir=$(git -C "$wt_path" \
+		rev-parse --git-dir 2>/dev/null)
+	if [[ -n "$wt_git_dir" ]]; then
+		mkdir -p "$wt_git_dir/info"
+		cat >> "$wt_git_dir/info/exclude" <<'STAGE_EXCLUDES'
+# Stage-level excludes — added by orchestrator, not committed.
+.silo-downloads/
+*.db
+*.sqlite
+*.sqlite3
+*.bin
+*.zip
+*.tar.gz
+*.tar.bz2
+*.tar.xz
+*.whl
+*.egg-info/
+*.pyc
+__pycache__/
+*.so
+*.o
+*.a
+*.dylib
+*.dll
+*.exe
+STAGE_EXCLUDES
+	fi
+
+	printf '%s' "$wt_path"
+}
+
+# Run a task's implement + quality loop inside a worktree.
+#
+# This function is designed to run in a background subshell.
+# It writes a JSON result to the specified log file.
+#
+# Arguments:
+#   $1  - task_id
+#   $2  - task_desc
+#   $3  - task_agent
+#   $4  - task_size (S/M/L)
+#   $5  - worktree_path
+#   $6  - wt_branch
+#   $7  - feature_branch
+#   $8  - result_file (path to write JSON result)
+#   $9  - base_branch
+# Returns:
+#   0 on success, 1 on failure
+#
+run_task_in_worktree() {
+	local task_id="$1"
+	local task_desc="$2"
+	local task_agent="$3"
+	local task_size="$4"
+	local wt_path="$5"
+	local wt_branch="$6"
+	local feature_branch="$7"
+	local result_file="$8"
+	local base_branch="$9"
+
+	cd "$wt_path" || {
+		printf '%s' \
+			'{"status":"failed","review_attempts":0}' \
+			> "$result_file"
+		return 1
+	}
+
+	local max_attempts
+	max_attempts=$(get_max_review_attempts "$task_size")
+	local review_attempts=0
+	local task_succeeded=false
+
+	local base_timeout
+	base_timeout=$(get_stage_timeout \
+		"implement-task-$task_id" "$task_size")
+	local base_model
+	base_model=$(resolve_model \
+		"implement-task-$task_id" "$task_size")
+
+	# Build affected files list
+	local -a affected_files=()
+	local f
+	while IFS= read -r f; do
+		[[ -n "$f" ]] && affected_files+=("$f")
+	done < <(
+		printf '%s' "$task_desc" \
+			| grep -oE \
+			'[a-zA-Z0-9_.][a-zA-Z0-9_./-]*(/[a-zA-Z0-9_./-]+)+' \
+			2>/dev/null || true
+	)
+	while IFS= read -r f; do
+		[[ -n "$f" ]] && affected_files+=("$f")
+	done < <(
+		git diff "$base_branch"...HEAD \
+			--name-only 2>/dev/null || true
+	)
+	local files_block
+	files_block=$(build_files_block \
+		"${affected_files[@]+"${affected_files[@]}"}")
+
+	local impl_result=""
+
+	while (( review_attempts < max_attempts )); do
+		review_attempts=$((review_attempts + 1))
+
+		local line_range_hint
+		line_range_hint=$(build_line_range_hint "$task_desc")
+		local test_discovery_skill
+		test_discovery_skill=$(load_skill "test-discovery")
+		local impl_prompt
+		impl_prompt="${PLATFORM_PATTERNS_PREFIX}Implement task $task_id on branch $wt_branch in the current working directory:
+
+${test_discovery_skill:+## Skill Instructions — READ AND FOLLOW THESE
+
+$test_discovery_skill
+
+## End Skill Instructions
+
+}$task_desc${line_range_hint}${files_block}
+SELF-REVIEW BEFORE COMMITTING:
+After implementing, verify your changes against the task description above:
+1. Does your implementation fully achieve the task's goal?
+2. Are there any obvious issues, missing edge cases, or incomplete parts?
+3. If you find problems, fix them before committing.
+
+Only commit when you are confident the task goal is achieved.
+When committing: run 'git diff --name-only' to list the files
+you changed, then 'git add' only those specific files. Never
+use 'git add -A' or 'git add .' — only stage files the task
+actually modified.
+Commit your changes with a descriptive message."
+
+		local current_timeout="$base_timeout"
+		local current_model=""
+		if (( review_attempts > 1 )); then
+			current_model=$(_next_model_up "$base_model")
+			current_timeout=$((base_timeout * 120 / 100))
+			log "Task $task_id retry: escalating" \
+				"to $current_model with" \
+				"timeout ${current_timeout}s"
+		fi
+
+		if [[ -n "$current_model" ]]; then
+			impl_result=$(run_stage \
+				"implement-task-$task_id" \
+				"$impl_prompt" \
+				"implement-issue-implement.json" \
+				"$task_agent" "$task_size" \
+				"$current_timeout" "$current_model")
+		else
+			impl_result=$(run_stage \
+				"implement-task-$task_id" \
+				"$impl_prompt" \
+				"implement-issue-implement.json" \
+				"$task_agent" "$task_size")
+		fi
+		_halt_if_budget_exceeded
+
+		local impl_status
+		impl_status=$(printf '%s' "$impl_result" \
+			| jq -r '.output.status')
+
+		if [[ "$impl_status" == "success" ]]; then
+			task_succeeded=true
+			break
+		fi
+
+		log_warn \
+			"Task $task_id attempt" \
+			"$review_attempts/$max_attempts failed"
+	done
+
+	if [[ "$task_succeeded" == "true" ]]; then
+		# Sanitize: remove accidentally committed binary/data files
+		sanitize_worktree_commits "." "$base_branch" "$task_id"
+
+		# Guard: verify the latest commit is within the code/tests allowlist
+		if ! guard_commit_path_allowlist "."; then
+			log_error \
+				"Task $task_id: implement stage committed paths" \
+				"outside the code/tests allowlist"
+			printf '%s' \
+				"{\"status\":\"failed\"," \
+				"\"review_attempts\":$review_attempts}" \
+				> "$result_file"
+			return 1
+		fi
+
+		# Run quality loop inside worktree
+		if should_run_quality_loop "$task_size"; then
+			local quality_max
+			quality_max=$(get_max_quality_iterations \
+				"$task_desc" "$base_branch")
+			log "Running quality loop for" \
+				"task $task_id in worktree"
+			run_quality_loop "." "$wt_branch" \
+				"task-$task_id" "$task_agent" \
+				"$quality_max" "$task_size"
+		fi
+
+		local commit_sha
+		commit_sha=$(printf '%s' "$impl_result" \
+			| jq -r '.output.commit')
+		local impl_summary
+		impl_summary=$(printf '%s' "$impl_result" \
+			| jq -r '.output.summary // "Implementation completed"')
+
+		local files_changed_wt_json
+		files_changed_wt_json=$(git -C "$wt_path" diff --name-only HEAD~1 HEAD \
+			2>/dev/null | jq -R -s 'split("\n") | map(select(length>0))')
+		printf '%s' "{
+\"status\":\"success\",
+\"review_attempts\":$review_attempts,
+\"commit\":\"$commit_sha\",
+\"files_changed\":${files_changed_wt_json:-[]},
+\"summary\":$(printf '%s' "$impl_summary" | jq -Rs .)
+}" > "$result_file"
+		return 0
+	fi
+
+	printf '%s' \
+		"{\"status\":\"failed\",\"review_attempts\":$review_attempts}" \
+		> "$result_file"
+	return 1
+}
+
+# Sanitize commits in a worktree: remove accidentally staged binary/data files.
+#
+# Uses git diff --name-only to identify changed source files, then checks for
+# files that should not have been committed (binaries, large data files).
+# Amends the last commit to exclude them if found.
+#
+# Arguments:
+#   $1 - worktree_path
+#   $2 - base_branch (to compare against)
+#   $3 - task_id (for logging)
+#
+# Binary patterns excluded:
+#   .silo-downloads/, *.db, *.sqlite*, *.bin, *.zip, *.tar.*, *.whl,
+#   *.egg-info/, *.pyc, __pycache__/, *.so, *.o, *.a, *.dylib, *.dll, *.exe
+#
+sanitize_worktree_commits() {
+	local wt_path="$1"
+	local base_branch="$2"
+	local task_id="$3"
+
+	# Binary/data file patterns to exclude from commits
+	local -a exclude_patterns=(
+		'\.silo-downloads/'
+		'\.db$'
+		'\.sqlite3?$'
+		'\.bin$'
+		'\.zip$'
+		'\.tar\.(gz|bz2|xz)$'
+		'\.whl$'
+		'\.egg-info/'
+		'\.pyc$'
+		'__pycache__/'
+		'\.so$'
+		'\.[oa]$'
+		'\.dylib$'
+		'\.dll$'
+		'\.exe$'
+	)
+
+	# Build combined regex
+	local exclude_regex
+	exclude_regex=$(printf '%s|' "${exclude_patterns[@]}")
+	exclude_regex="${exclude_regex%|}"  # trim trailing pipe
+
+	# Get files in the worktree's commits vs base
+	local -a bad_files=()
+	local file
+	while IFS= read -r file; do
+		[[ -n "$file" ]] || continue
+		if [[ "$file" =~ $exclude_regex ]]; then
+			bad_files+=("$file")
+		fi
+	done < <(
+		git -C "$wt_path" diff "$base_branch"...HEAD \
+			--name-only 2>/dev/null || true
+	)
+
+	if (( ${#bad_files[@]} == 0 )); then
+		return 0
+	fi
+
+	log_warn "Task $task_id: removing ${#bad_files[@]} binary/data file(s) from commits"
+	for file in "${bad_files[@]}"; do
+		log "  Removing: $file"
+		git -C "$wt_path" rm --cached "$file" 2>/dev/null || true
+	done
+	git -C "$wt_path" commit --amend --no-edit 2>/dev/null || true
+}
+
+# Post-commit path-allowlist guard (issue #315).
+#
+# After a commit-producing stage (implement, simplify, fix-review) makes a
+# commit, call this function to verify the new commit only touches files
+# inside the allowed set:
+#
+#   - paths under tests/
+#   - recognised source-code extensions:
+#       .ts .tsx .js .jsx .mjs .cjs .sh .bats
+#       .py .go .rb .java .rs .c .cpp .h .hpp
+#
+# Any path outside the allowlist causes the function to return non-zero
+# and emit a clear error, which the caller must treat as a stage failure.
+#
+# Arguments:
+#   $1 - git directory (passed to git -C); defaults to "."
+#   $2 - git ref to inspect; defaults to HEAD
+#
+guard_commit_path_allowlist() {
+	local git_dir="${1:-.}"
+	local ref="${2:-HEAD}"
+	local path ep
+	local -a bad=() _extra=() _raw=()
+	# Hoist the EXTRA_COMMIT_PATHS split outside the per-path loop.
+	# Trim whitespace around each pipe-separated entry so values like
+	# 'package.json | package-lock.json' work correctly.
+	if [[ -n "${EXTRA_COMMIT_PATHS:-}" ]]; then
+		IFS='|' read -ra _raw <<< "$EXTRA_COMMIT_PATHS"
+		for ep in "${_raw[@]}"; do
+			ep="${ep#"${ep%%[![:space:]]*}"}"
+			ep="${ep%"${ep##*[![:space:]]}"}"
+			[[ -n "$ep" ]] || continue
+			_extra+=("$ep")
+		done
+	fi
+
+	while IFS= read -r path; do
+		[[ -n "$path" ]] || continue
+		case "$path" in
+			# Hard denylist — not overridable by EXTRA_COMMIT_PATHS.
+			.github/workflows/**) bad+=("$path") ;;
+			tests/*) continue ;;
+			prisma/** | */prisma/**) continue ;;
+			docker-compose*.yml) continue ;;
+			docs/**) continue ;;
+			.claude/agents/**) continue ;;
+			.claude/skills/**) continue ;;
+			plugins/pipeline-core/skills/**) continue ;;
+			*.ts | *.tsx | *.js | *.jsx | *.mjs | *.cjs)
+				continue ;;
+			*.sh | *.bats | *.py | *.go | *.rb | *.java | *.rs)
+				continue ;;
+			*.c | *.cpp | *.h | *.hpp) continue ;;
+			*)
+				for ep in "${_extra[@]}"; do
+					# shellcheck disable=SC2254
+					case "$path" in
+						$ep) continue 2 ;;
+					esac
+				done
+				bad+=("$path") ;;
+		esac
+	done < <(
+		git -C "$git_dir" show --name-only --pretty=format: \
+			"$ref" 2>/dev/null \
+			| sed '/^$/d'
+	)
+
+	if (( ${#bad[@]} > 0 )); then
+		log_error \
+			"commit $ref touches paths outside the" \
+			"code/tests allowlist: ${bad[*]}"
+		return 1
+	fi
+	return 0
+}
+
+# Merge a worktree branch into the feature branch.
+#
+# Arguments:
+#   $1 - feature_branch
+#   $2 - wt_branch
+#   $3 - task_id
+# Returns:
+#   0 on success, 1 on merge conflict
+#
+merge_worktree_branch() {
+	local feature_branch="$1"
+	local wt_branch="$2"
+	local task_id="$3"
+
+	log "Merging $wt_branch into $feature_branch" \
+		"(task $task_id)"
+
+	git checkout "$feature_branch" >/dev/null 2>&1 || {
+		log_error "Failed to checkout $feature_branch"
+		return 1
+	}
+
+	if git merge --no-edit "$wt_branch" \
+		>/dev/null 2>&1; then
+		log "Merge of task $task_id succeeded"
+		return 0
+	fi
+
+	log_warn "Merge conflict for task $task_id" \
+		"— aborting merge"
+	git merge --abort >/dev/null 2>&1
+	return 1
+}
+
+# Clean up a git worktree and its branch.
+#
+# Arguments:
+#   $1 - worktree_path
+#   $2 - wt_branch
+#
+cleanup_worktree() {
+	local wt_path="$1"
+	local wt_branch="$2"
+
+	if [[ -d "$wt_path" ]]; then
+		git worktree remove --force "$wt_path" \
+			2>/dev/null >&2 || true
+	fi
+	git worktree prune 2>/dev/null >&2 || true
+	git branch -D "$wt_branch" 2>/dev/null >&2 || true
+}
+
+# Execute a batch of tasks in parallel using worktrees.
+#
+# Arguments:
+#   $1 - batch_number
+#   $2 - tasks_json (filtered to this batch)
+#   $3 - feature_branch
+#   $4 - base_branch
+# Outputs:
+#   JSON object on stdout:
+#   {"completed":[...],"failed":[...],"conflicted":[...]}
+#
+execute_batch_parallel() {
+	local batch_num="$1"
+	local batch_tasks="$2"
+	local feature_branch="$3"
+	local base_branch="$4"
+
+	# Pre-flight: clean up stale worktree branches from
+	# any previous failed run before creating new ones.
+	cleanup_stale_worktrees
+
+	local wt_base="${LOG_BASE}/worktrees"
+	local batch_count
+	batch_count=$(printf '%s' "$batch_tasks" \
+		| jq 'length')
+
+	log "Batch $batch_num: launching $batch_count" \
+		"tasks in parallel"
+
+	local -a pids=()
+	local -a task_ids=()
+	local -a wt_paths=()
+	local -a wt_branches=()
+	local -a result_files=()
+
+	local i
+	for ((i = 0; i < batch_count; i++)); do
+		local task
+		task=$(printf '%s' "$batch_tasks" \
+			| jq ".[$i]")
+		local tid tdesc tagent tsize
+		tid=$(printf '%s' "$task" | jq -r '.id')
+		tdesc=$(printf '%s' "$task" | jq -r '.description')
+		tagent=$(printf '%s' "$task" | jq -r '.agent')
+		tsize=$(extract_task_size "$tdesc")
+
+		local wt_branch="wt-i${ISSUE_NUMBER}-t${tid}"
+		local result_file
+		result_file="${LOG_BASE}/stages/task-${tid}-worktree.log"
+
+		local wt_path
+		wt_path=$(create_task_worktree \
+			"$wt_base" "$feature_branch" "$tid" "$ISSUE_NUMBER")
+
+		if [[ -z "$wt_path" ]]; then
+			log_error "Could not create worktree" \
+				"for task $tid"
+			# Clean up any partially-created branch
+			cleanup_worktree "" "$wt_branch"
+			printf '%s' \
+				'{"status":"failed","review_attempts":0}' \
+				> "$result_file"
+			task_ids+=("$tid")
+			wt_paths+=("")
+			wt_branches+=("$wt_branch")
+			result_files+=("$result_file")
+			continue
+		fi
+
+		task_ids+=("$tid")
+		wt_paths+=("$wt_path")
+		wt_branches+=("$wt_branch")
+		result_files+=("$result_file")
+
+		# Launch in background subshell with wall-time guard
+		(
+			# Enable job control so the child gets its own process group
+			# (PGID == _task_pid), letting the watchdog kill the whole tree.
+			set -m
+			run_task_in_worktree \
+				"$tid" "$tdesc" "$tagent" \
+				"$tsize" "$wt_path" \
+				"$wt_branch" "$feature_branch" \
+				"$result_file" "$base_branch" &
+			_task_pid=$!
+			set +m
+			set -m
+			( sleep "${MAX_TASK_WALL_TIME_SECS}" && \
+				kill -- -"$_task_pid" 2>/dev/null ) > /dev/null 2>&1 &
+			_watchdog_pid=$!
+			set +m
+			wait "$_task_pid" 2>/dev/null
+			_task_exit=$?
+			kill -- -"$_watchdog_pid" 2>/dev/null
+			wait "$_watchdog_pid" 2>/dev/null || true
+			# exit 143 = SIGTERM from watchdog; only treat as timeout
+			# when no result file was written (guards against race
+			# where task completes as watchdog fires).
+			if [[ $_task_exit -eq 143 && \
+				! -f "$result_file" ]]; then
+				log_error "Task $tid TIMED OUT" \
+					"after ${MAX_TASK_WALL_TIME_SECS}s"
+				printf '%s' \
+					'{"status":"timeout","review_attempts":0}' \
+					> "$result_file"
+			fi
+		) &
+		local last_pid=$!
+		pids+=("$last_pid")
+		_bg_pids+=("$last_pid")
+		log "Task $tid launched (PID $last_pid," \
+			"wall-time limit ${MAX_TASK_WALL_TIME_SECS}s)" \
+			"in $wt_path"
+	done
+
+	# Wait for all background tasks
+	local p
+	for p in "${pids[@]+"${pids[@]}"}"; do
+		wait "$p" 2>/dev/null || true
+	done
+
+	log "Batch $batch_num: all tasks finished," \
+		"collecting results"
+
+	# Ensure we are on the feature branch for merges
+	git checkout "$feature_branch" >/dev/null 2>&1 || true
+
+	# Collect results and attempt merges
+	local -a completed=()
+	local -a failed=()
+	local -a conflicted=()
+
+	for ((i = 0; i < ${#task_ids[@]}; i++)); do
+		local tid="${task_ids[$i]}"
+		local rf="${result_files[$i]}"
+		local wb="${wt_branches[$i]}"
+		local wp="${wt_paths[$i]}"
+
+		if [[ ! -f "$rf" ]]; then
+			log_error "No result file for task $tid"
+			failed+=("$tid")
+			cleanup_worktree "$wp" "$wb"
+			continue
+		fi
+
+		local rstatus
+		rstatus=$(jq -r '.status' "$rf" 2>/dev/null)
+
+		if [[ "$rstatus" == "timeout" ]]; then
+			log_error "Task $tid TIMED OUT" \
+				"(exceeded ${MAX_TASK_WALL_TIME_SECS}s wall time)"
+			failed+=("$tid")
+			cleanup_worktree "$wp" "$wb"
+			continue
+		elif [[ "$rstatus" != "success" ]]; then
+			log_error "Task $tid failed in worktree" \
+				"(status: $rstatus)"
+			failed+=("$tid")
+			cleanup_worktree "$wp" "$wb"
+			continue
+		fi
+
+		# Silent no-op guard: a subagent can self-report
+		# {"status":"success"} yet commit nothing to its worktree. Merging an
+		# empty branch is a git no-op ("Already up to date", rc 0), so without
+		# this check the task is counted "completed" and the issue sails to a
+		# false-green PR with the intended changes never landed. Treat an empty
+		# worktree branch as a failed task so it surfaces in the task summary.
+		if [[ -z "$(git rev-list "${feature_branch}..${wb}" 2>/dev/null)" ]]; then
+			log_error "Task $tid reported success but produced no commits" \
+				"— marking failed (silent no-op guard)"
+			failed+=("$tid")
+			cleanup_worktree "$wp" "$wb"
+			continue
+		fi
+
+		# Attempt merge
+		if merge_worktree_branch \
+			"$feature_branch" "$wb" "$tid"; then
+			completed+=("$tid")
+		else
+			conflicted+=("$tid")
+		fi
+
+		cleanup_worktree "$wp" "$wb"
+	done
+
+	# Build result JSON
+	local comp_json fail_json conf_json
+	comp_json=$(printf '%s\n' "${completed[@]+"${completed[@]}"}" \
+		| jq -R 'select(length>0) | tonumber' \
+		| jq -s '.')
+	fail_json=$(printf '%s\n' "${failed[@]+"${failed[@]}"}" \
+		| jq -R 'select(length>0) | tonumber' \
+		| jq -s '.')
+	conf_json=$(printf '%s\n' "${conflicted[@]+"${conflicted[@]}"}" \
+		| jq -R 'select(length>0) | tonumber' \
+		| jq -s '.')
+
+	printf '%s' "{\"completed\":${comp_json},\"failed\":${fail_json},\"conflicted\":${conf_json}}"
+}
+
+# =============================================================================
+# E2E TDD CLASSIFICATION
+# =============================================================================
+#
+# Classify the E2E strategy for a single task before it runs.
+#
+# Classification rules (in priority order):
+#   1. TEST_E2E_CMD not configured → none (can't run E2E)
+#   2. Agent is NOT playwright-test-developer AND desc has no UI keywords → none
+#   3. Agent IS playwright-test-developer AND size L AND UI keywords → tdd*
+#   4. Agent IS playwright-test-developer AND change_scope is frontend/ts-frontend → tdd*
+#   5. Agent IS playwright-test-developer → smoke
+#   6. UI keywords AND change_scope is frontend/ts-frontend → smoke
+#   7. Default → none
+#
+#   *tdd is downgraded to smoke when E2E_TDD_ENABLED=false
+#
+# Arguments:
+#   $1 - task_desc
+#   $2 - task_agent
+#   $3 - task_size  (S/M/L)
+# Outputs (stdout):
+#   none | smoke | tdd
+#
+classify_e2e_strategy() {
+	local task_desc="$1"
+	local task_agent="$2"
+	local task_size="$3"
+
+	# Rule 1: no E2E command → none regardless
+	if [[ -z "${TEST_E2E_CMD:-}" ]]; then
+		printf 'none'
+		return
+	fi
+
+	# Detect UI keywords in description
+	local has_ui_keywords=false
+	if printf '%s' "$task_desc" \
+		| grep -qiE \
+		'button|tab|form|click|navigate|modal|dialog|dropdown|checkbox|input|component|page|view|screen'; then
+		has_ui_keywords=true
+	fi
+
+	# Rule 2: not playwright agent AND no UI keywords → none
+	if [[ "$task_agent" != "playwright-test-developer" ]] \
+		&& [[ "$has_ui_keywords" == "false" ]]; then
+		printf 'none'
+		return
+	fi
+
+	# Detect change scope from current working directory
+	local change_scope
+	change_scope=$(detect_change_scope "." "${BASE_BRANCH:-main}" 2>/dev/null \
+		|| echo "backend")
+	local is_frontend=false
+	if [[ "$change_scope" == "frontend" \
+		|| "$change_scope" == "ts-frontend" ]]; then
+		is_frontend=true
+	fi
+
+	local _tdd_result="tdd"
+	# Honour E2E_TDD_ENABLED flag — downgrade tdd → smoke when disabled
+	if [[ "${E2E_TDD_ENABLED:-true}" == "false" ]]; then
+		_tdd_result="smoke"
+	fi
+
+	if [[ "$task_agent" == "playwright-test-developer" ]]; then
+		# Rule 3: playwright + L size + UI keywords → tdd
+		if [[ "$task_size" == "L" ]] \
+			&& [[ "$has_ui_keywords" == "true" ]]; then
+			printf '%s' "$_tdd_result"
+			return
+		fi
+		# Rule 4: playwright + frontend scope → tdd
+		if [[ "$is_frontend" == "true" ]]; then
+			printf '%s' "$_tdd_result"
+			return
+		fi
+		# Rule 5: playwright (other) → smoke
+		printf 'smoke'
+		return
+	fi
+
+	# Rule 6: UI keywords + frontend scope → smoke
+	if [[ "$has_ui_keywords" == "true" ]] \
+		&& [[ "$is_frontend" == "true" ]]; then
+		printf 'smoke'
+		return
+	fi
+
+	# Rule 7: default
+	printf 'none'
+}
+
+# Execute tasks serially (fallback / single-task batches).
+#
+# This extracts the existing sequential logic into a
+# reusable function for conflict-retry and single-task
+# batches.
+#
+# Arguments:
+#   $1 - tasks_json (array of task objects)
+#   $2 - feature_branch
+#   $3 - base_branch
+# Outputs:
+#   JSON: {"completed":[...],"failed":[...]}
+#
+execute_batch_serial() {
+	local serial_tasks="$1"
+	local feature_branch="$2"
+	local base_branch="$3"
+
+	local count
+	count=$(printf '%s' "$serial_tasks" | jq 'length')
+
+	local -a completed=()
+	local -a failed=()
+	# Track playwright tasks already run in TDD pre-run mode
+	local -a tdd_prerun_tids=()
+
+	local i
+	for ((i = 0; i < count; i++)); do
+		local task
+		task=$(printf '%s' "$serial_tasks" \
+			| jq ".[$i]")
+		local tid tdesc tagent tsize
+		tid=$(printf '%s' "$task" | jq -r '.id')
+		tdesc=$(printf '%s' "$task" \
+			| jq -r '.description')
+		tagent=$(printf '%s' "$task" \
+			| jq -r '.agent')
+		tsize=$(extract_task_size "$tdesc")
+
+		# Skip playwright tasks already run in TDD pre-run mode
+		local _already_prerun=false
+		local _prid
+		for _prid in "${tdd_prerun_tids[@]+"${tdd_prerun_tids[@]}"}"; do
+			if [[ "$_prid" == "$tid" ]]; then
+				_already_prerun=true
+				break
+			fi
+		done
+		if [[ "$_already_prerun" == "true" ]]; then
+			log "Task $tid already executed in TDD" \
+				"pre-run phase — skipping"
+			completed+=("$tid")
+			continue
+		fi
+
+		# Classify E2E strategy before running this task
+		local e2e_strategy
+		e2e_strategy=$(classify_e2e_strategy \
+			"$tdesc" "$tagent" "$tsize")
+		log "Task $tid E2E strategy: $e2e_strategy"
+
+		# TDD: if this is an implementation task and the adjacent next task
+		# is a playwright-test-developer task classified as tdd, run the
+		# playwright task FIRST (RED phase) before the implementation task.
+		if [[ "$tagent" != "playwright-test-developer" ]] \
+			&& (( i + 1 < count )); then
+			local _next_task _next_tid _next_tdesc _next_tagent _next_tsize
+			_next_task=$(printf '%s' "$serial_tasks" \
+				| jq ".[$((i + 1))]")
+			_next_tagent=$(printf '%s' "$_next_task" \
+				| jq -r '.agent')
+			if [[ "$_next_tagent" == "playwright-test-developer" ]]; then
+				_next_tid=$(printf '%s' "$_next_task" \
+					| jq -r '.id')
+				_next_tdesc=$(printf '%s' "$_next_task" \
+					| jq -r '.description')
+				_next_tsize=$(extract_task_size "$_next_tdesc")
+				local _next_strategy
+				_next_strategy=$(classify_e2e_strategy \
+					"$_next_tdesc" "$_next_tagent" \
+					"$_next_tsize")
+				if [[ "$_next_strategy" == "tdd" ]]; then
+					log "TDD pre-run: running playwright" \
+						"task $_next_tid before" \
+						"implementation task $tid"
+
+					# Build prompt for the playwright task
+					local _pw_files_block
+					_pw_files_block=$(build_files_block)
+					local _pw_prompt
+					_pw_prompt="Implement task $_next_tid on branch $feature_branch in the current working directory:
+
+$_next_tdesc${_pw_files_block}
+SELF-REVIEW BEFORE COMMITTING:
+After implementing, verify your changes against the task description above:
+1. Does your implementation fully achieve the task's goal?
+2. Are there any obvious issues, missing edge cases, or incomplete parts?
+3. If you find problems, fix them before committing.
+
+MANDATORY UI INTERACTION CONSTRAINTS:
+- Use data-testid selectors on actual buttons, forms, and navigation elements.
+- Do NOT call backend APIs directly from test code as a substitute for UI interactions.
+- Do NOT use waitForLoadState('networkidle') — use domcontentloaded + waitFor on specific elements.
+
+Only commit when you are confident the task goal is achieved.
+Commit your changes with a descriptive message."
+
+					local _pre_pw_sha
+					_pre_pw_sha=$(git rev-parse HEAD)
+
+					local _pw_timeout _pw_model
+					_pw_timeout=$(get_stage_timeout \
+						"implement-task-$_next_tid" \
+						"$_next_tsize")
+					_pw_model=$(resolve_model \
+						"implement-task-$_next_tid" \
+						"$_next_tsize")
+
+					local _pw_result
+					_pw_result=$(run_stage \
+						"implement-task-${_next_tid}-tdd-red" \
+						"$_pw_prompt" \
+						"implement-issue-implement.json" \
+						"$_next_tagent" "$_next_tsize" \
+						"$_pw_timeout" "$_pw_model")
+					_halt_if_budget_exceeded
+
+					local _pw_status
+					_pw_status=$(printf '%s' "$_pw_result" \
+						| jq -r '.output.status')
+
+					if [[ "$_pw_status" == "success" ]]; then
+						# Find new spec files added by the playwright task
+						local _new_specs
+						_new_specs=$(git diff "$_pre_pw_sha"..HEAD \
+							--name-only --diff-filter=A \
+							2>/dev/null \
+							| grep -E '\.(spec|test)\.(ts|js)$' \
+							|| true)
+
+						if [[ -n "$_new_specs" ]]; then
+							log "TDD RED phase: asserting" \
+								"new spec(s) fail" \
+								"before implementation:"
+							log "$_new_specs"
+							local _red_confirmed=false
+							local _spec_file
+							while IFS= read -r _spec_file; do
+								[[ -z "$_spec_file" ]] && continue
+								log "RED check:" \
+									"$TEST_E2E_CMD --" \
+									"$_spec_file"
+								if bash -c \
+									"$TEST_E2E_CMD -- $(printf '%q' "$_spec_file")" \
+									>/dev/null 2>&1; then
+									log_warn "TDD RED:" \
+										"$_spec_file passed" \
+										"(expected failure)"
+								else
+									log "TDD RED confirmed:" \
+										"$_spec_file fails" \
+										"as expected"
+									_red_confirmed=true
+								fi
+							done <<< "$_new_specs"
+							if [[ "$_red_confirmed" == "true" ]]; then
+								log "TDD RED phase confirmed" \
+									"— proceeding with" \
+									"implementation task $tid"
+							else
+								log_warn "TDD RED: not confirmed" \
+									"— all specs passed" \
+									"unexpectedly"
+							fi
+						else
+							log_warn "TDD pre-run: no new" \
+								"spec files found after" \
+								"playwright task $_next_tid" \
+								"— proceeding anyway"
+						fi
+						# Register regardless of whether new spec files were
+						# found — prevents double-execution when the playwright
+						# task only modifies page objects or fixtures.
+						tdd_prerun_tids+=("$_next_tid")
+					else
+						log_warn "TDD pre-run: playwright" \
+							"task $_next_tid failed" \
+							"— running implementation" \
+							"task $tid anyway"
+					fi
+				fi
+			fi
+		fi
+
+		log "Implementing task $tid" \
+			"(serial): $tdesc"
+
+		local max_attempts
+		max_attempts=$(get_max_review_attempts "$tsize")
+		local review_attempts=0
+		local task_succeeded=false
+
+		local base_timeout
+		base_timeout=$(get_stage_timeout \
+			"implement-task-$tid" "$tsize")
+		local base_model
+		base_model=$(resolve_model \
+			"implement-task-$tid" "$tsize")
+
+		# Build affected files list
+		local -a affected_files=()
+		local f
+		while IFS= read -r f; do
+			[[ -n "$f" ]] && affected_files+=("$f")
+		done < <(
+			printf '%s' "$tdesc" \
+				| grep -oE \
+				'[a-zA-Z0-9_.][a-zA-Z0-9_./-]*(/[a-zA-Z0-9_./-]+)+' \
+				2>/dev/null || true
+		)
+		while IFS= read -r f; do
+			[[ -n "$f" ]] && affected_files+=("$f")
+		done < <(
+			git diff "$base_branch"...HEAD \
+				--name-only 2>/dev/null || true
+		)
+		local files_block
+		files_block=$(build_files_block \
+			"${affected_files[@]+"${affected_files[@]}"}")
+
+		local impl_result=""
+
+		while (( review_attempts < max_attempts )); do
+			review_attempts=$((review_attempts + 1))
+
+			local line_range_hint
+			line_range_hint=$(build_line_range_hint "$tdesc")
+			local impl_prompt
+			impl_prompt="Implement task $tid on branch $feature_branch in the current working directory:
+
+$tdesc${line_range_hint}${files_block}
+SELF-REVIEW BEFORE COMMITTING:
+After implementing, verify your changes against the task description above:
+1. Does your implementation fully achieve the task's goal?
+2. Are there any obvious issues, missing edge cases, or incomplete parts?
+3. If you find problems, fix them before committing.
+
+MANDATORY UI INTERACTION CONSTRAINTS:
+- Use data-testid selectors on actual buttons, forms, and navigation elements.
+- Do NOT call backend APIs directly from test code as a substitute for UI interactions.
+- Do NOT use waitForLoadState('networkidle') — use domcontentloaded + waitFor on specific elements.
+
+Only commit when you are confident the task goal is achieved.
+Commit your changes with a descriptive message."
+
+			local current_timeout="$base_timeout"
+			local current_model=""
+			if (( review_attempts > 1 )); then
+				current_model=$(_next_model_up \
+					"$base_model")
+				current_timeout=$(( \
+					base_timeout * 120 / 100))
+				log "Task $tid retry: escalating" \
+					"to $current_model with" \
+					"timeout ${current_timeout}s"
+			fi
+
+			if [[ -n "$current_model" ]]; then
+				impl_result=$(run_stage \
+					"implement-task-$tid" \
+					"$impl_prompt" \
+					"implement-issue-implement.json" \
+					"$tagent" "$tsize" \
+					"$current_timeout" \
+					"$current_model")
+			else
+				impl_result=$(run_stage \
+					"implement-task-$tid" \
+					"$impl_prompt" \
+					"implement-issue-implement.json" \
+					"$tagent" "$tsize")
+			fi
+			_halt_if_budget_exceeded
+
+			local impl_status
+			impl_status=$(printf '%s' "$impl_result" \
+				| jq -r '.output.status')
+
+			if [[ "$impl_status" == "success" ]]; then
+				task_succeeded=true
+				break
+			fi
+
+			log_warn "Task $tid attempt" \
+				"$review_attempts/$max_attempts" \
+				"failed"
+		done
+
+		if [[ "$task_succeeded" == "true" ]]; then
+			# Quality loop
+			if should_run_quality_loop "$tsize"; then
+				local quality_max
+				quality_max=$(get_max_quality_iterations \
+					"$tdesc" "$base_branch")
+				log "Running quality loop for" \
+					"task $tid (serial)"
+				run_quality_loop "." \
+					"$feature_branch" \
+					"task-$tid" "$tagent" \
+					"$quality_max" "$tsize"
+			fi
+
+			# Write result file for main loop
+			local commit_sha
+			commit_sha=$(printf '%s' "$impl_result" \
+				| jq -r '.output.commit')
+			local impl_summary
+			impl_summary=$(printf '%s' "$impl_result" \
+				| jq -r \
+				'.output.summary // "Implementation completed"')
+			local files_changed_json
+			files_changed_json=$(git diff --name-only HEAD~1 HEAD \
+				2>/dev/null | jq -R -s \
+				'split("\n") | map(select(length>0))')
+			local rf
+			rf="${LOG_BASE}/stages/task-${tid}-serial.log"
+			printf '%s' "{
+\"status\":\"success\",
+\"review_attempts\":$review_attempts,
+\"commit\":\"$commit_sha\",
+\"summary\":$(printf '%s' "$impl_summary" | jq -Rs .),
+\"files_changed\":${files_changed_json:-[]}
+}" > "$rf"
+
+			completed+=("$tid")
+		else
+			failed+=("$tid")
+		fi
+	done
+
+	# Build result JSON
+	local comp_json fail_json
+	comp_json=$(printf '%s\n' \
+		"${completed[@]+"${completed[@]}"}" \
+		| jq -R 'select(length>0) | tonumber' \
+		| jq -s '.')
+	fail_json=$(printf '%s\n' \
+		"${failed[@]+"${failed[@]}"}" \
+		| jq -R 'select(length>0) | tonumber' \
+		| jq -s '.')
+
+	printf '%s' \
+		"{\"completed\":${comp_json},\"failed\":${fail_json}}"
+}
+
+# =============================================================================
+# PROMPT FILE-LIST BUILDER
+# =============================================================================
+#
+# Formats a list of file paths into the "LIKELY AFFECTED FILES:" block that
+# is injected into the implement-task prompt.  Keeping this in a named
+# function makes it testable in isolation.
+#
+# Arguments:
+#   $@ - zero or more file paths
+# Outputs:
+#   A leading newline when no files are provided (preserves blank-line
+#   separator in prompt).  A "LIKELY AFFECTED FILES:" section listing
+#   deduplicated, sorted file paths when one or more are provided.
+#
+# Build a targeted read hint from a task description.
+#
+# Parses "(lines N[–-]M)" from the task description and emits a
+# "TARGETED READ:" line instructing the subagent to jump to that offset.
+# No hard read limit is imposed — subagents should read additional context
+# (adjacent functions, callers, etc.) as needed.
+#
+# Arguments:
+#   $1 - task description string
+# Outputs:
+#   A "TARGETED READ:" line when a line range is found, or empty string.
+#
+build_line_range_hint() {
+    local task_desc="$1"
+    local start_line end_line
+    if [[ "$task_desc" =~ \(lines?[[:space:]]+([0-9]+)[[:space:]]*[-–][[:space:]]*([0-9]+)\) ]]; then
+        start_line="${BASH_REMATCH[1]}"
+        end_line="${BASH_REMATCH[2]}"
+        local offset=$(( start_line - 1 ))
+        printf '\nTARGETED READ: The primary change target is around lines %s–%s — use offset=%s to jump there, then read additional context (adjacent functions, callers) as needed.\n' \
+            "$start_line" "$end_line" "$offset"
+    fi
+}
+
+build_files_block() {
+    local block=$'\n'
+    if [[ $# -gt 0 ]]; then
+        local deduped
+        deduped=$(printf '%s\n' "$@" | sort -u)
+        block=$'\nLIKELY AFFECTED FILES:\n'
+        local f
+        while IFS= read -r f; do
+            [[ -n "$f" ]] && block+="- $f"$'\n'
+        done <<< "$deduped"
+    fi
+    printf '%s' "$block"
+}
+
+# =============================================================================
+# TEST LOOP HELPER
+# =============================================================================
+
+# Check whether a file path matches any pattern in FRONTEND_PATH_PATTERNS.
+# Each pattern is a simple glob matched via bash case (supports * and ?).
+# Arguments:
+#   $1 - file path to check
+# Returns:
+#   0 if the file matches a frontend pattern
+#   1 if no match or FRONTEND_PATH_PATTERNS is empty
+_matches_frontend_pattern() {
+    local file="$1"
+
+    if [[ -z "${FRONTEND_PATH_PATTERNS:-}" ]]; then
+        return 1
+    fi
+
+    local pattern
+    local IFS='|'
+    for pattern in $FRONTEND_PATH_PATTERNS; do
+        # shellcheck disable=SC2254
+        case "$file" in
+            $pattern) return 0 ;;
+        esac
+    done
+
+    return 1
+}
+
+# Filter a newline-delimited file list to only implementation-relevant files.
+# Excludes .claude/ pipeline files, docs/, and non-code config files from the
+# list passed to the test validation prompt.
+# Arguments:
+#   stdin - newline-delimited file list
+# Outputs:
+#   Filtered file list (newline-delimited)
+filter_implementation_files() {
+    grep -v -E '^\.claude/' \
+    | grep -v -E '^docs/' \
+    | grep -v -E '\.(md|json|yaml|yml|toml|lock|gitignore)$' \
+    || true
+}
+
+# Check if a file is a Playwright spec (lives in tests/e2e/ or similar E2E directories).
+# Arguments:
+#   $1 - file path
+# Returns:
+#   0 if Playwright spec, 1 otherwise
+_is_playwright_spec() {
+    local file="$1"
+    case "$file" in
+        tests/e2e/*.spec.*|test/e2e/*.spec.*|e2e/*.spec.*|**/e2e/*.spec.*) return 0 ;;
+    esac
+    return 1
+}
+
+# Build a targeted E2E command from changed Playwright spec files.
+# If specs exist in the diff, appends them to TEST_E2E_CMD; otherwise returns
+# the base command unchanged.
+# Arguments:
+#   $1 - base branch to diff against
+# Outputs:
+#   The E2E command string (targeted or full)
+_build_targeted_e2e_cmd() {
+    local base="$1"
+    local pw_specs=""
+    pw_specs=$(git diff "$base"...HEAD --name-only \
+        -- 'tests/e2e/*.spec.*' 'test/e2e/*.spec.*' \
+           'e2e/*.spec.*' '**/e2e/*.spec.*' \
+        2>/dev/null || true)
+    if [[ -n "$pw_specs" ]]; then
+        log "Targeted E2E: running changed spec files only"
+        printf '%s -- %s' "$TEST_E2E_CMD" "$pw_specs"
+    else
+        printf '%s' "$TEST_E2E_CMD"
+    fi
+}
+
+# Detect the scope of changes on the current branch vs the base branch.
+# Classifies changed files by extension to determine which test suite to run.
+# Arguments:
+#   $1 - working directory
+#   $2 - base branch to diff against
+# Outputs:
+#   One of: typescript | bash | config | mixed | frontend | ts-frontend
+detect_change_scope() {
+    local work_dir="$1"
+    local base="$2"
+
+    local changed_files
+    # Three-dot diff ($base...HEAD) uses merge-base semantics: compares HEAD against
+    # the common ancestor of $base and HEAD, so we only see files changed on this branch
+    # (not files changed on $base since the branch point).
+    changed_files=$(git -C "$work_dir" diff "$base"...HEAD --name-only 2>/dev/null || true)
+
+    if [[ -z "$changed_files" ]]; then
+        log_warn "detect_change_scope: no changed files found vs '$base' — check BASE_BRANCH configuration"
+        echo "config"
+        return 0
+    fi
+
+    local has_ts=false
+    local has_bash=false
+    local has_other_code=false
+    local has_frontend=false
+
+    while IFS= read -r file; do
+        # Check frontend pattern match (before extension classification)
+        if _matches_frontend_pattern "$file"; then
+            has_frontend=true
+        fi
+
+        case "$file" in
+            *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs) has_ts=true ;;
+            # Pipeline scripts (.claude/scripts/) have bats tests — route to bash
+            # Note: in case patterns, * matches / so .claude/scripts/*.sh covers
+            # any depth under scripts/ (e.g. .claude/scripts/sub/file.sh)
+            .claude/scripts/*.sh) has_bash=true ;;
+            # ALL bats files need bash tests regardless of location
+            *.bats) has_bash=true ;;
+            # Hooks and config shell scripts also have bats tests — route to bash
+            .claude/hooks/*.sh|.claude/config/*.sh) has_bash=true ;;
+            # Other .claude files (config, schemas, skills, CLAUDE.md) — skip
+            .claude/*) ;;
+            *.sh) has_bash=true ;;
+            # Config/docs: no tests needed
+            *.md|*.json|*.yaml|*.yml|*.toml|*.env|*.lock|*.gitignore) ;;
+            # Any other extension (css, sql, py, etc.): treat as testable code
+            *.*) has_other_code=true ;;
+            # Extensionless files (Makefile, Dockerfile, etc.): treat as testable code
+            *) has_other_code=true ;;
+        esac
+    done <<< "$changed_files"
+
+    if [[ "$has_ts" == "true" && "$has_bash" == "true" ]]; then
+        echo "mixed"
+    elif [[ "$has_ts" == "true" && "$has_frontend" == "true" ]]; then
+        echo "ts-frontend"
+    elif [[ "$has_ts" == "true" ]]; then
+        echo "typescript"
+    elif [[ "$has_frontend" == "true" ]]; then
+        # Only frontend files (CSS, etc.) without TS — still need E2E
+        echo "frontend"
+    elif [[ "$has_bash" == "true" ]]; then
+        echo "bash"
+    elif [[ "$has_other_code" == "true" ]]; then
+        # Unknown code files — run full test suite to be safe
+        echo "typescript"
+    else
+        echo "config"
+    fi
+
+    return 0
+}
+
+# Checks whether every failure in a JSON failures array is caused by an
+# environment infrastructure error (Redis, database connection, HTTP 500,
+# network timeouts, etc.) rather than a code-level defect.
+#
+# When ALL failures are environment-related, dispatching a fix agent is
+# pointless — no code change can resolve infrastructure unavailability.
+#
+# Arguments:
+#   $1 - JSON array of failure objects with "test" and "message" fields
+# Returns:
+#   0 if every failure matches an environment pattern (skip fix dispatch)
+#   1 if any failure is code-level (fix dispatch should proceed)
+all_failures_environment_related() {
+	local failures_json="$1"
+	local count
+	count=$(printf '%s' "$failures_json" \
+		| jq 'length // 0' 2>/dev/null || echo 0)
+	if (( count == 0 )); then
+		return 1
+	fi
+	# Count failures whose message does NOT match any known environment-error
+	# pattern.  If that count is zero every failure is an infrastructure issue
+	# and we should skip the fix agent.  Only the message field is checked —
+	# matching the test name would cause false positives for tests whose names
+	# happen to contain infrastructure keywords (e.g. "redis-retry-logic").
+	local non_env_count
+	local env_pattern
+	env_pattern='redis|ECONNREFUSED|connection refused|HTTP 500'
+	env_pattern+='|database connection|socket hang up'
+	env_pattern+='|ETIMEDOUT|ENOTFOUND|connect timeout|ECONNRESET'
+	non_env_count=$(printf '%s' "$failures_json" \
+		| jq --arg pat "$env_pattern" '
+			[.[] | select(
+				((.message // ""))
+				| test($pat; "i")
+				| not
+			)] | length
+		' 2>/dev/null || echo 1)
+	(( non_env_count == 0 ))
+}
+
+# Build the bash test command for a given loop directory.
+# Prefers run-tests.sh when it exists; falls back to direct bats glob otherwise.
+# Appends "&& bats [--jobs N] tests/*.bats" when at least one *.bats file
+# exists in "$loop_dir/tests/".  Uses parallel execution via --jobs when the
+# installed bats version supports it; falls back to serial otherwise.
+# Outputs the constructed command string on stdout.
+# Arguments:
+#   $1 - loop_dir: working directory to inspect
+_build_bash_test_command() {
+	local loop_dir="$1"
+	local bash_test_command
+	local bats_cmd
+
+	# Detect --jobs support in the installed bats version.
+	# Run tests in parallel across all CPU cores when supported;
+	# fall back to serial execution otherwise.
+	# Two conditions must both be true before enabling --jobs:
+	#   1. The installed bats advertises --jobs in its help output.
+	#   2. A parallel backend (GNU parallel or rush) is available,
+	#      since bats --jobs delegates to one of these at runtime.
+	# Also evaluate the CPU count portably at detection time:
+	#   nproc is Linux-only; macOS uses sysctl -n hw.logicalcpu.
+	local cpu_count
+	cpu_count=$(nproc 2>/dev/null \
+		|| sysctl -n hw.logicalcpu 2>/dev/null \
+		|| echo 4)
+	if bats --help 2>&1 | grep -q -- '--jobs' \
+		&& { command -v parallel > /dev/null 2>&1 \
+			|| command -v rush > /dev/null 2>&1; }; then
+		bats_cmd="bats --jobs $cpu_count"
+	else
+		bats_cmd="bats"
+	fi
+
+	if [[ -f "$loop_dir/.claude/scripts/implement-issue-test/run-tests.sh" ]]; then
+		bash_test_command="bash .claude/scripts/implement-issue-test/run-tests.sh"
+	else
+		bash_test_command="$bats_cmd .claude/scripts/implement-issue-test/*.bats"
+	fi
+	if compgen -G "$loop_dir/tests/*.bats" > /dev/null 2>&1; then
+		bash_test_command="$bash_test_command && $bats_cmd tests/*.bats"
+	fi
+	printf '%s\n' "$bash_test_command"
+}
+
+# Run the test loop (test+validate -> fix, repeat until pass)
+# Called once after all tasks complete
+# Flow:
+#   1. Run tests AND validate comprehensiveness in a single stage (default agent)
+#   2. If tests fail: fix with task agent, loop
+#   3. If tests pass but validation fails: fix with task agent, loop
+#   4. If tests pass and validation passes: done
+# Arguments:
+#   $1 - working directory
+#   $2 - branch name
+#   $3 - agent to use for fix stages (optional, falls back to global $AGENT)
+#   $4 - pre-computed change scope (optional; computed via detect_change_scope if omitted)
+#   $5 - complexity hint for model selection (S/M/L, optional)
+#   $6 - loop_profile: pipeline profile (minimal|standard|full, optional)
+# Returns:
+#   0 on success (tests pass and validated)
+#   0 on convergence soft exit (loop_complete=true, pipeline continues)
+#   0 on max iterations exceeded (soft-fail, adds to DEGRADED_STAGES)
+run_test_loop() {
+    local loop_dir="$1"
+    local loop_branch="$2"
+    local loop_agent="${3:-$AGENT}"
+    local loop_complexity="${5:-}"
+    local loop_profile="${6:-}"
+
+    local loop_complete=false
+    local test_iteration=0
+    local validation_fix_iteration=0
+    local max_test_iter
+    max_test_iter=$(apply_profile_to_test_max_iter \
+        "$loop_profile" "$MAX_TEST_ITERATIONS")
+
+    log "Starting test loop after all tasks complete"
+
+    # -------------------------------------------------------------------------
+    # SMART TEST TARGETING: detect what changed and route accordingly
+    # Use pre-computed scope if provided (avoids duplicate detect_change_scope call).
+    # -------------------------------------------------------------------------
+    local change_scope
+    if [[ -n "${4:-}" ]]; then
+        case "${4}" in
+            typescript|bash|config|mixed|frontend|ts-frontend) change_scope="$4" ;;
+            *) log_warn "Invalid pre-computed scope '${4}'; recomputing"
+               change_scope=$(detect_change_scope "$loop_dir" "$BASE_BRANCH") ;;
+        esac
+        log "Using pre-computed change scope: $change_scope"
+    else
+        change_scope=$(detect_change_scope "$loop_dir" "$BASE_BRANCH")
+        log "Detected change scope: $change_scope"
+    fi
+
+    if [[ "$change_scope" == "config" ]]; then
+        log "Config/markdown-only changes detected — skipping test loop"
+        comment_issue "Test Loop: Skipped" "⏭️ No testable code changes detected (config/markdown only). Skipping test loop." ""
+        return 0
+    fi
+
+    # Build the test command based on scope
+    local test_command bash_test_command
+    bash_test_command=$(_build_bash_test_command "$loop_dir")
+
+    local safe_dir safe_branch
+    safe_dir=$(printf '%q' "$loop_dir")
+    safe_branch=$(printf '%q' "$BASE_BRANCH")
+
+    # Compute explicit changed test files (three-dot merge-base diff).
+    # Pass them directly to Jest instead of relying on --changedSince's
+    # dependency graph, which can miss or over-include files.
+    # Exclude .integration.test.ts files (run separately).
+    # Split into Jest unit tests vs Playwright E2E specs.
+    local changed_test_files=""
+    local jest_test_files=""
+    local playwright_test_files=""
+    if [[ "$change_scope" == "typescript" || "$change_scope" == "mixed" || "$change_scope" == "ts-frontend" ]]; then
+        local _tl_git_raw _tl_git_exit
+        _tl_git_raw=$(timeout "$TEST_LOOP_GIT_TIMEOUT" git -C "$loop_dir" diff \
+            "$BASE_BRANCH"...HEAD --name-only 2>/dev/null)
+        _tl_git_exit=$?
+        if (( _tl_git_exit == 124 )); then
+            log_warn "test_loop: git diff timed out after ${TEST_LOOP_GIT_TIMEOUT}s — using --changedSince fallback"
+            _tl_git_raw=""
+        fi
+        changed_test_files=$(printf '%s' "$_tl_git_raw" \
+            | grep -E '\.test\.[jt]sx?$|\.spec\.[jt]sx?$' \
+            | grep -v '\.integration\.test\.' \
+            || true)
+
+        # Split: Playwright specs (in e2e/ directories) vs Jest unit tests
+        local file
+        while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            if _is_playwright_spec "$file"; then
+                playwright_test_files="${playwright_test_files:+$playwright_test_files
+}$file"
+            else
+                jest_test_files="${jest_test_files:+$jest_test_files
+}$file"
+            fi
+        done <<< "$changed_test_files"
+
+        if [[ -n "$playwright_test_files" ]]; then
+            log "Playwright specs detected (excluded from Jest): $(echo "$playwright_test_files" | tr '\n' ' ')"
+        fi
+    fi
+
+    local jest_command
+    if [[ -n "$jest_test_files" ]]; then
+        jest_command="npx jest --passWithNoTests $(echo "$jest_test_files" | tr '\n' ' ')"
+        log "Explicit Jest test files: $(echo "$jest_test_files" | tr '\n' ' ')"
+    else
+        jest_command="npx jest --passWithNoTests --changedSince=$safe_branch"
+        if [[ -n "$changed_test_files" ]]; then
+            log "All changed test files are Playwright specs — falling back to --changedSince=$safe_branch for Jest"
+        else
+            log "No changed test files found — falling back to --changedSince=$safe_branch"
+        fi
+    fi
+
+    case "$change_scope" in
+        bash)
+            test_command="cd $safe_dir && $bash_test_command"
+            ;;
+        *)
+            # typescript, ts-frontend, frontend, mixed: run Jest.
+            # Mixed BATS pipeline tests run separately as non-blocking (see bats_section below).
+            test_command="cd $safe_dir && $jest_command"
+            ;;
+    esac
+
+    # Build E2E command when configured and scope includes frontend,
+    # OR when Playwright specs were found in the changed files
+    local e2e_command=""
+    local e2e_rebuild_note=""
+    if [[ -n "${TEST_E2E_CMD:-}" ]] && { [[ "$change_scope" == "frontend" || "$change_scope" == "ts-frontend" ]] || [[ -n "$playwright_test_files" ]]; }; then
+        # Rebuild containers so E2E tests run against fresh code
+        log "Rebuilding containers before E2E tests in test loop..."
+        local rebuild_json=""
+        if rebuild_json=$(rebuild_and_health_check \
+            "${TEST_E2E_BASE_URL:-http://localhost:30004}" 120); then
+            e2e_command="$TEST_E2E_CMD"
+            e2e_rebuild_note="Container rebuild: success. "
+            log "E2E testing enabled for $change_scope scope: $e2e_command"
+        else
+            local rb_health
+            rb_health=$(printf '%s' "$rebuild_json" \
+                | jq -r '.health // "unknown"')
+            log_warn "Container rebuild/health failed (health: $rb_health)" \
+                "— skipping E2E in test loop"
+            e2e_rebuild_note="Container rebuild failed (health: $rb_health). E2E skipped. "
+        fi
+    elif [[ -n "$playwright_test_files" && -z "${TEST_E2E_CMD:-}" ]]; then
+        log "WARNING: Playwright specs found but TEST_E2E_CMD not configured — Playwright specs will be skipped"
+    fi
+
+    # Compute the test loop's own wall-clock budget.
+    # Formula: test-iter-timeout × max(planned_iter, 1) + slack
+    # Each factor is env-overridable; TEST_LOOP_WALL_BUDGET overrides all.
+    local test_loop_wall_budget
+    test_loop_wall_budget=$(calc_test_loop_budget)
+    if [[ -n "${TEST_LOOP_WALL_BUDGET:-}" ]]; then
+        log "Test loop wall-clock budget: ${test_loop_wall_budget}s" \
+            "(env override)"
+    else
+        local _tl_iter_timeout _tl_planned_eff
+        _tl_iter_timeout=$(get_stage_timeout "test-iter" "")
+        _tl_planned_eff=$(( TEST_LOOP_PLANNED_ITERATIONS > 1 \
+            ? TEST_LOOP_PLANNED_ITERATIONS : 1 ))
+        log "Test loop wall-clock budget: ${test_loop_wall_budget}s" \
+            "(${_tl_iter_timeout}s/iter × ${_tl_planned_eff}" \
+            "+ ${TEST_ITER_WALL_TIME_SLACK}s slack)"
+    fi
+    local test_loop_start
+    test_loop_start=$(date +%s)
+
+    local prior_failure_sigs=""
+    while [[ "$loop_complete" != "true" ]]; do
+        test_iteration=$((test_iteration + 1))
+        increment_test_iteration  # Track iteration in status file
+
+        if ! check_wall_timeout; then
+            log_warn "Wall-clock timeout in test loop at iteration $test_iteration"
+            set_final_state "wall_timeout_test"
+            DEGRADED_STAGES+=("test:wall_timeout:iter=$test_iteration")
+            loop_complete=true
+            break
+        fi
+
+        if ! check_test_loop_wall_timeout \
+                "$test_loop_start" "$test_loop_wall_budget"; then
+            log_warn "Test-loop budget timeout at iteration $test_iteration"
+            set_final_state "wall_timeout_test"
+            DEGRADED_STAGES+=("test:wall_timeout_budget:iter=$test_iteration")
+            loop_complete=true
+            break
+        fi
+
+        if (( test_iteration > max_test_iter )); then
+            log_warn "Test loop exceeded max iterations ($max_test_iter). Soft-failing and continuing."
+            set_final_state "max_iterations_test"
+            DEGRADED_STAGES+=("test:max_iterations:iter=$test_iteration")
+            loop_complete=true
+            break
+        fi
+
+        log "Test loop iteration $test_iteration/$max_test_iter (scope: $change_scope)"
+
+        # =========================================================================
+        # COMBINED TEST EXECUTION + VALIDATION → single stage
+        # =========================================================================
+
+        # Compute explicit changed-file list (three-dot merge-base diff) for
+        # validation scope. Recomputed each iteration since fix stages may
+        # add commits. Filter to implementation-relevant files only —
+        # exclude .claude/ pipeline files, docs, and non-code configs.
+        local changed_files_raw changed_files
+        changed_files_raw=$(git -C "$loop_dir" diff "$BASE_BRANCH"...HEAD --name-only 2>/dev/null || true)
+        changed_files=$(printf '%s\n' "$changed_files_raw" | filter_implementation_files)
+
+        # Build BATS section.
+        # bash scope (.claude/scripts changes): BLOCKING — failures fail the stage.
+        # mixed scope: informational only — failures are reported but non-blocking.
+        local bats_section=""
+        if [[ "$change_scope" == "bash" ]]; then
+            bats_section="STEP 1c — PIPELINE BATS TESTS (BLOCKING)
+Run the pipeline BATS tests:
+cd $safe_dir && $bash_test_command
+
+BATS failures ARE a test failure — set result to 'failed' if any BATS test fails.
+Include bats_result ('passed', 'failed', or 'skipped') and bats_summary in output.
+
+"
+        elif [[ "$change_scope" == "mixed" ]]; then
+            bats_section="STEP 1c — PIPELINE BATS TESTS (informational only, non-blocking)
+Run the pipeline BATS tests:
+cd $safe_dir && $bash_test_command
+
+Report pass/fail. BATS failures are INFORMATIONAL ONLY — they do NOT count as overall test failure.
+Include bats_result ('passed', 'failed', or 'skipped') and bats_summary in output.
+Do NOT set result to 'failed' based on BATS test failures alone.
+
+"
+        fi
+
+        # Build validation section for the combined prompt
+        local validation_section=""
+        if [[ -n "$changed_files" ]]; then
+            validation_section="STEP 2 — TEST VALIDATION (only if all tests passed in Step 1)
+If tests failed in Step 1, set validation_result to 'skipped' and skip this step.
+
+Validate test comprehensiveness for issue #$ISSUE_NUMBER.
+
+CHANGED FILES (implementation-relevant only, .claude/ and docs excluded):
+$changed_files
+
+ONLY validate tests for these specific files. Do NOT expand scope beyond this list.
+
+IMPORTANT SCOPE CONSTRAINTS:
+- If NONE of the changed files contain testable code (e.g., config-only, style-only, docs-only changes), set validation_result to 'passed' immediately. Do NOT request new tests for non-logic changes.
+- Only validate tests for modified code files (services, routes, components, hooks, scripts)
+- Do NOT request tests for config files, static assets, or type-only changes
+
+PRE-EXISTING ISSUES POLICY:
+- If a test file has pre-existing quality issues NOT introduced by this PR, set validation_result to 'passed' and note them under 'pre_existing_issues'.
+- Only set validation_result to 'failed' for quality issues directly related to changed files in this PR.
+
+For each modified implementation file that warrants testing, identify the corresponding test file and audit:
+1. Check for TODO/FIXME/incomplete tests
+2. Check for hollow assertions (expect(true).toBe(true), no assertions)
+3. Verify edge cases and error conditions are tested
+4. Check for mock abuse patterns
+
+INTEGRATION TEST REQUIREMENT FOR API ROUTES (claude-pipeline#25):
+- If ANY changed file is an API route file (matches */routes/*.ts or */routes/*.js), there MUST be
+  an integration test that verifies the actual HTTP response shape (not just unit tests of service methods).
+- Unit tests that mock the service layer are NOT sufficient for route changes — the Fastify response schema
+  can silently strip fields via fast-json-stringify, which unit tests cannot catch.
+- If route files were changed but no integration test exists for the changed endpoint(s), set
+  validation_result to 'failed' and describe which endpoint(s) lack integration test coverage.
+- This is a HARD REQUIREMENT, not a suggestion. Do NOT pass with a note about missing integration tests."
+        else
+            validation_section="STEP 2 — TEST VALIDATION: SKIPPED
+No changed files detected vs $BASE_BRANCH. Set validation_result to 'skipped'."
+        fi
+
+        # Build E2E section if applicable
+        local e2e_section=""
+        if [[ -n "$e2e_command" ]]; then
+            e2e_section="STEP 1b — E2E TEST EXECUTION (only if unit tests passed in Step 1)
+If tests failed in Step 1, skip this step entirely.
+
+${e2e_rebuild_note}Run the E2E test suite:
+$e2e_command
+
+Report pass/fail. E2E failures count as overall test failure (set result to 'failed').
+Include e2e_result ('passed', 'failed', or 'skipped') and e2e_summary in output.
+
+"
+        fi
+
+        # Build Playwright skip notice if specs were found but no E2E runner configured
+        local playwright_notice=""
+        if [[ -n "$playwright_test_files" && -z "${TEST_E2E_CMD:-}" ]]; then
+            playwright_notice="
+NOTE: The following Playwright E2E specs were found in changed files but TEST_E2E_CMD is not configured.
+These files are NOT run by Jest — they require a Playwright runner. Skipping them.
+Files: $(echo "$playwright_test_files" | tr '\n' ', ')
+"
+        fi
+
+        # Run deterministic linter on changed test files BEFORE loading the
+        # test-validation skill. Findings are injected into the prompt so the
+        # LLM agent merges them verbatim into validation_issues. Gated by
+        # LINT_TEST_ASSERTIONS env var (default: enabled). Findings emitted
+        # as JSON array on stdout; empty array means no issues found.
+        local precheck_section=""
+        local lint_script="$SCRIPT_DIR/lint-test-assertions.sh"
+        if [[ "${LINT_TEST_ASSERTIONS:-1}" != "0" ]] \
+                && [[ -n "$changed_test_files" ]] \
+                && [[ -f "$lint_script" ]]; then
+            local -a precheck_files=()
+            local _ptf
+            while IFS= read -r _ptf; do
+                [[ -z "$_ptf" ]] && continue
+                precheck_files+=("$_ptf")
+            done <<< "$changed_test_files"
+
+            local precheck_json
+            precheck_json=$(cd "$loop_dir" \
+                && bash "$lint_script" "${precheck_files[@]}" 2>/dev/null \
+                || printf '[]')
+            if ! printf '%s' "$precheck_json" \
+                    | jq -e 'type == "array"' >/dev/null 2>&1; then
+                log_warn "lint-test-assertions.sh emitted non-array output — ignoring"
+                precheck_json="[]"
+            fi
+
+            local precheck_count
+            precheck_count=$(printf '%s' "$precheck_json" \
+                | jq 'length' 2>/dev/null || echo 0)
+
+            if (( precheck_count > 0 )); then
+                log "Deterministic pre-check identified" \
+                    "$precheck_count test-quality issue(s)"
+                precheck_section="
+
+Deterministic pre-checks already identified:
+The following test-quality issues were detected by lint-test-assertions.sh
+before this LLM validation stage. You MUST include each finding verbatim
+in your \`validation_issues\` array (preserving the file, line, pattern,
+snippet, and severity fields):
+
+$precheck_json
+"
+            fi
+        elif [[ "${LINT_TEST_ASSERTIONS:-1}" != "0" ]] \
+                && [[ -n "$changed_test_files" ]] \
+                && [[ ! -f "$lint_script" ]]; then
+            log_warn "lint-test-assertions.sh not found at $lint_script" \
+                "— skipping deterministic pre-check"
+        fi
+
+        local test_validation_skill
+        test_validation_skill=$(load_skill "test-validation")
+
+        local test_prompt="${test_validation_skill:+## Skill Instructions — READ AND FOLLOW THESE
+
+$test_validation_skill
+
+## End Skill Instructions
+
+}Run the test suite and validate test quality in working directory $safe_dir.
+
+STEP 1 — TEST EXECUTION
+Run the following command:
+$test_command
+
+Report pass/fail with test counts and failure details.
+If tests fail, set validation_result to 'skipped' (no point validating failing tests).
+${playwright_notice}
+${e2e_section}${bats_section}$validation_section${precheck_section}
+
+Output both test results and validation findings in one structured response.
+- result: 'passed' or 'failed' (from Jest test execution — BATS failures do NOT affect this)
+- summary: overall summary suitable for an issue comment
+- validation_result: 'passed', 'failed', or 'skipped'
+- validation_issues: array of issues found (if any)
+- pre_existing_issues: array of pre-existing quality issues (informational only)
+- validation_summary: summary of validation findings
+- e2e_result: 'passed', 'failed', or 'skipped' (from E2E execution, if applicable)
+- e2e_summary: summary of E2E test findings (if applicable)
+- bats_result: 'passed', 'failed', or 'skipped' (from BATS pipeline tests, informational only)
+- bats_summary: summary of BATS test findings (informational only)"
+
+        local test_result
+        test_result=$(run_stage "test-iter-$test_iteration" "$test_prompt" "implement-issue-test-validate.json" "default" "$loop_complexity")
+        _halt_if_budget_exceeded
+
+        # Handle timeout: skip result inspection and retry on next iteration
+        if is_stage_timeout "$test_result"; then
+            log_warn "Test stage timed out on iteration $test_iteration — retrying next iteration"
+            comment_issue "Test Loop: Timeout ($test_iteration/$max_test_iter)" "⏱️ Test stage timed out. Retrying on next iteration." ""
+            continue
+        fi
+
+        local test_status test_summary
+        test_status=$(printf '%s' "$test_result" | jq -r '.output.result')
+        test_summary=$(printf '%s' "$test_result" | jq -r '.output.summary // "Tests completed"')
+
+        local validate_status validate_summary
+        validate_status=$(printf '%s' "$test_result" | jq -r '.output.validation_result // "skipped"')
+        validate_summary=$(printf '%s' "$test_result" | jq -r '.output.validation_summary // ""')
+
+        # -----------------------------------------------------------------
+        # HANDLE TEST FAILURES
+        # -----------------------------------------------------------------
+        if [[ "$test_status" == "failed" ]]; then
+            comment_issue "Test Loop: Tests ($test_iteration/$max_test_iter)" "❌ **Result:** $test_status
+
+$test_summary" "default"
+            log "Tests failed. Getting failures and fixing..."
+            local failures
+            failures=$(printf '%s' "$test_result" | jq -c '.output.failures')
+
+            # Filter failures: only include failures from PR-changed test files.
+            # Explicit mode (changed_test_files non-empty): all failures are from
+            # PR-changed files since Jest ran only those files explicitly.
+            # Fallback mode (changed_test_files empty, --changedSince used): failures
+            # may be from dependency-pulled test files (pre-existing relative to this PR).
+            local pr_failures skipped_count
+            pr_failures="$failures"
+            skipped_count=0
+            if [[ -z "$changed_test_files" ]]; then
+                skipped_count=$(printf '%s' "$failures" | jq 'length // 0' 2>/dev/null || echo 0)
+                if (( skipped_count > 0 )); then
+                    log "INFO: Skipping $skipped_count pre-existing failure(s) — failures from --changedSince fallback are not from PR-changed test files"
+                    pr_failures="[]"
+                fi
+            fi
+
+            # If no PR-introduced failures remain, exit test loop gracefully.
+            # Pre-existing failures do not block the pipeline (consistent with validation policy).
+            local pr_failure_count
+            pr_failure_count=$(printf '%s' "$pr_failures" | jq 'length // 0' 2>/dev/null || echo 0)
+            if (( pr_failure_count == 0 )); then
+                log "INFO: All test failures are pre-existing. Skipping fix-agent dispatch."
+                if (( skipped_count > 0 )); then
+                    comment_issue "Test Loop: Pre-existing Failures ($test_iteration/$max_test_iter)" \
+                        "ℹ️ $skipped_count pre-existing failure(s) detected (not from PR-changed test files). Skipping fix-agent." "default"
+                fi
+                loop_complete=true
+                break
+            fi
+
+            # Skip fix agent when every remaining failure is an environment
+            # infrastructure error (Redis, DB, HTTP 500, network timeouts).
+            # Code changes cannot resolve infrastructure unavailability, so
+            # dispatching a fix agent would waste iterations and tokens.
+            if all_failures_environment_related "$pr_failures"; then
+                log "INFO: All failures are environment-related." \
+                    "Skipping fix-agent dispatch."
+                local env_title="Test Loop: Environment Errors"
+                env_title+=" ($test_iteration/$max_test_iter)"
+                local env_body
+                env_body="ℹ️ All test failures appear to be"
+                env_body+=" environment-related (Redis/DB connection"
+                env_body+=" errors, HTTP 500, network timeouts)."
+                env_body+=" These require infrastructure fixes, not code"
+                env_body+=" changes. Skipping fix-agent."
+                comment_issue "$env_title" "$env_body" ""
+                loop_complete=true
+                break
+            fi
+
+            # Convergence detection: exit early if same PR-scoped failures repeat 2 times
+            local failure_sig
+            failure_sig=$(printf '%s' "$pr_failures" | md5sum | cut -d' ' -f1)
+            prior_failure_sigs="${prior_failure_sigs} ${failure_sig}"
+            local sig_count
+            sig_count=$(printf '%s' "$prior_failure_sigs" | tr ' ' '\n' | grep -c "^${failure_sig}$" || true)
+            if (( sig_count >= 2 )); then
+                # Extract failure descriptions for both log and comment message
+                local failure_summaries
+                failure_summaries=$(printf '%s' "$pr_failures" | jq -r '.[] | "- \(.title): \(.description)"' 2>/dev/null || printf '')
+                log_warn "Test-fix convergence failure: same failures repeated $sig_count times. Breaking loop (soft exit).${failure_summaries:+ Failures: ${failure_summaries}}"
+
+                comment_issue "Test Loop: Convergence Failure (soft exit)" "⚠️ Same test failures repeated $sig_count times. Breaking test-fix loop to prevent waste. Pipeline will continue to docs/PR/complete stages.
+
+**Repeated Failures:**
+${failure_summaries}
+
+$test_summary" "default"
+                set_final_state "test_convergence_soft_exit"
+                loop_complete=true
+                break
+            fi
+
+            # Oscillation detection: check for A→B→A test failure cycling
+            if (( test_iteration > 2 )); then
+                local sig_list
+                sig_list="${prior_failure_sigs## }"  # trim leading space
+                local -a sigs_arr=($sig_list)
+                local arr_len=${#sigs_arr[@]}
+                if (( arr_len >= 3 )) && [[ "${sigs_arr[$((arr_len-1))]}" == "${sigs_arr[$((arr_len-3))]}" && "${sigs_arr[$((arr_len-1))]}" != "${sigs_arr[$((arr_len-2))]}" ]]; then
+                    local failure_summaries
+                    failure_summaries=$(printf '%s' "$pr_failures" | jq -r '.[] | "- \(.title): \(.description)"' 2>/dev/null || printf '')
+                    log_warn "Test-fix oscillation detected: failures cycling A→B→A. Breaking loop (soft exit)."
+                    comment_issue "Test Loop: Oscillation Detected (soft exit)" "⚠️ Test failures oscillating (A→B→A pattern). Breaking test-fix loop.
+
+**Current Failures:**
+${failure_summaries}
+
+$test_summary" "default"
+                    set_final_state "test_oscillation_soft_exit"
+                    DEGRADED_STAGES+=("test:oscillation:iter=$test_iteration")
+                    loop_complete=true
+                    break
+                fi
+            fi
+
+            local fix_prompt="${PLATFORM_PATTERNS_PREFIX}ENVIRONMENT NOTE: If failures mention Redis/database connection errors, HTTP 500 from route handlers, or similar infrastructure issues, these are environment issues not code bugs. Do NOT attempt to fix these — note them as environment-dependent and focus only on code-level failures.
+
+Fix ONLY the specific test failures listed below. Do NOT rewrite test files, introduce new dependencies, or modify pre-existing test code. Only fix the failing assertions.
+
+Working directory: $safe_dir
+Branch: $loop_branch
+
+Failures:
+$pr_failures
+
+Fix the issues and commit. Output a summary of fixes applied."
+
+            verify_on_feature_branch "$loop_branch" || true
+
+            local fix_result
+            fix_result=$(run_stage "fix-tests-iter-$test_iteration" "$fix_prompt" "implement-issue-fix.json" "$loop_agent" "$loop_complexity")
+            _halt_if_budget_exceeded
+
+            local fix_summary
+            fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
+
+            # Comment: Fix results
+            comment_issue "Test Loop: Test Fix ($test_iteration/$max_test_iter)" "$fix_summary" "$loop_agent"
+            continue
+        fi
+
+        # -----------------------------------------------------------------
+        # TESTS PASSED — check validation result
+        # -----------------------------------------------------------------
+        if [[ "$validate_status" == "passed" || "$validate_status" == "skipped" ]]; then
+            comment_issue "Test Loop: Results ($test_iteration/$max_test_iter)" "✅ **Tests:** passed
+✅ **Validation:** $validate_status
+
+$test_summary" "default"
+
+            loop_complete=true
+            log "Test loop complete on iteration $test_iteration (tests passed, validation: $validate_status)"
+        else
+            # Validation failed — fix quality issues
+            validation_fix_iteration=$((validation_fix_iteration + 1))
+
+            if (( validation_fix_iteration > MAX_VALIDATION_FIX_ITERATIONS )); then
+                log_warn "Validation fix loop exceeded max iterations ($MAX_VALIDATION_FIX_ITERATIONS). Soft-failing and continuing."
+                set_final_state "max_iterations_validation_fix"
+                DEGRADED_STAGES+=("validation_fix:max_iterations:iter=$validation_fix_iteration")
+                loop_complete=true
+                break
+            fi
+
+            comment_issue "Test Loop: Results ($test_iteration/$max_test_iter)" "✅ **Tests:** passed
+🔄 **Validation:** $validate_status
+
+$test_summary
+
+$validate_summary" "default"
+
+            log "Test validation found issues. Fixing... (validation fix iteration $validation_fix_iteration/$MAX_VALIDATION_FIX_ITERATIONS)"
+            local validate_issues
+            validate_issues=$(printf '%s' "$test_result" | jq -r '
+                if .output.validation_issues then (.output.validation_issues | tostring)
+                elif .output.validation_summary then .output.validation_summary
+                else "Fix test quality issues"
+                end
+            ')
+
+            local fix_prompt="${PLATFORM_PATTERNS_PREFIX}Address test quality issues in working directory $safe_dir on branch $loop_branch:
+
+$validate_issues
+
+SCOPE CONSTRAINT: Only fix quality issues in test files that correspond to PR-changed implementation files. Do not modify tests for unrelated implementation files.
+
+Fix the test quality issues (add missing assertions, remove TODOs, add edge case tests, etc.) and commit.
+Output a summary of fixes applied."
+
+            verify_on_feature_branch "$loop_branch" || true
+
+            # Pass loop_complexity so run_stage can route model selection by
+            # task size: S→haiku, M→sonnet, L→opus (via resolve_model).
+            local fix_result
+            fix_result=$(run_stage "fix-test-quality-iter-$test_iteration" "$fix_prompt" "implement-issue-fix.json" "$loop_agent" "$loop_complexity")
+            _halt_if_budget_exceeded
+
+            local fix_summary
+            fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
+
+            # Comment: Fix results
+            comment_issue "Test Loop: Validation Fix ($test_iteration/$max_test_iter)" "$fix_summary" "$loop_agent"
+        fi
+    done
+
+    return 0
+}
+
+# =============================================================================
+# DOCKER REBUILD + HEALTH CHECK HELPER
+#
+# Rebuilds frontend/backend containers and polls health endpoint.
+# Reusable by e2e_verify, acceptance_test, and test_loop stages.
+#
+# Arguments:
+#   $1 - base_url      (e.g., http://localhost:30004)
+#   $2 - timeout_secs  (default 120)
+#
+# Returns: 0 on success, 1 on failure
+# Outputs: JSON status object to stdout
+# =============================================================================
+
+rebuild_and_health_check() {
+	local base_url="${1:-http://localhost:30004}"
+	local timeout_secs="${2:-120}"
+	local start_ts
+	start_ts=$(date +%s)
+
+	local rebuild_status="success"
+
+	# Step 1: Rebuild containers
+	log "Rebuilding frontend + backend containers (--no-cache)..."
+	if ! docker-compose build --no-cache frontend backend 2>&1 \
+		| tail -5; then
+		log_error "Container rebuild failed"
+		rebuild_status="failed"
+		local elapsed=$(( $(date +%s) - start_ts ))
+		printf '{"rebuild":"%s","health":"skipped","elapsed_secs":%d}' \
+			"$rebuild_status" "$elapsed"
+		return 1
+	fi
+
+	# Step 2: Start containers
+	log "Starting containers..."
+	if ! docker-compose up -d frontend backend 2>&1; then
+		log_error "Container start failed"
+		rebuild_status="failed"
+		local elapsed=$(( $(date +%s) - start_ts ))
+		printf '{"rebuild":"%s","health":"skipped","elapsed_secs":%d}' \
+			"$rebuild_status" "$elapsed"
+		return 1
+	fi
+
+	# Step 3: Poll health endpoint
+	local health_url="${base_url}/health"
+	local deadline=$(( $(date +%s) + timeout_secs ))
+	log "Polling health endpoint: $health_url (timeout: ${timeout_secs}s)..."
+
+	while true; do
+		if curl -sf "$health_url" >/dev/null 2>&1; then
+			local elapsed=$(( $(date +%s) - start_ts ))
+			log "Health check passed in ${elapsed}s"
+			printf '{"rebuild":"%s","health":"healthy","elapsed_secs":%d}' \
+				"$rebuild_status" "$elapsed"
+			return 0
+		fi
+
+		if (( $(date +%s) >= deadline )); then
+			local elapsed=$(( $(date +%s) - start_ts ))
+			log_error \
+				"Health check timed out after ${timeout_secs}s"
+			printf '{"rebuild":"%s","health":"timeout","elapsed_secs":%d}' \
+				"$rebuild_status" "$elapsed"
+			return 1
+		fi
+
+		sleep 5
+	done
+}
+
+# =============================================================================
+# PARALLEL POST-TASK STAGES
+#
+# Runs e2e-verify and acceptance-test concurrently using bash & + wait.
+# docs runs sequentially after both complete (it modifies files).
+# Exit codes from both parallel stages are captured independently.
+# Stage timing is logged for each parallel stage.
+#
+# Arguments:
+#   $1 - branch          (feature branch name)
+#   $2 - branch_scope    (from detect_change_scope)
+#   $3 - pipeline_profile (minimal|standard|full)
+#   $4 - max_task_size   (S|M|L)
+# =============================================================================
+
+run_parallel_post_task_stages() {
+	local branch="$1"
+	local branch_scope="$2"
+	local pipeline_profile="$3"
+	local max_task_size="$4"
+
+	# ------------------------------------------------------------------
+	# Determine skip conditions sequentially before launching subshells.
+	# This avoids STATUS_FILE race conditions on set_stage_started writes.
+	# ------------------------------------------------------------------
+	local run_e2e=true run_acceptance=true
+
+	# E2E VERIFY skip logic
+	if [[ -n "$RESUME_MODE" ]] && is_stage_completed "e2e_verify"; then
+		log "Skipping e2e_verify stage (already completed)"
+		run_e2e=false
+	elif [[ -z "${TEST_E2E_CMD:-}" ]]; then
+		log "Skipping e2e_verify stage (TEST_E2E_CMD not configured)"
+		run_e2e=false
+	elif [[ "$branch_scope" != "frontend" \
+		&& "$branch_scope" != "ts-frontend" ]]; then
+		log "Skipping e2e_verify stage" \
+			"(scope '$branch_scope' is not frontend)"
+		run_e2e=false
+	fi
+
+	# ACCEPTANCE TEST skip logic
+	if [[ -n "$RESUME_MODE" ]] && is_stage_completed "acceptance_test"; then
+		log "Skipping acceptance_test stage (already completed)"
+		run_acceptance=false
+	elif [[ "$pipeline_profile" == "minimal" ]]; then
+		log "Skipping acceptance test: minimal profile (single S-task)"
+		run_acceptance=false
+	fi
+
+	# Handle skipped stages sequentially (no parallelism needed)
+	if ! $run_e2e; then
+		set_stage_started "e2e_verify"
+		set_stage_completed "e2e_verify"
+	fi
+	if ! $run_acceptance; then
+		set_stage_started "acceptance_test"
+		if [[ "$pipeline_profile" == "minimal" ]]; then
+			comment_issue "Acceptance Test: Skipped" \
+				"⏭️ Minimal profile (single S-task). Skipping acceptance test."
+		fi
+		set_stage_completed "acceptance_test"
+	fi
+
+	# Both skipped — nothing more to do
+	if ! $run_e2e && ! $run_acceptance; then
+		return 0
+	fi
+
+	# Mark running stages as started BEFORE parallelism (sequential,
+	# no STATUS_FILE write race).
+	$run_e2e && set_stage_started "e2e_verify"
+	$run_acceptance && set_stage_started "acceptance_test"
+
+	# ------------------------------------------------------------------
+	# Launch parallel stages
+	# ------------------------------------------------------------------
+	local e2e_pid="" acceptance_pid=""
+	local e2e_start=0 acceptance_start=0
+	# Temp files carry failure summaries out of subshells for sequential
+	# fix dispatch; avoids two fix agents committing to $branch concurrently.
+	local e2e_fail_file acceptance_fail_file
+	e2e_fail_file=$(mktemp)
+	acceptance_fail_file=$(mktemp)
+
+	if $run_e2e; then
+		e2e_start=$(date +%s)
+		log "Running E2E verification for frontend changes (parallel)..."
+		(
+			# Step 1: Rebuild containers and wait for health
+			local rebuild_json rebuild_rc
+			rebuild_json=$(rebuild_and_health_check \
+				"${TEST_E2E_BASE_URL:-http://localhost:30004}" 120) \
+				|| true
+			rebuild_rc=$?
+			local rebuild_status health_status
+			rebuild_status=$(printf '%s' "$rebuild_json" \
+				| jq -r '.rebuild // "skipped"')
+			health_status=$(printf '%s' "$rebuild_json" \
+				| jq -r '.health // "skipped"')
+
+			if ((rebuild_rc != 0)); then
+				log_error "Container rebuild/health failed — skipping E2E"
+				comment_issue "E2E Verification: Skipped" \
+					"⚠️ Container rebuild or health check failed. \
+Rebuild: $rebuild_status, Health: $health_status. \
+E2E tests skipped." "playwright-test-developer"
+				exit 1
+			fi
+
+			# Step 2: Build targeted test command
+			local e2e_cmd
+			e2e_cmd=$(_build_targeted_e2e_cmd "$BASE_BRANCH")
+
+			# Step 3: Run E2E tests
+			local e2e_verify_prompt
+			e2e_verify_prompt="Run E2E tests to verify the frontend \
+changes for issue #$ISSUE_NUMBER.
+
+CONTAINER STATUS:
+Rebuild: $rebuild_status | Health: $health_status
+
+TEST COMMAND:
+$e2e_cmd
+
+BASE URL: ${TEST_E2E_BASE_URL:-http://localhost:30004}
+
+SCREENSHOT DIRECTORY: test-results/
+
+INSTRUCTIONS:
+1. Run the E2E test suite using the command above
+2. If tests fail, report the failures with details about what \
+visual/behavioral issues were found
+3. Include screenshot paths from test-results/ in your report
+4. Focus on verifying user-visible behavior: layout, interactions, \
+navigation, visual regressions
+
+Report result as 'passed' or 'failed' with a detailed summary."
+
+			local e2e_verify_result
+			e2e_verify_result=$(run_stage "e2e-verify" \
+				"$e2e_verify_prompt" \
+				"implement-issue-e2e-validate.json" \
+				"playwright-test-developer")
+			_halt_if_budget_exceeded
+
+			local e2e_verify_status e2e_verify_summary
+			e2e_verify_status=$(printf '%s' "$e2e_verify_result" \
+				| jq -r '.output.result')
+			e2e_verify_summary=$(printf '%s' "$e2e_verify_result" \
+				| jq -r '.output.summary // "E2E verification completed"')
+
+			local e2e_icon="✅"
+			[[ "$e2e_verify_status" == "failed" ]] \
+				&& e2e_icon="❌"
+			comment_issue "E2E Verification" \
+				"$e2e_icon **Result:** $e2e_verify_status
+Container rebuild: $rebuild_status | Health: $health_status
+
+$e2e_verify_summary" "playwright-test-developer"
+
+			if [[ "$e2e_verify_status" == "failed" ]]; then
+				# Write summary for sequential fix dispatch after wait.
+				# Fixes must not run concurrently with acceptance fixes
+				# to prevent two agents committing to $branch at once.
+				printf '%s' "$e2e_verify_summary" > "$e2e_fail_file"
+				exit 1
+			fi
+		) &
+		e2e_pid=$!
+		_bg_pids+=("$e2e_pid")
+	fi
+
+	if $run_acceptance; then
+		acceptance_start=$(date +%s)
+		(
+			# Check if any changed files are API route files
+			local changed_route_files
+			changed_route_files=$(git diff "$BASE_BRANCH"...HEAD \
+				--name-only \
+				-- '*/routes/*.ts' '*/routes/*.js' \
+				2>/dev/null || true)
+
+			if [[ -z "$changed_route_files" ]]; then
+				log "No API route files changed" \
+					"— skipping acceptance test"
+				comment_issue "Acceptance Test: Skipped" \
+					"⏭️ No API route files changed. Skipping endpoint verification." \
+					"default"
+			elif ! command -v docker &>/dev/null \
+				&& ! command -v docker-compose &>/dev/null; then
+				log_warn \
+					"Docker not available — skipping acceptance test"
+				comment_issue "Acceptance Test: Skipped" \
+					"⚠️ Docker not available. Endpoint verification skipped. Manual verification recommended before merge." \
+					"default"
+			else
+				log "API route files changed — running acceptance test"
+				log "Changed routes: $changed_route_files"
+
+				local acceptance_prompt
+				acceptance_prompt="Verify the fix for issue \
+#$ISSUE_NUMBER works against running services.
+
+CHANGED API ROUTE FILES:
+$changed_route_files
+
+ACCEPTANCE CRITERIA (from issue):
+$("$PLATFORM_DIR/read-issue.sh" "$ISSUE_NUMBER" 2>/dev/null \
+	| jq -r '.body' \
+	| awk '/^## Acceptance Criteria/{found=1; next} \
+		found && /^## /{exit} found{print}')
+
+STEPS:
+1. Check if Docker containers are running \
+(docker compose ps or docker-compose ps)
+2. If containers are not running, try to start them \
+(docker compose up -d) — if this fails, skip with a warning
+3. For each changed route file, identify the endpoint(s) \
+that were modified
+4. Hit each modified endpoint with a real HTTP request \
+(use curl or node http module from inside the container)
+5. Verify the response shape matches what the acceptance criteria expect
+6. If the response is wrong, report 'failed' with details about \
+what was expected vs actual
+
+Output result as 'passed' or 'failed' with a detailed summary."
+
+				local acceptance_result
+				acceptance_result=$(run_stage "acceptance-test" \
+					"$acceptance_prompt" \
+					"implement-issue-test.json" \
+					"default")
+				_halt_if_budget_exceeded
+
+				local acceptance_status acceptance_summary
+				acceptance_status=$(printf '%s' "$acceptance_result" \
+					| jq -r '.output.result')
+				acceptance_summary=$(printf '%s' "$acceptance_result" \
+					| jq -r \
+					'.output.summary // "Acceptance test completed"')
+
+				local acceptance_icon="✅"
+				[[ "$acceptance_status" == "failed" ]] \
+					&& acceptance_icon="❌"
+				comment_issue "Acceptance Test" \
+					"$acceptance_icon **Result:** $acceptance_status
+
+$acceptance_summary" "default"
+
+				if [[ "$acceptance_status" == "failed" ]]; then
+					# Write summary for sequential fix dispatch after wait.
+					# Fixes must not run concurrently with e2e fixes
+					# to prevent two agents committing to $branch at once.
+					printf '%s' "$acceptance_summary" \
+						> "$acceptance_fail_file"
+					exit 1
+				fi
+			fi
+		) &
+		acceptance_pid=$!
+		_bg_pids+=("$acceptance_pid")
+	fi
+
+	# ------------------------------------------------------------------
+	# Wait for both parallel stages; capture exit codes independently.
+	# ------------------------------------------------------------------
+	local e2e_exit=0 acceptance_exit=0
+	local e2e_elapsed=0 acceptance_elapsed=0
+
+	if [[ -n "$e2e_pid" ]]; then
+		wait "$e2e_pid"
+		e2e_exit=$?
+		e2e_elapsed=$(( $(date +%s) - e2e_start ))
+		log "Stage timing: e2e-verify completed in ${e2e_elapsed}s" \
+			"(exit=$e2e_exit)"
+		if ((e2e_exit != 0)); then
+			log_warn \
+				"e2e-verify stage exited with code $e2e_exit"
+		fi
+	fi
+
+	if [[ -n "$acceptance_pid" ]]; then
+		wait "$acceptance_pid"
+		acceptance_exit=$?
+		acceptance_elapsed=$(( $(date +%s) - acceptance_start ))
+		log "Stage timing: acceptance-test completed in" \
+			"${acceptance_elapsed}s (exit=$acceptance_exit)"
+		if ((acceptance_exit != 0)); then
+			log_warn \
+				"acceptance-test stage exited with code $acceptance_exit"
+		fi
+	fi
+
+	# Issue #583: a parallel stage (e2e/acceptance) may have tripped the run
+	# budget inside its background subshell.  Halt in the PARENT shell BEFORE
+	# dispatching any sequential fix stage, so no fix CLI call runs post-breach.
+	_halt_if_budget_exceeded
+
+	# ------------------------------------------------------------------
+	# Sequential fix dispatch: if a stage failed, dispatch fix agents
+	# one at a time to avoid concurrent commits to $branch.
+	# ------------------------------------------------------------------
+	if [[ -s "$e2e_fail_file" ]]; then
+		local e2e_fail_summary
+		e2e_fail_summary=$(<"$e2e_fail_file")
+		local max_e2e_fixes="${MAX_E2E_FIX_ITERATIONS:-2}"
+		local e2e_fix_iter=0
+		local e2e_fixed=false
+
+		while ((e2e_fix_iter < max_e2e_fixes)); do
+			e2e_fix_iter=$((e2e_fix_iter + 1))
+			log_error \
+				"E2E verification failed" \
+				"— fix iteration $e2e_fix_iter/$max_e2e_fixes"
+
+			local e2e_fix_prompt
+			e2e_fix_prompt="E2E tests for issue #$ISSUE_NUMBER \
+FAILED (attempt $e2e_fix_iter/$max_e2e_fixes). The unit tests passed \
+but E2E tests found visual/behavioral issues.
+
+Failure details:
+$e2e_fail_summary
+
+SCREENSHOT DIRECTORY: test-results/
+Check test-results/ for failure screenshots to diagnose visual issues.
+
+Fix the frontend code to resolve these E2E failures. Do NOT modify \
+the test files — fix the implementation code.
+Commit your changes."
+
+			verify_on_feature_branch "$branch" || true
+
+			local e2e_fix_result
+			e2e_fix_result=$(run_stage \
+				"fix-e2e-iter-$e2e_fix_iter" \
+				"$e2e_fix_prompt" \
+				"implement-issue-fix.json" \
+				"$AGENT" \
+				"$max_task_size")
+			_halt_if_budget_exceeded
+
+			local e2e_fix_summary
+			e2e_fix_summary=$(printf '%s' "$e2e_fix_result" \
+				| jq -r '.output.summary // "Fix applied"')
+			comment_issue "E2E Fix (iteration $e2e_fix_iter)" \
+				"🔧 $e2e_fix_summary" "$AGENT"
+
+			# Rebuild containers if fix changed Docker-relevant files
+			local docker_changes
+			docker_changes=$(git diff HEAD~1 --name-only \
+				-- 'Dockerfile*' 'docker-compose*' 'Containerfile*' \
+				2>/dev/null || true)
+			if [[ -n "$docker_changes" ]]; then
+				log "Fix changed Docker files — rebuilding containers"
+				rebuild_and_health_check \
+					"${TEST_E2E_BASE_URL:-http://localhost:30004}" \
+					120 >/dev/null 2>&1 || true
+			fi
+
+			# Re-run E2E tests
+			local rerun_cmd
+			rerun_cmd=$(_build_targeted_e2e_cmd "$BASE_BRANCH")
+
+			local rerun_prompt
+			rerun_prompt="Re-run E2E tests after fix iteration \
+$e2e_fix_iter for issue #$ISSUE_NUMBER.
+
+TEST COMMAND:
+$rerun_cmd
+
+BASE URL: ${TEST_E2E_BASE_URL:-http://localhost:30004}
+
+SCREENSHOT DIRECTORY: test-results/
+
+Report result as 'passed' or 'failed' with a detailed summary."
+
+			local rerun_result
+			rerun_result=$(run_stage \
+				"e2e-verify-rerun-iter-$e2e_fix_iter" \
+				"$rerun_prompt" \
+				"implement-issue-e2e-validate.json" \
+				"playwright-test-developer")
+			_halt_if_budget_exceeded
+
+			local rerun_status rerun_summary
+			rerun_status=$(printf '%s' "$rerun_result" \
+				| jq -r '.output.result')
+			rerun_summary=$(printf '%s' "$rerun_result" \
+				| jq -r '.output.summary // "E2E rerun completed"')
+
+			local rerun_icon="✅"
+			[[ "$rerun_status" == "failed" ]] && rerun_icon="❌"
+			comment_issue \
+				"E2E Verification (rerun $e2e_fix_iter)" \
+				"$rerun_icon **Result:** $rerun_status
+
+$rerun_summary" "playwright-test-developer"
+
+			if [[ "$rerun_status" == "passed" ]]; then
+				e2e_fixed=true
+				break
+			fi
+
+			# Update failure summary for next iteration
+			e2e_fail_summary="$rerun_summary"
+		done
+
+		if ! $e2e_fixed; then
+			log_warn "E2E failed after $max_e2e_fixes fix attempts" \
+				"— proceeding with soft failure"
+			comment_issue "E2E Verification: Soft Failure" \
+				"⚠️ E2E tests still failing after $max_e2e_fixes \
+fix attempts. Manual intervention needed before PR merge.
+
+Last failure:
+$e2e_fail_summary" "playwright-test-developer"
+		fi
+	fi
+
+	if [[ -s "$acceptance_fail_file" ]]; then
+		local acceptance_fail_summary
+		acceptance_fail_summary=$(<"$acceptance_fail_file")
+		log_error \
+			"Acceptance test failed" \
+			"— dispatching implementation agent to fix"
+
+		local acceptance_fix_prompt
+		acceptance_fix_prompt="The acceptance test for \
+issue #$ISSUE_NUMBER FAILED. The unit tests passed but the fix does \
+not work when tested against the actual running endpoint.
+
+Failure details:
+$acceptance_fail_summary
+
+Common causes:
+- Response field names don't match what the frontend/consumer expects
+- Fastify response schema strips fields via fast-json-stringify
+- Docker container running stale code (may need rebuild)
+- Database migration not applied
+
+Investigate the root cause and fix the issue. Commit your changes."
+
+		verify_on_feature_branch "$branch" || true
+
+		local acceptance_fix_result
+		acceptance_fix_result=$(run_stage \
+			"fix-acceptance-test" \
+			"$acceptance_fix_prompt" \
+			"implement-issue-fix.json" \
+			"$AGENT")
+		_halt_if_budget_exceeded
+
+		local acceptance_fix_summary
+		acceptance_fix_summary=$(printf '%s' \
+			"$acceptance_fix_result" \
+			| jq -r '.output.summary // "Fix applied"')
+		comment_issue "Acceptance Test Fix" \
+			"$acceptance_fix_summary" "$AGENT"
+	fi
+
+	# Clean up temp files
+	rm -f "$e2e_fail_file" "$acceptance_fail_file"
+
+	# Mark completed AFTER parallelism (sequential writes, no race)
+	$run_e2e && set_stage_completed "e2e_verify"
+	$run_acceptance && set_stage_completed "acceptance_test"
+
+	log "Parallel post-task stages complete:" \
+		"e2e_exit=$e2e_exit acceptance_exit=$acceptance_exit"
+
+	return 0
+}
+
+# _handle_merge_pr_timeout <cmd_label> <limit_secs>
+# Sets current_stage to merge_pr_timeout, calls set_final_state "error",
+# and exits 1.  Called on any per-command timeout inside merge_pr stage.
+_handle_merge_pr_timeout() {
+	local cmd_label="$1"
+	local limit_secs="$2"
+	log_error "merge_pr: ${cmd_label} timed out after ${limit_secs}s"
+	set_stage_started "merge_pr_timeout"
+	set_final_state "error"
+	exit 1
+}
+
+# =============================================================================
+# PRIOR-PR LOOKUP HELPER
+# =============================================================================
+#
+# _prior_merged_prs_for_issue <issue_number> [exclude_pr_number]
+#
+# Queries the GitHub issue timeline API and emits one record per merged PR
+# that was cross-referenced from the issue. Each record is a single line in
+# the form:
+#   PR#|title|merged_at|file1,file2,...
+#
+# Purpose: the pr-review stage builds its diff with `git diff base...HEAD`,
+# which contains only the current PR's commits. On multi-PR issues the
+# reviewer cannot see what prior merged PRs already shipped to main, so it
+# reports those acceptance criteria as missing. This helper surfaces the
+# prior PRs so the prompt-construction code can inject a "Prior Merged PRs"
+# context block.
+#
+# Gating: TRACKER must be "github" (default). On any other tracker, on a
+# missing issue number, or when the gh API call fails, the function emits
+# no output and returns 0 — callers see "no prior PRs" and behave as today.
+#
+# Arguments:
+#   $1 - issue number (required; non-empty)
+#   $2 - PR number to exclude from output (optional; e.g. the current PR
+#        being reviewed, so the reviewer never sees its own diff listed
+#        as a prior PR)
+#
+# Stdout: zero or more newline-delimited records, no trailing blank line.
+# Stderr: warnings via log_warn on recoverable lookup failures.
+# Returns: always 0 — callers must check whether stdout is empty, not exit
+#          status, to decide whether to inject the section.
+_prior_merged_prs_for_issue() {
+	local issue_number="${1:-$ISSUE_NUMBER}"
+	local exclude_pr="${2:-}"
+
+	# Gate: only the GitHub timeline endpoint is supported. Jira/GitLab
+	# return silently — the caller's prompt is unchanged.
+	[[ "${TRACKER:-github}" == "github" ]] || return 0
+	[[ -n "$issue_number" ]] || return 0
+
+	# Resolve owner/repo for the timeline endpoint. `gh repo view` reads
+	# the current git remote; failure here means we're not in a gh-aware
+	# checkout and the lookup cannot proceed.
+	local repo
+	repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner' \
+		2>/dev/null)
+	if [[ -z "$repo" ]]; then
+		log_warn "_prior_merged_prs_for_issue: could not resolve" \
+			"repo via gh repo view; skipping prior-PR lookup"
+		return 0
+	fi
+
+	# Query the timeline for cross-referenced events whose source is a
+	# merged PR. --paginate yields one JSON array per page; jq -cs 'add'
+	# below flattens them into a single array.
+	local timeline_json
+	timeline_json=$(GH_PAGER='' gh api \
+		"repos/${repo}/issues/${issue_number}/timeline" \
+		--paginate \
+		--jq '[
+			.[]
+			| select(.event == "cross-referenced"
+				and .source.issue.pull_request.merged_at
+					!= null)
+			| {pr: .source.issue.number,
+			   title: .source.issue.title,
+			   merged: .source.issue.pull_request.merged_at}
+		]' 2>/dev/null)
+
+	if [[ -z "$timeline_json" || "$timeline_json" == "null" ]]; then
+		return 0
+	fi
+
+	local merged_prs
+	merged_prs=$(printf '%s' "$timeline_json" \
+		| jq -cs 'add // []' 2>/dev/null)
+	[[ -z "$merged_prs" || "$merged_prs" == "[]" ]] && return 0
+
+	# Walk the merged-PR array and emit one pipe-delimited record per PR.
+	# A second gh call per PR fetches its changed files — bounded by the
+	# number of prior PRs (typically 1–3 on real issues).
+	local pr_count
+	pr_count=$(printf '%s' "$merged_prs" | jq 'length' 2>/dev/null)
+	[[ -z "$pr_count" || "$pr_count" == "0" ]] && return 0
+
+	local i=0 pr_num pr_title pr_merged pr_files
+	while ((i < pr_count)); do
+		pr_num=$(printf '%s' "$merged_prs" \
+			| jq -r ".[$i].pr // empty" 2>/dev/null)
+		if [[ -z "$pr_num" ]]; then
+			((i++))
+			continue
+		fi
+		if [[ -n "$exclude_pr" && "$pr_num" == "$exclude_pr" ]]; then
+			((i++))
+			continue
+		fi
+		pr_title=$(printf '%s' "$merged_prs" \
+			| jq -r ".[$i].title // \"\"" 2>/dev/null)
+		pr_merged=$(printf '%s' "$merged_prs" \
+			| jq -r ".[$i].merged // \"\"" 2>/dev/null)
+
+		# Comma-delimited file list; empty string if the lookup fails.
+		# We use gh pr view (auto-detects repo) rather than gh api to
+		# keep this consistent with other gh calls in this script.
+		pr_files=$(gh pr view "$pr_num" \
+			--repo "$repo" \
+			--json files \
+			--jq '[.files[].path] | join(",")' 2>/dev/null)
+		pr_files="${pr_files:-}"
+
+		printf '%s|%s|%s|%s\n' \
+			"$pr_num" "$pr_title" "$pr_merged" "$pr_files"
+		((i++)) || true
+	done
+	return 0
+}
+
+# =============================================================================
+# MAIN FLOW
+# =============================================================================
+
+main() {
+    # Declare local variables used throughout main
+    local branch tasks_json task_count completed_tasks max_task_size="" pipeline_profile=""
+
+    # -------------------------------------------------------------------------
+    # RESUME VS FRESH START INITIALIZATION
+    # -------------------------------------------------------------------------
+    if [[ -n "$RESUME_MODE" ]]; then
+        log "=========================================="
+        log "Implement Issue Orchestrator RESUMING"
+        log "=========================================="
+        log "Issue: #$ISSUE_NUMBER"
+        log "Branch: $BRANCH"
+        log "Resume stage: $RESUME_STAGE"
+        log "Resume task: ${RESUME_TASK:-none}"
+        log "Log dir: $LOG_BASE"
+
+        # Use values from resume state
+        branch="$BRANCH"
+        tasks_json="$RESUME_TASKS_JSON"
+
+        # Update status to indicate resumption
+        jq --arg state "running" \
+           '.state = $state | .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+        sync_status_to_log
+
+        # Comment on issue about resumption
+        comment_issue "Resuming Automated Processing" "Resuming processing of issue #$ISSUE_NUMBER.
+
+**Resuming from stage:** \`$RESUME_STAGE\`
+**Branch:** \`$branch\`
+
+Log directory: \`$LOG_BASE\`"
+
+    else
+        log "=========================================="
+        log "Implement Issue Orchestrator Starting"
+        log "=========================================="
+        log "Issue: #$ISSUE_NUMBER"
+        log "Branch: $BASE_BRANCH"
+        log "Agent: ${AGENT:-default}"
+        log "Log dir: $LOG_BASE"
+
+        init_status
+
+        # -------------------------------------------------------------------------
+        # COMMENT #1: Starting automated processing
+        # -------------------------------------------------------------------------
+        comment_issue "Starting Automated Processing" "Processing issue #$ISSUE_NUMBER against branch \`$BASE_BRANCH\`.
+
+**Stages:**
+1. Parse issue (extract tasks from issue body)
+2. Validate plan (verify references exist)
+3. Implement tasks with self-review (per-task quality loop: simplify, review)
+4. Test loop (run tests, fix failures)
+5. Documentation
+6. Create/update PR
+7. PR review loop (combined spec + code review)
+
+Log directory: \`$LOG_BASE\`"
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: PARSE ISSUE (extract tasks from issue body)
+    # -------------------------------------------------------------------------
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "parse_issue"; then
+        log "Skipping parse_issue stage (already completed)"
+    else
+        set_stage_started "parse_issue"
+
+        log "Fetching issue #$ISSUE_NUMBER..."
+        local issue_body
+        issue_body=$("$PLATFORM_DIR/read-issue.sh" "$ISSUE_NUMBER" 2>>"${LOG_FILE:-/dev/stderr}" | jq -r '.body')
+
+        if [[ -z "$issue_body" ]]; then
+            log_error "Failed to fetch issue #$ISSUE_NUMBER body"
+            set_final_state "error"
+            exit 1
+        fi
+
+        # Save issue body for reference
+        printf '%s\n' "$issue_body" > "$LOG_BASE/context/issue-body.md"
+
+        # Extract tasks from ## Implementation Tasks section
+        # Format: - [ ] `[agent-name]` Task description
+        log "Parsing implementation tasks from issue body..."
+        # Section slice via the shared _extract_tasks_section helper, which
+        # mirrors _issue_body_tasks_section exactly (CRLF-tolerant, heading
+        # matched case-insensitively and UNANCHORED via ISSUE_TASKS_HEADING_ERE)
+        # so "## implementation tasks", "## Implementation Tasks (draft)", and
+        # CRLF bodies all parse.  Using the one helper (rather than an inline awk
+        # literal) keeps this path, the resume grep guard, and the tests from
+        # ever drifting apart.
+        local tasks_section
+        tasks_section=$(_extract_tasks_section "$issue_body")
+
+        if [[ -z "$tasks_section" ]]; then
+            log_error "No 'Implementation Tasks' section found in issue #$ISSUE_NUMBER"
+            set_final_state "error"
+            exit 1
+        fi
+
+        # Parse tasks using fuzzy parser (handles missing backticks, asterisk
+        # bullets, leading whitespace, and missing square brackets; warns on stderr)
+        tasks_json=$(_parse_task_lines "$tasks_section")
+
+        local task_count
+        task_count=$(printf '%s' "$tasks_json" | jq length)
+
+        if (( task_count == 0 )); then
+            # LOUD failure (issue #584): rather than dump a raw body excerpt and
+            # leave the operator guessing, run the shared preflight lint and
+            # report WHY each in-section candidate line was rejected
+            # (format / agent-unresolved / path-unresolved).  This replaces the
+            # silent per-line `continue` drop in _parse_task_lines with an
+            # actionable, per-line report before the run aborts.
+            #
+            # The library is sourced inside a subshell so its helper definitions
+            # (e.g. _infer_agent_from_path, which the orchestrator defines with
+            # different internals) never collide with this script's own.
+            local lint_report=""
+            if [[ -f "$SCRIPT_DIR/issue-body-lib.sh" ]]; then
+                lint_report=$(
+                    source "$SCRIPT_DIR/issue-body-lib.sh" 2>/dev/null \
+                        && lint_task_lines "$issue_body"
+                )
+            fi
+
+            log_error "No parseable tasks found in issue #$ISSUE_NUMBER's '## Implementation Tasks' section."
+            if [[ -n "$lint_report" ]]; then
+                log_error "Per-line rejection report (cause <TAB> line):"
+                local _lint_line
+                while IFS= read -r _lint_line; do
+                    [[ -z "$_lint_line" ]] && continue
+                    log_error "  rejected: $_lint_line"
+                done <<< "$lint_report"
+                log_error "Fix: each task must be '- [ ] \`[agent-name]\` **(S)** desc — \`path\`'. See plugins/pipeline-core/skills/explore/SKILL.md (Task Format Specification)."
+            else
+                local excerpt="${issue_body:0:500}"
+                log_error "Preflight lint found no candidate lines to classify. Issue body excerpt (first 500 chars):
+---
+$excerpt
+---"
+            fi
+            set_final_state "error"
+            exit 1
+        fi
+
+        log "Extracted $task_count tasks from issue body"
+
+        # Compute parallelizable batch assignments for all tasks.
+        # Tasks whose inferred file sets do not overlap are grouped into the
+        # same batch; tasks sharing files are placed in sequential batches.
+        log "Computing task batch assignments for dependency-aware scheduling..."
+        tasks_json=$(compute_task_batches "$tasks_json" "${BASE_BRANCH:-main}")
+
+        # Log the batch groupings so operators can see the scheduling decision
+        printf '%s' "$tasks_json" | jq -r '
+            ([.[].batch] | max) as $max_batch |
+            "Batch groupings: \($max_batch) sequential batch(es) across \(length) tasks" ,
+            (range(1; $max_batch + 1) as $b |
+              "  Batch \($b) (can run in parallel): tasks \([
+                .[] | select(.batch == $b) | "#\(.id)"
+              ] | join(", "))")
+        ' | while IFS= read -r line; do
+            log "$line"
+        done
+
+        set_tasks "$tasks_json"
+        printf '%s\n' "$tasks_json" > "$LOG_BASE/context/tasks.json"
+
+        # Create or checkout feature branch
+        branch="feature/issue-${ISSUE_NUMBER}"
+        log "Setting up feature branch: $branch"
+
+        if git show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null; then
+            log "Branch $branch already exists, checking out"
+            git checkout "$branch" 2>/dev/null
+        else
+            log "Creating branch $branch from $BASE_BRANCH"
+            git checkout -b "$branch" "$BASE_BRANCH" 2>/dev/null
+        fi
+
+        set_branch_info "$branch"
+
+        set_stage_completed "parse_issue"
+        log "Parse issue complete. Branch: $branch, Tasks: $task_count"
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: TRIAGE (classify route — fast-path or full)
+    # -------------------------------------------------------------------------
+    local triage_route
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "triage"; then
+        triage_route=$(jq -r '.route // "full"' "$STATUS_FILE")
+        log "Skipping triage stage (already completed). Route: $triage_route"
+    else
+        triage_route=$(run_triage_stage)
+    fi
+
+    if [[ "$triage_route" == "fast-path" ]]; then
+        log "Triage routes to surgical fast-path. Handing off to surgical-fast-path.sh"
+        export STATUS_FILE LOG_BASE ISSUE_NUMBER BASE_BRANCH SCHEMA_DIR CLAUDE_CLI
+        export BRANCH="${branch:-$(jq -r '.branch // ""' "$STATUS_FILE")}"
+        exec "$SCRIPT_DIR/surgical-fast-path.sh"
+    fi
+    log "Triage routes to full pipeline."
+
+    # -------------------------------------------------------------------------
+    # PIPELINE PROFILE: classify complexity now that task sizes are known
+    # -------------------------------------------------------------------------
+    pipeline_profile=$(compute_pipeline_profile "$tasks_json")
+    log "Pipeline profile: $pipeline_profile"
+    # TODO(issue-XX): wire pipeline_profile to stage-selection logic so that
+    # 'minimal' skips optional quality/simplify stages and 'full' enforces them.
+
+    # -------------------------------------------------------------------------
+    # WALL-CLOCK BUDGET: phase-budget floor then complexity bump
+    #
+    # Step 1 — Phase-budget floor: raise MAX_ORCHESTRATOR_WALL_TIME to at
+    #   least the sum of all per-phase budgets (calc_orchestrator_wall_time).
+    #   Computed here — after all env vars have taken effect — so env
+    #   overrides to per-phase budgets are reflected in the floor.
+    #
+    # Step 2 — Complexity bump: add 1800s per L-sized task on top of the
+    #   already-floored base, capped at 4x to limit runaway wall times.
+    # -------------------------------------------------------------------------
+    local l_task_count base_wall_time max_wall_time wall_time_bump
+    l_task_count=$(printf '%s' "$tasks_json" | jq -r '.[].description' \
+        | while IFS= read -r d; do
+            s=$(extract_task_size "$d")
+            [[ -n "$s" ]] && printf '%s\n' "$s"
+          done \
+        | grep -c '^L$' || true)
+
+    # Step 1: phase-budget floor
+    local phase_budget_sum
+    phase_budget_sum=$(calc_orchestrator_wall_time)
+    if (( MAX_ORCHESTRATOR_WALL_TIME < phase_budget_sum )); then
+        log "Wall-clock budget raised to phase-budget sum:" \
+            "${MAX_ORCHESTRATOR_WALL_TIME}s → ${phase_budget_sum}s"
+        MAX_ORCHESTRATOR_WALL_TIME=$phase_budget_sum
+    fi
+
+    # Step 2: complexity bump
+    base_wall_time="$MAX_ORCHESTRATOR_WALL_TIME"
+    max_wall_time=$(( base_wall_time * 4 ))
+    wall_time_bump=$(( l_task_count * 1800 ))
+    MAX_ORCHESTRATOR_WALL_TIME=$(( base_wall_time + wall_time_bump ))
+    if (( MAX_ORCHESTRATOR_WALL_TIME > max_wall_time )); then
+        MAX_ORCHESTRATOR_WALL_TIME=$max_wall_time
+    fi
+    if (( wall_time_bump > 0 )); then
+        log "Complexity-adjusted wall-clock budget: ${base_wall_time}s + ${wall_time_bump}s (${l_task_count} L-task(s)) = ${MAX_ORCHESTRATOR_WALL_TIME}s (cap: ${max_wall_time}s)"
+    else
+        log "Wall-clock budget: ${MAX_ORCHESTRATOR_WALL_TIME}s (no L-tasks, no adjustment)"
+    fi
+
+    # -------------------------------------------------------------------------
+    # EARLY SCOPE CHECK: config-only bypass
+    # If all branch changes are config/doc files only, skip implement/test stages
+    # and jump directly to PR creation.
+    # Only applies when the branch already has commits (e.g., resuming a branch
+    # with config-only changes). A fresh branch with zero commits must proceed
+    # to implementation regardless of scope.
+    # -------------------------------------------------------------------------
+    local early_scope="code"
+    local early_commit_count
+    local _vp_git_exit
+    early_commit_count=$(timeout "$VALIDATE_PLAN_GIT_TIMEOUT" \
+        git rev-list --count "${BASE_BRANCH}..${branch}" 2>/dev/null)
+    _vp_git_exit=$?
+    if (( _vp_git_exit == 124 )); then
+        log_warn "validate_plan: git rev-list timed out after" \
+            "${VALIDATE_PLAN_GIT_TIMEOUT}s — defaulting to 0 commits"
+        early_commit_count=0
+    elif (( _vp_git_exit != 0 )); then
+        early_commit_count=0
+    fi
+
+    if (( early_commit_count > 0 )); then
+        early_scope=$(detect_change_scope "." "$BASE_BRANCH")
+        log "Early scope check: $early_scope (${early_commit_count} commits on branch)"
+    else
+        log "Early scope check: skipped (fresh branch, 0 commits)"
+    fi
+
+    if [[ "$early_scope" == "config" ]]; then
+        log "Config-only scope detected — skipping implement/quality/test stages"
+        if [[ -z "$RESUME_MODE" ]]; then
+            comment_issue "Config-Only Changes Detected" "Config-only changes detected — skipping to PR creation."
+        fi
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: VALIDATE PLAN (lightweight check)
+    # -------------------------------------------------------------------------
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "validate_plan"; then
+        log "Skipping validate_plan stage (already completed)"
+        # Load tasks from status file for implement stage
+        tasks_json=$(jq -c '.tasks' "$STATUS_FILE")
+    elif [[ "$early_scope" == "config" ]]; then
+        log "Skipping validate_plan stage (config-only scope)"
+        set_stage_started "validate_plan"
+        set_stage_completed "validate_plan"
+    else
+        set_stage_started "validate_plan"
+
+        # (c) Validate ## Implementation Tasks section exists in saved issue body
+        local issue_body_file="$LOG_BASE/context/issue-body.md"
+        if [[ -f "$issue_body_file" ]]; then
+            # Case-insensitive (-i) to match the hardened section extractor —
+            # a lowercase "## implementation tasks" or annotated
+            # "## Implementation Tasks (draft)" heading must not trip this
+            # resume-path guard after the parser accepted it.  Uses the shared
+            # ISSUE_TASKS_HEADING_ERE so it stays identical to the PARSE ISSUE awk.
+            if ! grep -qiE "$ISSUE_TASKS_HEADING_ERE" "$issue_body_file"; then
+                log_error "Issue body missing 'Implementation Tasks' section"
+                set_final_state "error"
+                exit 1
+            fi
+        else
+            log "WARNING: Issue body file not found at $issue_body_file — skipping section check"
+        fi
+
+        local task_count
+        task_count=$(printf '%s' "$tasks_json" | jq length)
+
+        if (( task_count == 0 )); then
+            log_error "No tasks to implement"
+            set_final_state "error"
+            exit 1
+        fi
+
+        # (a) Verify agent names have definitions in .claude/agents/
+        # Agent names are normalized by _parse_task_lines (legacy remapping +
+        # "default" fallback), so warn only when the post-normalization name
+        # is neither "default" nor a known local agent.
+        local agents_dir="$SCRIPT_DIR/../agents"
+        for ((i=0; i<task_count; i++)); do
+            local check_agent
+            check_agent=$(printf '%s' "$tasks_json" | jq -r ".[$i].agent")
+            if [[ "$check_agent" != "default" \
+                && ! -f "$agents_dir/${check_agent}.md" ]]; then
+                log "WARNING: Task $((i+1)) uses agent '$check_agent'" \
+                    "which has no definition in .claude/agents/"
+            fi
+        done
+
+        # (b) Warn about large task descriptions (>200 chars)
+        for ((i=0; i<task_count; i++)); do
+            local check_desc
+            check_desc=$(printf '%s' "$tasks_json" | jq -r ".[$i].description")
+            local desc_len=${#check_desc}
+            if (( desc_len > 200 )); then
+                log "WARNING: Task $((i+1)) description is $desc_len chars — consider splitting into smaller tasks"
+            fi
+        done
+
+        # (d) Extract backtick-quoted file paths from issue body and check existence
+        if [[ -f "$issue_body_file" ]]; then
+            local -a found_paths=()
+            local path_match
+            while IFS= read -r path_match; do
+                [[ -n "$path_match" ]] || continue
+                found_paths+=("$path_match")
+                if (( ${#found_paths[@]} >= 10 )); then
+                    break
+                fi
+            done < <(grep -oE '`[a-zA-Z0-9_./-]+\.[a-zA-Z]{1,5}`' "$issue_body_file" \
+                | sed 's/`//g' \
+                | sort -u \
+                | head -10)
+
+            for path_match in ${found_paths[@]+"${found_paths[@]}"}; do
+                if [[ ! -e "$path_match" ]]; then
+                    log "WARNING: Referenced file path '$path_match' does not exist in the repo"
+                fi
+            done
+        fi
+
+        log "Plan validated: $task_count tasks ready for implementation"
+
+        # Comment: Confirm plan
+        local task_list_md=""
+        for ((i=0; i<task_count; i++)); do
+            local desc agent
+            desc=$(printf '%s' "$tasks_json" | jq -r ".[$i].description")
+            agent=$(printf '%s' "$tasks_json" | jq -r ".[$i].agent")
+            task_list_md="${task_list_md}
+$((i+1)). \`[$agent]\` $desc"
+        done
+
+        comment_issue "Implementation Plan Confirmed" "Extracted **$task_count tasks** from issue body. Starting implementation.
+
+**Tasks:**
+$task_list_md
+
+**Branch:** \`$branch\`" "" "$VALIDATE_PLAN_COMMENT_TIMEOUT"
+
+        set_stage_completed "validate_plan"
+        log "Plan validation complete."
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: IMPLEMENT (per-task loop)
+    # -------------------------------------------------------------------------
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "implement"; then
+        log "Skipping implement stage (already completed)"
+    elif [[ "$early_scope" == "config" ]]; then
+        log "Skipping implement stage (config-only scope)"
+        set_stage_started "implement"
+        set_stage_completed "implement"
+        set_stage_completed "quality_loop"
+    else
+        set_stage_started "implement"
+
+        task_count=$(printf '%s' "$tasks_json" | jq length)
+
+        # In resume mode, count already completed tasks
+        if [[ -n "$RESUME_MODE" ]]; then
+            completed_tasks=$(get_completed_task_count)
+            log "Resuming implementation: $completed_tasks/$task_count tasks already completed"
+        else
+            completed_tasks=0
+        fi
+
+        # Compute max_task_size across all tasks (needed by
+        # test loop later regardless of execution order).
+        for ((i = 0; i < task_count; i++)); do
+            local task_desc_tmp
+            task_desc_tmp=$(printf '%s' "$tasks_json" \
+                | jq -r ".[$i].description")
+            local ts_tmp
+            ts_tmp=$(extract_task_size "$task_desc_tmp")
+            case "$ts_tmp" in
+                L) max_task_size="L" ;;
+                M) [[ "$max_task_size" != "L" ]] \
+                    && max_task_size="M" ;;
+                S) [[ -z "$max_task_size" ]] \
+                    && max_task_size="S" ;;
+            esac
+        done
+
+        # Determine distinct batch numbers (ascending)
+        # Uses while-read instead of readarray for bash 3.2 compat (macOS).
+        local -a batch_nums=()
+        while IFS= read -r _bn; do
+            batch_nums+=("$_bn")
+        done < <(
+            printf '%s' "$tasks_json" \
+                | jq -r '.[].batch' \
+                | sort -nu
+        )
+
+        log "Task batches: ${#batch_nums[@]}" \
+            "batch(es) across $task_count tasks"
+
+        # Helper: process results for a set of task IDs
+        # after serial or parallel execution.  Updates
+        # task status, posts comments, tracks progress.
+        _process_batch_results() {
+            local result_json="$1"
+            local src_label="$2"
+
+            # Issue #583: the batch executors (execute_batch_serial/parallel) run
+            # in command-substitution subshells, so a budget halt inside them
+            # exits only that subshell.  This funnel runs in the PARENT shell
+            # after every batch dispatch, so re-assert the durable budget halt
+            # here — otherwise the run would keep spending on later stages.
+            _halt_if_budget_exceeded
+
+            # Process completed tasks
+            local comp_count
+            comp_count=$(printf '%s' "$result_json" \
+                | jq '.completed | length')
+            local ci
+            for ((ci = 0; ci < comp_count; ci++)); do
+                local tid
+                tid=$(printf '%s' "$result_json" \
+                    | jq -r ".completed[$ci]")
+
+                # Read result file for this task
+                local rf=""
+                if [[ -f "${LOG_BASE}/stages/task-${tid}-worktree.log" ]]; then
+                    rf="${LOG_BASE}/stages/task-${tid}-worktree.log"
+                elif [[ -f "${LOG_BASE}/stages/task-${tid}-serial.log" ]]; then
+                    rf="${LOG_BASE}/stages/task-${tid}-serial.log"
+                fi
+
+                local rattempts="0"
+                local commit_sha="unknown"
+                local impl_summary="Implementation completed"
+                if [[ -n "$rf" && -f "$rf" ]]; then
+                    rattempts=$(jq -r \
+                        '.review_attempts // 0' \
+                        "$rf" 2>/dev/null)
+                    commit_sha=$(jq -r \
+                        '.commit // "unknown"' \
+                        "$rf" 2>/dev/null)
+                    impl_summary=$(jq -r \
+                        '.summary // "Implementation completed"' \
+                        "$rf" 2>/dev/null)
+                fi
+
+                update_task "$tid" "completed" \
+                    "$rattempts"
+                completed_tasks=$((completed_tasks + 1))
+
+                # Get task description for comment
+                local tdesc
+                tdesc=$(printf '%s' "$tasks_json" \
+                    | jq -r \
+                    ".[] | select(.id == $tid) | .description")
+                local tagent
+                tagent=$(printf '%s' "$tasks_json" \
+                    | jq -r \
+                    ".[] | select(.id == $tid) | .agent")
+
+                comment_issue \
+                    "Task $tid Complete ($src_label)" \
+                    "**$tdesc**
+
+**Commit:** \`$commit_sha\`
+
+$impl_summary" "$tagent"
+
+                # Update progress
+                jq --arg progress \
+                    "$completed_tasks/$task_count" \
+                    '.stages.implement.task_progress = $progress | .last_update = (now | todate)' \
+                    "$STATUS_FILE" \
+                    > "${STATUS_FILE}.tmp" \
+                    && mv "${STATUS_FILE}.tmp" \
+                    "$STATUS_FILE"
+                sync_status_to_log
+            done
+
+            # Process failed tasks
+            local fail_count
+            fail_count=$(printf '%s' "$result_json" \
+                | jq '.failed | length')
+            local fi_idx
+            for ((fi_idx = 0; fi_idx < fail_count; fi_idx++)); do
+                local tid
+                tid=$(printf '%s' "$result_json" \
+                    | jq -r ".failed[$fi_idx]")
+                log_error "Task $tid failed ($src_label)"
+                update_task "$tid" "failed" "0"
+            done
+        }
+
+        # Iterate over batches in order
+        for batch_num in "${batch_nums[@]}"; do
+            # Filter tasks for this batch
+            local batch_tasks
+            batch_tasks=$(printf '%s' "$tasks_json" \
+                | jq "[.[] | select(.batch == $batch_num)]")
+            local batch_size
+            batch_size=$(printf '%s' "$batch_tasks" \
+                | jq 'length')
+
+            # Skip already-completed tasks in resume mode
+            if [[ -n "$RESUME_MODE" ]]; then
+                local pending_tasks
+                pending_tasks=$(printf '%s' "$batch_tasks" \
+                    | jq '[.[] | select(
+                        .id as $tid |
+                        '"$(jq -r \
+                            '[.tasks[] | select(.status == "completed") | .id]' \
+                            "$STATUS_FILE" 2>/dev/null \
+                            || printf '[]')"' |
+                        index($tid) | not
+                    )]')
+                local pending_count
+                pending_count=$(printf '%s' \
+                    "$pending_tasks" | jq 'length')
+                if ((pending_count == 0)); then
+                    log "Batch $batch_num: all tasks" \
+                        "already completed (resume)"
+                    continue
+                fi
+                if ((pending_count < batch_size)); then
+                    log "Batch $batch_num:" \
+                        "$((batch_size - pending_count))" \
+                        "task(s) already done," \
+                        "$pending_count remaining"
+                fi
+                batch_tasks="$pending_tasks"
+                batch_size="$pending_count"
+            fi
+
+            # Mark tasks in_progress
+            local ti
+            for ((ti = 0; ti < batch_size; ti++)); do
+                local tid
+                tid=$(printf '%s' "$batch_tasks" \
+                    | jq -r ".[$ti].id")
+                update_task "$tid" "in_progress"
+            done
+
+            log "Batch $batch_num: $batch_size task(s)"
+
+            if ((batch_size == 1)); then
+                # Single task: run serially (no worktree)
+                log "Batch $batch_num: single task," \
+                    "running serially"
+                local serial_result
+                serial_result=$(execute_batch_serial \
+                    "$batch_tasks" "$branch" \
+                    "$BASE_BRANCH")
+                _process_batch_results \
+                    "$serial_result" "serial"
+            else
+                # Multiple tasks: run in parallel
+                local par_result
+                par_result=$(execute_batch_parallel \
+                    "$batch_num" "$batch_tasks" \
+                    "$branch" "$BASE_BRANCH")
+
+                _process_batch_results \
+                    "$par_result" "parallel"
+
+                # If ALL tasks failed (no completions),
+                # retry each failed task serially before
+                # propagating the failure upward.
+                local par_comp_count
+                par_comp_count=$(printf '%s' "$par_result" \
+                    | jq '.completed | length')
+                local par_fail_count
+                par_fail_count=$(printf '%s' "$par_result" \
+                    | jq '.failed | length')
+                if ((par_comp_count == 0 && par_fail_count > 0)); then
+                    log_warn "Batch $batch_num: all" \
+                        "$par_fail_count task(s) failed" \
+                        "in parallel — retrying serially"
+
+                    local fail_ids
+                    fail_ids=$(printf '%s' "$par_result" \
+                        | jq '.failed')
+                    local full_retry_tasks
+                    full_retry_tasks=$(printf '%s' \
+                        "$batch_tasks" \
+                        | jq --argjson ids "$fail_ids" \
+                        '[.[] | select(
+                            .id as $t |
+                            $ids | index($t)
+                        )]')
+
+                    local full_retry_result
+                    full_retry_result=$(execute_batch_serial \
+                        "$full_retry_tasks" "$branch" \
+                        "$BASE_BRANCH")
+                    _process_batch_results \
+                        "$full_retry_result" "full-batch-retry"
+                fi
+
+                # Handle conflicted tasks by re-running
+                # them serially
+                local conf_count
+                conf_count=$(printf '%s' "$par_result" \
+                    | jq '.conflicted | length')
+                if ((conf_count > 0)); then
+                    log_warn "Batch $batch_num:" \
+                        "$conf_count task(s) had" \
+                        "merge conflicts —" \
+                        "retrying serially"
+
+                    # Build tasks JSON for conflicted IDs
+                    local conf_ids
+                    conf_ids=$(printf '%s' "$par_result" \
+                        | jq '.conflicted')
+                    local retry_tasks
+                    retry_tasks=$(printf '%s' \
+                        "$batch_tasks" \
+                        | jq --argjson ids "$conf_ids" \
+                        '[.[] | select(
+                            .id as $t |
+                            $ids | index($t)
+                        )]')
+
+                    local retry_result
+                    retry_result=$(execute_batch_serial \
+                        "$retry_tasks" "$branch" \
+                        "$BASE_BRANCH")
+                    _process_batch_results \
+                        "$retry_result" "conflict-retry"
+                fi
+            fi
+
+            # Ensure we are on the feature branch
+            timeout "$IMPLEMENT_GIT_TIMEOUT" git checkout "$branch" 2>&1 >/dev/null
+            local _impl_git_exit=$?
+            if (( _impl_git_exit == 124 )); then
+                log_warn "implement: git checkout $branch timed out after ${IMPLEMENT_GIT_TIMEOUT}s"
+            fi
+        done
+
+        set_stage_completed "implement"
+        set_stage_completed "quality_loop"
+        log "Implementation complete." \
+            "$completed_tasks/$task_count tasks" \
+            "completed (with per-task quality loops)."
+
+        # Guardrail: abort if no tasks completed but tasks were expected.
+        # Guard: if the branch has commits ahead of base (from a prior run or
+        # partial work), continue to PR creation instead of aborting.
+        if (( completed_tasks == 0 && task_count > 0 )); then
+            local commits_ahead
+            commits_ahead=$(git rev-list --count "${BASE_BRANCH}..HEAD" 2>/dev/null || echo "0")
+            if (( commits_ahead > 0 )); then
+                log_warn "0/$task_count tasks completed this run, but branch has $commits_ahead commit(s) ahead of $BASE_BRANCH — continuing to PR creation."
+            else
+                log_error "ABORT: 0/$task_count tasks completed — implementation produced no changes." \
+                    "This usually indicates a bug in the orchestrator (e.g. undefined variable, worktree failure)." \
+                    "Check stage logs for errors."
+                comment_issue "Implementation Failed" \
+                    "❌ 0/$task_count tasks completed. No changes were produced. Aborting pipeline." \
+                    "error"
+                set_final_state "error"
+                exit 1
+            fi
+        fi
+
+        # -----------------------------------------------------------------
+        # PARTIAL-COMPLETION GATE (issue #577)
+        # When fewer tasks completed this run than were planned, this is a
+        # partial delivery: record an implement:partial:<n>/<m> marker in
+        # DEGRADED_STAGES (consulted by the merge gate below to block
+        # auto-merge) and post an issue comment naming each failed task.
+        # DEGRADED_STAGES is guarded against set -u unbound expansion at every
+        # read site, so appending here is safe.
+        # -----------------------------------------------------------------
+        if (( completed_tasks < task_count )); then
+            DEGRADED_STAGES+=("implement:partial:${completed_tasks}/${task_count}")
+            log_warn "Partial implementation: ${completed_tasks}/${task_count} tasks completed —" \
+                "recording implement:partial and reporting failed tasks."
+
+            # Persist a merge-block reason so a standalone process-pr or a
+            # resumed run honours the gate from status.json too.  Use // to
+            # avoid clobbering a reason a prior gate (e.g. convergence) set.
+            if [[ -f "$STATUS_FILE" ]]; then
+                jq --arg reason "Partial implementation: ${completed_tasks}/${task_count} tasks completed (implement:partial:${completed_tasks}/${task_count})." \
+                   '.merge_blocked_reason = (.merge_blocked_reason // $reason) | .last_update = (now | todate)' \
+                   "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+                sync_status_to_log
+            fi
+
+            # Build a bullet list of the failed tasks from status.json.
+            local _failed_list=""
+            if [[ -f "$STATUS_FILE" ]]; then
+                _failed_list=$(jq -r '
+                    [.tasks[]? | select(.status == "failed")
+                        | "- Task \(.id // "?"): \(.description // "(no description)")"]
+                    | join("\n")' "$STATUS_FILE" 2>/dev/null || printf '')
+            fi
+            [[ -n "$_failed_list" ]] \
+                || _failed_list="- (failed tasks not individually recorded in status.json)"
+
+            comment_issue "Implementation: Partial" \
+                "⚠️ Only **${completed_tasks}/${task_count}** implementation task(s) completed. The following task(s) failed:
+
+$_failed_list
+
+Auto-merge will be blocked and the PR left open for review. To merge anyway, re-run with \`BLOCK_MERGE_ON_PARTIAL=0\`." \
+                "default"
+        fi
+    fi
+
+    # -------------------------------------------------------------------------
+    # CHANGE SCOPE (computed once; shared by test loop and docs stage)
+    # -------------------------------------------------------------------------
+    local branch_scope
+    branch_scope=$(detect_change_scope "." "$BASE_BRANCH")
+    log "Branch change scope: $branch_scope"
+
+    # Already-done check: if all tasks reported already_done or files_changed:[],
+    # the issue was previously implemented — exit cleanly without PR or tests.
+    # Guard: only skip PR creation if the branch also has no commits (prevents false-positive
+    # exits when agents set already_done:true after genuinely committing changes).
+    if is_stage_completed "implement"; then
+        local all_already_done=true
+        local _rf _already_done _files_changed
+        # files_changed is now reliably written by execute_batch_serial (added in feat/issue-152),
+        # so a missing or empty array is a genuine signal that no files were changed, not a gap.
+        # The commits_ahead guard below remains as defence-in-depth against false-positive exits.
+        for _rf in "${LOG_BASE}/stages"/task-*-worktree.log \
+                   "${LOG_BASE}/stages"/task-*-serial.log; do
+            [[ -f "$_rf" ]] || continue
+            _already_done=$(jq -r '.already_done // false' "$_rf" 2>/dev/null || echo "false")
+            _files_changed=$(jq -r '(.files_changed // []) | length' "$_rf" 2>/dev/null || echo "1")
+            if [[ "$_already_done" != "true" && "$_files_changed" != "0" ]]; then
+                all_already_done=false
+                break
+            fi
+        done
+
+        if [[ "$all_already_done" == "true" && "$completed_tasks" -gt 0 ]]; then
+            # Guard: serial conflict-retry logs report already_done=true even when new commits
+            # landed. Check for actual commits before concluding the issue was pre-implemented.
+            local _commits_check
+            _commits_check=$(git rev-list --count "${BASE_BRANCH}..HEAD" 2>/dev/null || echo "0")
+            if (( _commits_check > 0 )); then
+                log "All $completed_tasks task(s) reported already_done but branch has $_commits_check commit(s) ahead of $BASE_BRANCH — continuing to PR creation."
+            else
+                log "All $completed_tasks task(s) reported already_done — issue was previously implemented."
+                comment_issue "Already Implemented" \
+                    "✅ All tasks for this issue were already completed in a prior run. No new changes are needed. Closing as done." \
+                    "default"
+                set_final_state "already_implemented"
+                jq '.task_summary.sp_completed = 0 | .task_summary.sp_total = 0' status.json > status.json.tmp && mv status.json.tmp status.json
+                exit 0
+            fi
+        fi
+    fi
+
+    # Guardrail: if we just ran implementation but have no changes, something went wrong.
+    if is_stage_completed "implement" && [[ "$branch_scope" == "config" ]]; then
+        local commits_ahead
+        commits_ahead=$(git rev-list --count "${BASE_BRANCH}..HEAD" 2>/dev/null || echo "0")
+        if (( commits_ahead > 0 )); then
+            log "Branch has $commits_ahead commit(s) ahead of" \
+                "$BASE_BRANCH — continuing."
+        else
+            log_error "ABORT: Implementation stage completed but branch has 0 commits ahead of $BASE_BRANCH." \
+                "Worktree merge-back likely failed. Check orchestrator log for merge errors."
+            comment_issue "Implementation Failed" \
+                "❌ Implementation completed but no commits landed on the feature branch. Aborting." \
+                "error"
+            set_final_state "error"
+            exit 1
+        fi
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: TEST LOOP (after all tasks complete)
+    # -------------------------------------------------------------------------
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "test_loop"; then
+        log "Skipping test_loop stage (already completed)"
+    elif [[ "$early_scope" == "config" ]]; then
+        log "Skipping test_loop stage (config-only scope)"
+        set_stage_started "test_loop"
+        set_stage_completed "test_loop"
+    else
+        set_stage_started "test_loop"
+        log "Running test loop after all tasks complete..."
+
+        run_test_loop "." "$branch" "$AGENT" \
+            "$branch_scope" "$max_task_size" "$pipeline_profile"
+
+        # ---------------------------------------------------------------------
+        # NON-BLOCKING FULL-SUITE CHECK (informational + degraded-stage signal)
+        # The smart-targeted test_loop only runs tests related to the changed
+        # files, so a suite broken without a related change — e.g. a task that
+        # should have fixed it but produced nothing (see #468) — can pass the
+        # loop yet leave `npm test` red. Run the FULL suite ($TEST_UNIT_CMD)
+        # once here to surface that; --changedSince shares the same dependency-
+        # graph blind spot and would miss it. Kept NON-BLOCKING because the base
+        # branch itself may legitimately be red; failures are posted as a comment
+        # AND recorded in DEGRADED_STAGES so they show up in the pipeline summary
+        # instead of being silently reported green.
+        # ---------------------------------------------------------------------
+        if [[ "$branch_scope" == "typescript" || "$branch_scope" == "mixed" || "$branch_scope" == "ts-frontend" ]]; then
+            log "Running informational full-suite check (non-blocking)..."
+            local full_scope_output full_scope_rc
+            full_scope_output=$(eval "${TEST_UNIT_CMD:-npm test}" 2>&1) || true
+            full_scope_rc=$?
+
+            if (( full_scope_rc != 0 )); then
+                local full_scope_failures
+                full_scope_failures=$(printf '%s' "$full_scope_output" | tail -40)
+                DEGRADED_STAGES+=("test:full_suite_red")
+                comment_issue "Full-Suite Check: test suite is RED (non-blocking)" \
+                    "⚠️ The full \`${TEST_UNIT_CMD:-npm test}\` run failed on this branch. The smart-targeted test loop only runs tests related to the changed files, so these failures were not caught there. They may be **pre-existing on \`$BASE_BRANCH\`** OR failures this PR was expected to fix — **review before merge; do not assume green.**
+
+<details>
+<summary>Failure details (last 40 lines)</summary>
+
+\`\`\`
+$full_scope_failures
+\`\`\`
+</details>" "default"
+                log "WARN: Full-suite check found failures (non-blocking, recorded as degraded)"
+            else
+                log "Full-suite check passed — $TEST_UNIT_CMD is green on this branch"
+            fi
+        fi
+
+        # ---------------------------------------------------------------------
+        # NON-BLOCKING FULL-SUITE BATS CHECK (informational + degraded signal)
+        # The smart-targeted test_loop runs BATS only for `bash`-scoped branches.
+        # A typescript/mixed/config branch that touches a `.sh`/`.bats` file (e.g.
+        # this orchestrator itself) runs Jest only, so a broken pipeline BATS
+        # suite can merge unnoticed — the mirror image of the Jest gap above. Run
+        # the FULL BATS suite via run-tests.sh once here for any NON-`bash` scope
+        # to surface that. Kept NON-BLOCKING because the base branch itself may
+        # legitimately be red; failures are posted as a comment AND recorded in
+        # DEGRADED_STAGES so they show up in the pipeline summary instead of being
+        # silently reported green.
+        # ---------------------------------------------------------------------
+        local bats_runner=".claude/scripts/implement-issue-test/run-tests.sh"
+        if [[ "$branch_scope" != "bash" && -f "$bats_runner" ]]; then
+            log "Running informational full-suite BATS check (non-blocking)..."
+            local bats_full_output bats_full_rc
+            bats_full_output=$(bash "$bats_runner" 2>&1)
+            bats_full_rc=$?
+
+            if (( bats_full_rc != 0 )); then
+                local bats_full_failures
+                bats_full_failures=$(printf '%s' "$bats_full_output" | tail -40)
+                DEGRADED_STAGES+=("test:bats_full_suite_red")
+                comment_issue "Full-Suite BATS Check: pipeline tests are RED (non-blocking)" \
+                    "⚠️ The full BATS suite (\`bash $bats_runner\`) failed on this branch. The smart-targeted test loop runs BATS only for \`bash\`-scoped branches, so these failures were not caught there (scope: \`$branch_scope\`). They may be **pre-existing on \`$BASE_BRANCH\`** OR failures this PR was expected to fix — **review before merge; do not assume green.**
+
+<details>
+<summary>Failure details (last 40 lines)</summary>
+
+\`\`\`
+$bats_full_failures
+\`\`\`
+</details>" "default"
+                log "WARN: Full-suite BATS check found failures (non-blocking, recorded as degraded)"
+            else
+                log "Full-suite BATS check passed — pipeline BATS tests are green on this branch"
+            fi
+        fi
+
+        # ---------------------------------------------------------------------
+        # E2E-UNVALIDATED GUARD: the test loop above is unit-only when
+        # TEST_E2E_CMD is unset. If this branch changed Playwright e2e infra or
+        # specs, NONE of it was executed here — a runtime-only bug (e.g. #481's
+        # `await import()` of a .ts in globalSetup) passes tsc/lint/jest and
+        # merges broken. Surface it loudly (non-blocking) so a human runs
+        # Playwright before trusting the PR.
+        # ---------------------------------------------------------------------
+        if [[ -z "${TEST_E2E_CMD:-}" ]]; then
+            local e2e_changed
+            e2e_changed=$(git diff "$BASE_BRANCH"...HEAD --name-only 2>/dev/null \
+                | grep -E '^(tests/e2e/|playwright\.config\.)' || true)
+            if [[ -n "$e2e_changed" ]]; then
+                DEGRADED_STAGES+=("test:e2e_unvalidated")
+                comment_issue "E2E NOT validated by the test loop" \
+                    "⚠️ This branch changes Playwright e2e files, but \`TEST_E2E_CMD\` is unset so the test loop ran **unit tests only** — the e2e specs/infra here were **not executed**. tsc/lint/jest cannot catch runtime-only e2e bugs (e.g. a dynamic import of a \`.ts\` in globalSetup). **Run Playwright manually before trusting this PR.**
+
+\`\`\`
+$e2e_changed
+\`\`\`" "default"
+                log "WARN: e2e files changed but not validated (TEST_E2E_CMD unset) — recorded as degraded"
+            fi
+        fi
+
+        set_stage_completed "test_loop"
+        log "Test loop complete."
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGES: E2E VERIFY + ACCEPTANCE TEST (run in parallel)
+    # Both stages run concurrently via run_parallel_post_task_stages.
+    # docs runs sequentially after both complete (it modifies files).
+    # -------------------------------------------------------------------------
+    run_parallel_post_task_stages \
+        "$branch" "$branch_scope" "$pipeline_profile" "$max_task_size"
+
+    # -------------------------------------------------------------------------
+    # NAS PRE-MERGE NOTIFICATION
+    # If the issue carries the env:nas-premerge label the pipeline cannot run
+    # the NAS build automatically pre-merge; instead it posts a comment asking
+    # the human to trigger the NAS build manually before merging the PR.
+    # The pipeline then proceeds to PR creation without blocking.
+    # Full deploy_verify (env:test/env:nas/env:staging) runs post-merge below.
+    # -------------------------------------------------------------------------
+    local nas_pm_labels=""
+    case "${TRACKER:-github}" in
+        github)
+            nas_pm_labels=$(gh issue view "$ISSUE_NUMBER" \
+                --json labels -q '.labels[].name' 2>/dev/null || true)
+            ;;
+        jira)
+            nas_pm_labels=$(acli jira workitem view "$ISSUE_NUMBER" \
+                --fields labels --json 2>/dev/null \
+                | jq -r '.fields.labels[]?' 2>/dev/null || true)
+            ;;
+    esac
+
+    if printf '%s\n' "$nas_pm_labels" | grep -q '^env:nas-premerge$'; then
+        comment_issue "NAS Pre-Merge Build Required" \
+            "⚠️ This issue has the \`env:nas-premerge\` label. Please trigger a NAS build manually before merging this PR.
+
+The pipeline is proceeding to PR creation. Once you have triggered and confirmed the NAS pre-merge build, this PR can be merged." \
+            "default"
+    fi
+
+    # -------------------------------------------------------------------------
+    # Pre-compute modified TypeScript files before docs stage
+    # -------------------------------------------------------------------------
+    local modified_ts_files
+    modified_ts_files=$(git diff "$BASE_BRANCH"...HEAD --name-only -- '*.ts' '*.tsx' 2>/dev/null | grep -E '^(apps|packages)/' | sort)
+
+    # Format the file list for the prompt
+    local files_for_prompt
+    if [[ -n "$modified_ts_files" ]]; then
+        files_for_prompt=$(printf '%s' "$modified_ts_files" | sed 's/^/- /')
+    else
+        files_for_prompt="(no TypeScript files modified)"
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: DOCS
+    # -------------------------------------------------------------------------
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "docs"; then
+        log "Skipping docs stage (already completed)"
+    else
+        if ! should_run_docs_stage "$branch_scope"; then
+            log "Skipping docs stage: no TypeScript/React files changed (scope: $branch_scope)"
+            set_stage_started "docs"
+            comment_issue "Docs Stage: Skipped" "⏭️ No TypeScript/React files changed (scope: \`$branch_scope\`). Skipping docs stage."
+            set_stage_completed "docs"
+        elif [[ "$pipeline_profile" == "minimal" ]]; then
+            log "Skipping docs stage: minimal profile (single S-task)"
+            set_stage_started "docs"
+            comment_issue "Docs Stage: Skipped" \
+                "⏭️ Minimal profile (single S-task). Skipping docs stage."
+            set_stage_completed "docs"
+        elif all_tasks_s_complexity; then
+            log "Skipping docs stage: all tasks are S-complexity"
+            set_stage_started "docs"
+            comment_issue "Docs Stage: Skipped" "⏭️ All tasks are S-complexity. Skipping docs stage."
+            set_stage_completed "docs"
+        else
+            set_stage_started "docs"
+
+            local file_idx=0
+            while IFS= read -r ts_file; do
+                [[ -z "$ts_file" ]] && continue
+                (( file_idx++ )) || true
+                local docs_file_prompt="Write JSDoc/TSDoc comments for the TypeScript file \`$ts_file\` on branch $branch in the current working directory.
+
+File: $ts_file
+
+Add comprehensive JSDoc/TSDoc comments to this file only. Stage the changes with \`git add $ts_file\` but do NOT commit."
+                run_stage "docs-file-$file_idx" "$docs_file_prompt" "implement-issue-implement.json" "default"
+            done <<< "$modified_ts_files"
+
+            # Build explicit git add commands for only the files documented above.
+            # This prevents the agent from using 'git add -A' or 'git add .'.
+            local docs_commit_add_cmds
+            docs_commit_add_cmds=$(while IFS= read -r f; do
+                [[ -z "$f" ]] && continue
+                printf 'git add "%s"\n' "$f"
+            done <<< "$modified_ts_files")
+
+            local docs_commit_prompt="Commit the docblock changes added by the docs-file-N stages for issue #$ISSUE_NUMBER.
+
+Stage and commit ONLY these specific files — do NOT use 'git add -A' or 'git add .':
+
+$docs_commit_add_cmds
+Then commit with:
+git commit -m 'docs(issue-$ISSUE_NUMBER): add JSDoc comments'
+
+Only the files listed above should be staged and committed."
+            run_stage "docs-commit" "$docs_commit_prompt" "implement-issue-implement.json" "default"
+
+            set_stage_completed "docs"
+        fi
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: PR
+    # -------------------------------------------------------------------------
+    local pr_number
+
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "pr"; then
+        log "Skipping PR creation stage (already completed)"
+        # Load PR number from status
+        pr_number=$(jq -r '.stages.pr.pr_number // empty' "$STATUS_FILE")
+        if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
+            log_error "PR stage marked complete but no PR number found in status"
+            set_final_state "error"
+            exit 1
+        fi
+        log "Using existing PR #$pr_number"
+    else
+        set_stage_started "pr"
+
+        local pr_creation_skill
+        pr_creation_skill=$(load_skill "pr-creation")
+
+        local pr_prompt="Create a merge request for issue #$ISSUE_NUMBER.
+
+Run this exact command (substitute a short description for <description>):
+
+git push -u origin $branch 2>/dev/null; $PLATFORM_DIR/create-mr.sh --source '$branch' --target '$BASE_BRANCH' --title 'feat(issue-$ISSUE_NUMBER): <description>' --body 'Closes #$ISSUE_NUMBER'
+
+The command will output the MR number. Use that as pr_number in your response.
+
+${pr_creation_skill:+## Skill Instructions
+
+$pr_creation_skill}"
+
+        local pr_result
+        pr_result=$(run_stage "pr" "$pr_prompt" "implement-issue-pr.json" "" "" "" "opus")
+        _halt_if_budget_exceeded
+
+        local pr_status
+        pr_status=$(printf '%s' "$pr_result" | jq -r '.output.status')
+        pr_number=$(printf '%s' "$pr_result" | jq -r '.output.pr_number')
+
+        if [[ "$pr_status" != "success" ]]; then
+            log_error "PR creation failed"
+            set_final_state "error"
+            exit 1
+        fi
+
+        # Validate pr_number is present; recover via find-mr.sh if missing
+        if [[ -z "$pr_number" || "$pr_number" == "null" || ! "$pr_number" =~ ^[0-9]+$ ]]; then
+            log_warn "PR number missing or invalid from structured output (got: '$pr_number') — recovering via find-mr.sh"
+            pr_number=$("$PLATFORM_DIR/find-mr.sh" --branch "$branch" 2>/dev/null || true)
+            if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
+                log_warn "find-mr.sh recovery failed — trying gh pr list fallback"
+                pr_number=$(gh pr list --head "$branch" --json number -q '.[0].number' 2>/dev/null || true)
+                if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
+                    log_error "Could not recover PR/MR number from find-mr.sh or gh pr list for branch '$branch'"
+                    set_final_state "error"
+                    exit 1
+                fi
+                log "Recovered PR/MR #$pr_number from gh pr list"
+            else
+                log "Recovered PR/MR #$pr_number from find-mr.sh"
+            fi
+        fi
+
+        log "PR #$pr_number created/updated"
+
+        # Store PR info in status
+        jq --argjson pr "$pr_number" \
+           '.stages.pr.pr_number = $pr | .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+        sync_status_to_log
+        set_stage_completed "pr"
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: PR REVIEW LOOP
+    # -------------------------------------------------------------------------
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "pr_review"; then
+        log "Skipping pr_review stage (already completed)"
+    else
+        set_stage_started "pr_review"
+
+        local pr_approved=false
+
+        # Scale PR review by diff size
+        local pr_review_config
+        pr_review_config=$(get_pr_review_config)
+        local pr_review_model pr_review_timeout pr_review_max_iter
+        pr_review_model=$(printf '%s' "$pr_review_config" | jq -r '.model')
+        pr_review_timeout=$(printf '%s' "$pr_review_config" | jq -r '.timeout')
+        pr_review_max_iter=$(printf '%s' "$pr_review_config" | jq -r '.max_iterations')
+        pr_review_max_iter=$(apply_profile_to_pr_review_max_iter \
+            "$pipeline_profile" "$pr_review_max_iter")
+
+        local diff_lines
+        diff_lines=$(get_diff_line_count "$BASE_BRANCH")
+        log "PR review config: model=$pr_review_model, timeout=${pr_review_timeout}s, max_iter=$pr_review_max_iter (diff: ${diff_lines} lines, profile: $pipeline_profile)"
+
+        local review_history_file="$LOG_BASE/context/pr-review-history.json"
+
+        # Compute the PR-review loop's own wall-clock budget.
+        # Formula: pr_review_timeout * max(max_iter, 1) + slack
+        # Each factor is diff-size-scaled (timeout) and profile-adjusted
+        # (max_iter), so the budget reflects actual expected work.
+        # Override the entire budget with PR_REVIEW_WALL_BUDGET (env).
+        local pr_review_effective_iter
+        pr_review_effective_iter=$(( pr_review_max_iter > 1 \
+            ? pr_review_max_iter : 1 ))
+        local pr_review_wall_budget
+        if [[ -n "$PR_REVIEW_WALL_BUDGET" ]]; then
+            pr_review_wall_budget="$PR_REVIEW_WALL_BUDGET"
+            log "PR review wall-clock budget: ${pr_review_wall_budget}s (env override)"
+        else
+            pr_review_wall_budget=$(( pr_review_timeout \
+                * pr_review_effective_iter \
+                + PR_REVIEW_WALL_TIME_SLACK ))
+            log "PR review wall-clock budget: ${pr_review_wall_budget}s" \
+                "(${pr_review_timeout}s/iter × ${pr_review_effective_iter}" \
+                "+ ${PR_REVIEW_WALL_TIME_SLACK}s slack)"
+        fi
+        local pr_review_loop_start
+        pr_review_loop_start=$(date +%s)
+
+    while [[ "$pr_approved" != "true" ]]; do
+        increment_pr_review_iteration
+        local pr_iteration
+        pr_iteration=$(jq -r '.pr_review_iterations' "$STATUS_FILE")
+
+        if ! check_wall_timeout; then
+            log_warn "Wall-clock timeout in PR review loop at iteration $pr_iteration"
+            set_final_state "wall_timeout_pr_review"
+            DEGRADED_STAGES+=("pr_review:wall_timeout")
+            persist_merge_blocked_reason \
+                "PR review loop hit wall-clock timeout without an approved verdict (pr_review:wall_timeout)."
+            pr_approved=true
+            break
+        fi
+
+        if ! check_pr_review_wall_timeout \
+                "$pr_review_loop_start" "$pr_review_wall_budget"; then
+            log_warn "PR-review budget timeout at iteration $pr_iteration"
+            set_final_state "wall_timeout_pr_review"
+            DEGRADED_STAGES+=("pr_review:wall_timeout")
+            persist_merge_blocked_reason \
+                "PR review loop hit its wall-clock budget without an approved verdict (pr_review:wall_timeout)."
+            pr_approved=true
+            break
+        fi
+
+        if (( pr_iteration > pr_review_max_iter )); then
+            log_warn "PR review loop exceeded max iterations ($pr_review_max_iter). Soft-failing and continuing."
+            set_final_state "max_iterations_pr_review"
+            DEGRADED_STAGES+=("pr_review:max_iterations:iter=$pr_iteration")
+            persist_merge_blocked_reason \
+                "PR review loop ended without an approved verdict after max iterations (pr_review:max_iterations:iter=$pr_iteration)."
+            pr_approved=true
+            break
+        fi
+
+        log "PR review iteration $pr_iteration"
+
+        # -------------------------------------------------------------------------
+        # COMBINED SPEC + CODE REVIEW → PR comment #11 (single pass)
+        # -------------------------------------------------------------------------
+        # Include the diff inline so the reviewer doesn't waste turns running git diff
+        # and exploring the entire codebase. For small diffs this dramatically reduces
+        # token usage (4.7M → ~50K observed on an 11-line diff).
+        local pr_diff
+        pr_diff=$(git diff "$BASE_BRANCH"...HEAD -- 2>/dev/null | head -500)
+
+        # Sibling-file scan: for each directory containing a changed file,
+        # collect other .ts/.tsx files (excluding tests and already-diffed files),
+        # deduplicate, cap at 5. Uses newline-delimited strings for bash 3 compat.
+        local repo_root
+        repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+
+        # Collect changed files (newline-delimited for lookup)
+        local changed_files_nl
+        changed_files_nl=$(git diff --name-only "$BASE_BRANCH"...HEAD -- 2>/dev/null)
+
+        local -a sibling_files_list=()
+        local seen_nl="" sib_f sib_dir
+        while IFS= read -r sib_f; do
+            [[ -z "$sib_f" ]] && continue
+            sib_dir="${sib_f%/*}"
+            [[ "$sib_dir" == "$sib_f" ]] && sib_dir="."
+            for f in "$repo_root/$sib_dir"/*.ts "$repo_root/$sib_dir"/*.tsx; do
+                [[ -f "$f" ]] || continue
+                [[ "$f" == *".test."* || "$f" == *".spec."* ]] && continue
+                # Normalize back to repo-relative path
+                local rel="${f#"$repo_root"/}"
+                # Skip files already in the diff
+                printf '%s\n' "$changed_files_nl" | grep -qxF "$rel" && continue
+                # Deduplicate
+                printf '%s\n' "$seen_nl" | grep -qxF "$rel" && continue
+                seen_nl="${seen_nl}${rel}
+"
+                sibling_files_list+=("$rel")
+                ((${#sibling_files_list[@]} >= 5)) && break 2
+            done
+        done <<< "$changed_files_nl"
+
+        local sibling_files_prompt=""
+        if ((${#sibling_files_list[@]} > 0)); then
+            local sibling_list
+            sibling_list=$(printf '%s, ' "${sibling_files_list[@]}")
+            sibling_list="${sibling_list%, }"
+            sibling_files_prompt="
+
+Also check these sibling files for the same auth, schema, and N+1 patterns: ${sibling_list}
+For sibling files, only report major-severity findings (omit minor findings)."
+        fi
+
+        local pr_review_skill
+        pr_review_skill=$(load_skill "pr-review")
+
+        # Inject prior merged PRs for this issue into the review prompt.
+        # Filter out the current PR (exclude "$pr_number") so the reviewer
+        # does not see the current diff listed as prior work.
+        # Cap at 10 rows to keep the prompt size bounded.
+        local prior_prs_rows prior_prs_prompt=""
+        prior_prs_rows=$(
+            _prior_merged_prs_for_issue "$ISSUE_NUMBER" "$pr_number" \
+                | head -n 10)
+        if [[ -n "$prior_prs_rows" ]]; then
+            prior_prs_prompt="
+## Prior Merged PRs for Issue #${ISSUE_NUMBER}
+
+${prior_prs_rows}
+"
+        fi
+
+        local review_prompt="Review PR #$pr_number for issue #$ISSUE_NUMBER against base $BASE_BRANCH.
+
+${pr_review_skill:+## Skill Instructions — READ AND FOLLOW THESE
+
+$pr_review_skill
+
+## End Skill Instructions
+
+}${prior_prs_prompt}Part 1 — Spec Review: Verify the PR achieves the goals of the issue. Check goal achievement, not code quality. Flag scope creep.
+Part 2 — Code Review: Review code quality, patterns, standards, and security.
+
+Here is the diff to review (do NOT run git diff yourself — use this):
+
+\`\`\`diff
+$pr_diff
+\`\`\`
+${sibling_files_prompt}
+Approve or request changes. Output a summary suitable for an issue comment."
+
+        local review_result
+        review_result=$(run_stage "pr-review-iter-$pr_iteration" "$review_prompt" "implement-issue-review.json" "code-reviewer" "" "$pr_review_timeout" "$pr_review_model")
+        _halt_if_budget_exceeded
+
+        # Handle timeout: skip result inspection and retry on next iteration
+        if is_stage_timeout "$review_result"; then
+            log_warn "PR review timed out on iteration $pr_iteration — retrying next iteration"
+            comment_pr "$pr_number" "PR Review: Timeout (Iteration $pr_iteration)" "⏱️ Review stage timed out. Retrying on next iteration." "code-reviewer"
+            continue
+        fi
+
+        local review_verdict review_summary verdict_source
+        review_summary=$(printf '%s' "$review_result" | jq -r '.output.summary // "Review completed"')
+        local has_result_field
+        has_result_field=$(printf '%s' "$review_result" | jq '.output | has("result")' 2>/dev/null)
+
+        if [[ "$has_result_field" == "true" ]]; then
+            # Structured output available: extract verdict from .output.result field
+            review_verdict=$(printf '%s' "$review_result" | jq -r '.output.result')
+            verdict_source="structured output"
+            log "Verdict extracted from structured output: $review_verdict"
+        else
+            # Fallback: parse verdict from summary text
+            verdict_source="fallback text"
+            local summary_lower
+            summary_lower=$(printf '%s' "$review_summary" | tr '[:upper:]' '[:lower:]')
+
+            # Check for approval keywords
+            if grep -qiE '(approved|lgtm|looks good|no issues)' <<< "$summary_lower"; then
+                review_verdict="approved"
+                log "Verdict parsed from fallback text: approved (matched approval keywords)"
+            # Check for rejection keywords
+            elif grep -qiE '(changes requested|request changes|must fix|blocking|critical)' <<< "$summary_lower"; then
+                review_verdict="changes_requested"
+                log "Verdict parsed from fallback text: changes_requested (matched rejection keywords)"
+            else
+                # Default to changes_requested if ambiguous
+                review_verdict="changes_requested"
+                log "Verdict parsed from fallback text: changes_requested (ambiguous/default)"
+            fi
+        fi
+
+        # -------------------------------------------------------------------------
+        # MAJOR-ISSUE OVERRIDE: If reviewer said "approved" but flagged major
+        # issues, override to changes_requested.  This prevents the pipeline from
+        # closing issues that are not actually fixed (see claude-pipeline#25).
+        # -------------------------------------------------------------------------
+        if [[ "$review_verdict" == "approved" ]]; then
+            local major_issue_count
+            major_issue_count=$(printf '%s' "$review_result" | jq '[.output.issues // [] | .[] | select(.severity == "major")] | length' 2>/dev/null || echo "0")
+            if (( major_issue_count > 0 )); then
+                log_warn "Review verdict was 'approved' but $major_issue_count major issue(s) found — overriding to changes_requested"
+                review_verdict="changes_requested"
+                local major_descriptions
+                major_descriptions=$(printf '%s' "$review_result" | jq -r '[.output.issues[] | select(.severity == "major") | .description] | join("; ")' 2>/dev/null || echo "")
+                review_summary="${review_summary}
+
+⚠️ **Override:** Reviewer approved but $major_issue_count major issue(s) must be resolved first:
+${major_descriptions}"
+            fi
+        fi
+
+        # Comment #11: PR Combined Review Result
+        local review_icon="✅"
+        [[ "$review_verdict" == "changes_requested" ]] && review_icon="🔄"
+
+        # Create follow-up GH issues for adjacent_issues with major severity
+        local followup_comment=""
+        if [[ "$review_verdict" == "approved" ]]; then
+            local adjacent_json adj_count
+            adjacent_json=$(printf '%s' "$review_result" | \
+                jq -c '[.adjacent_issues // [] | .[] | select(.severity == "major")]' \
+                2>/dev/null || echo "[]")
+            adj_count=$(printf '%s' "$adjacent_json" | jq 'length' 2>/dev/null || echo "0")
+            if (( adj_count > 0 )); then
+                local created_nums=()
+                while IFS= read -r adj_item; do
+                    local adj_title adj_body
+                    adj_title=$(printf '%s' "$adj_item" | jq -r '.title // ""')
+                    adj_body=$(printf '%s' "$adj_item" | jq -r '.body // ""')
+                    [[ -z "$adj_title" ]] && continue
+
+                    # Deduplication: skip if an open issue with the same title already exists
+                    local dup_count
+                    dup_count=$(gh issue list --state open --json title \
+                        2>/dev/null | jq --arg t "$adj_title" '[.[] | select(.title == $t)] | length' \
+                        2>/dev/null || echo "0")
+                    if (( dup_count > 0 )); then
+                        log "Skipping duplicate follow-up issue (title already open): $adj_title"
+                        continue
+                    fi
+
+                    # Validate/build body to enforce canonical task format
+                    local validated_body
+                    validated_body=$(_build_adj_body "$adj_body" "$adj_title")
+                    validated_body="<!-- pipeline-autocreated -->
+${validated_body}"
+
+                    local new_num
+                    new_num=$("$PLATFORM_DIR/create-issue.sh" \
+                        --title "$adj_title" --body "$validated_body" \
+                        --labels "pipeline-followup,needs-explore" \
+                        2>/dev/null || true)
+                    if [[ -n "$new_num" ]]; then
+                        created_nums+=("#$new_num")
+                        log "Created follow-up issue #$new_num: $adj_title"
+                    else
+                        log "WARN: failed to create follow-up issue for: $adj_title"
+                    fi
+                done < <(printf '%s' "$adjacent_json" | jq -c '.[]'  2>/dev/null)
+                if (( ${#created_nums[@]} > 0 )); then
+                    local nums_joined
+                    nums_joined=$(printf '%s, ' "${created_nums[@]}")
+                    nums_joined="${nums_joined%, }"
+                    followup_comment="
+
+---
+📋 **Follow-up issues created:** $nums_joined"
+                fi
+            fi
+        fi
+
+        comment_pr "$pr_number" "PR Review (Iteration $pr_iteration)" "$review_icon **Result:** $review_verdict
+
+$review_summary$followup_comment" "code-reviewer"
+
+        if [[ "$review_verdict" == "approved" ]]; then
+            pr_approved=true
+            log "PR approved on iteration $pr_iteration"
+        else
+            log "PR review requested changes. Fixing..."
+
+            # Collect feedback
+            local review_comments
+            review_comments=$(printf '%s' "$review_result" | jq -r '[.output.issues // [] | .[] | "\(.file // ""):\(.line // "") → \(.description // "")"] | join("\n- ")')
+
+            # Append current iteration issues to history file
+            local current_issues
+            current_issues=$(printf '%s' "$review_result" | jq -c '.output.issues // []')
+            if [[ -f "$review_history_file" ]]; then
+                local existing
+                existing=$(< "$review_history_file")
+                printf '%s' "$existing" | jq --argjson new "$current_issues" '. + [$new]' > "$review_history_file"
+            else
+                printf '[%s]' "$current_issues" > "$review_history_file"
+            fi
+
+            # Build cumulative findings from prior iterations
+            local cumulative_findings=""
+            if [[ -f "$review_history_file" ]]; then
+                cumulative_findings=$(jq -r '
+                    [.[-2:] | .[] | .[]? | .description] | unique | join("\n- ")
+                ' "$review_history_file" 2>/dev/null || printf '')
+            fi
+
+            local fix_from_review_skill
+            fix_from_review_skill=$(load_skill "fix-from-review")
+
+            local fix_prompt="${fix_from_review_skill:+## Skill Instructions — READ AND FOLLOW THESE
+
+$fix_from_review_skill
+
+## End Skill Instructions
+
+}Address PR review feedback on branch $branch in the current working directory:
+
+Current iteration findings:
+$review_comments
+
+$(if [[ -n "$cumulative_findings" ]]; then
+    printf 'Cumulative findings across all iterations (ensure ALL are addressed):\n'
+    printf -- '- %s\n' "$cumulative_findings"
+fi)
+
+Fix the issues and commit. Output a summary of fixes applied."
+
+            verify_on_feature_branch "$branch" || true
+
+            local fix_result
+            fix_result=$(run_stage "fix-pr-review-iter-$pr_iteration" "$fix_prompt" "implement-issue-fix.json" "$AGENT")
+            _halt_if_budget_exceeded
+
+            local fix_summary
+            fix_summary=$(printf '%s' "$fix_result" | jq -r '.output.summary // "Fixes applied"')
+
+            # Comment #12: PR Fix Result
+            comment_pr "$pr_number" "PR Review Fix (Iteration $pr_iteration)" "$fix_summary" "$AGENT"
+
+            # Push updates (quality loop skipped — re-review will catch remaining issues)
+            log "Pushing updates to PR..."
+            git push origin "$branch" 2>/dev/null || log "Warning: Could not push to origin"
+        fi
+        done
+
+        set_stage_completed "pr_review"
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: COMPLETE → PR comment #14
+    # -------------------------------------------------------------------------
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "complete"; then
+        log "Workflow already completed"
+    else
+        set_stage_started "complete"
+
+        local complete_skill
+        complete_skill=$(load_skill "complete-summary")
+
+        local complete_prompt="Generate a completion summary for PR #$pr_number implementing issue #$ISSUE_NUMBER on branch $branch.
+
+${complete_skill:+## Skill Instructions — READ AND FOLLOW THESE
+
+$complete_skill
+
+## End Skill Instructions
+
+}Output a summary suitable for a PR/MR comment."
+
+        local complete_result
+        complete_result=$(run_stage "complete" "$complete_prompt" "implement-issue-complete.json")
+        _halt_if_budget_exceeded
+
+        local complete_summary
+        complete_summary=$(printf '%s' "$complete_result" | jq -r '.output.summary // "Implementation completed successfully"')
+
+        # Add degradation warning to completion comment if any stages soft-failed
+        local degraded_warning=""
+        if (( ${#DEGRADED_STAGES[@]} > 0 )); then
+            degraded_warning="⚠️ **Quality Warning:** The following stages hit their iteration limits and were soft-failed:
+"
+            for ds in "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}"; do
+                degraded_warning+="- \`$ds\`
+"
+            done
+            degraded_warning+="
+Manual review of these areas is recommended.
+
+---
+"
+        fi
+
+        # Comment #14: Implementation complete
+        comment_pr "$pr_number" "Implementation Complete" "${degraded_warning}Issue #$ISSUE_NUMBER has been implemented!
+
+**Branch:** \`$branch\`
+**PR:** #$pr_number
+
+$complete_summary
+
+---
+*This PR is ready for human review and merge.*"
+
+        set_stage_completed "complete"
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: MERGE
+    # Merges the PR/MR into the base branch after successful review.
+    # Uses merge-mr.sh which respects MERGE_STYLE (squash/merge/rebase) from
+    # platform.sh. After merge, checks out and pulls the base branch.
+    # -------------------------------------------------------------------------
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "merge_pr"; then
+        log "Skipping merge_pr stage (already completed)"
+    else
+        set_stage_started "merge_pr"
+        log "merge_pr: stage started"
+
+        # ---------------------------------------------------------------------
+        # MERGE GATE — refuse to auto-merge when the quality loop bailed via a
+        # convergence failure (the reviewer kept flagging the same, likely-real
+        # feedback that more iterations could not resolve).  The block reason is
+        # read from the persisted status.json field so a standalone process-pr
+        # run honours it too; if absent, fall back to scanning the in-memory
+        # DEGRADED_STAGES array.  Override with BLOCK_MERGE_ON_CONVERGENCE_FAILURE=0.
+        # ---------------------------------------------------------------------
+        local merge_blocked_reason=""
+        local merge_block_kind=""   # "convergence" | "partial"
+
+        # Read the persisted merge_blocked_reason once; nothing mutates
+        # status.json between the two gates, so both share this value.
+        local _persisted
+        _persisted=$(jq -r '.merge_blocked_reason // empty' \
+            "$STATUS_FILE" 2>/dev/null || printf '')
+
+        # Gate A — quality-loop convergence failure.  Override:
+        # BLOCK_MERGE_ON_CONVERGENCE_FAILURE=0.  A convergence reason may be
+        # persisted in status.json (so a standalone process-pr honours it) or
+        # live in the in-memory DEGRADED_STAGES array.  A persisted *partial*
+        # reason is deliberately left for Gate B so it gets the
+        # completed_partial state rather than merge_blocked.
+        if [[ "${BLOCK_MERGE_ON_CONVERGENCE_FAILURE:-1}" == "0" ]]; then
+            log "BLOCK_MERGE_ON_CONVERGENCE_FAILURE=0 — skipping merge-block check"
+        else
+            if [[ -n "$_persisted" && "$_persisted" != "Partial implementation:"* ]]; then
+                merge_blocked_reason="$_persisted"
+                merge_block_kind="convergence"
+            else
+                local _ds
+                for _ds in "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}"; do
+                    if [[ "$_ds" == quality:convergence_failure:* ]]; then
+                        merge_blocked_reason="Quality loop convergence failure recorded in degraded_stages: $_ds"
+                        merge_block_kind="convergence"
+                        break
+                    fi
+                done
+            fi
+        fi
+
+        # Gate B — partial task completion or an unresolved PR-review verdict
+        # (issue #577).  Override: BLOCK_MERGE_ON_PARTIAL=0.  Reason source is a
+        # persisted "Partial implementation:" line (process-pr / resumed runs)
+        # or the in-memory DEGRADED_STAGES array (implement:partial:*,
+        # pr_review:max_iterations:*, pr_review:wall_timeout).
+        if [[ -z "$merge_blocked_reason" ]]; then
+            if [[ "${BLOCK_MERGE_ON_PARTIAL:-1}" == "0" ]]; then
+                log "BLOCK_MERGE_ON_PARTIAL=0 — skipping partial/pr-review merge-block check"
+            else
+                if [[ "$_persisted" == "Partial implementation:"* ]]; then
+                    merge_blocked_reason="$_persisted"
+                    merge_block_kind="partial"
+                else
+                    local _dsp
+                    for _dsp in "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}"; do
+                        if [[ "$_dsp" == implement:partial:* ]]; then
+                            merge_blocked_reason="Partial implementation — not all tasks completed (degraded_stages: $_dsp)."
+                            merge_block_kind="partial"
+                            break
+                        fi
+                        if [[ "$_dsp" == pr_review:max_iterations:* || "$_dsp" == pr_review:wall_timeout ]]; then
+                            merge_blocked_reason="PR review loop ended without an approved verdict (degraded_stages: $_dsp)."
+                            merge_block_kind="partial"
+                            break
+                        fi
+                    done
+                fi
+            fi
+        fi
+        log "merge_pr: merge_blocked_reason check done — blocked='${merge_blocked_reason:-<none>}' kind='${merge_block_kind:-none}'"
+
+        if [[ -n "$merge_blocked_reason" ]]; then
+            local _task_summary_line
+            _task_summary_line=$(_format_task_summary_line)
+
+            # Partial-delivery / unresolved-review block (issue #577): distinct
+            # completed_partial state and a non-zero exit (2) so batch metrics
+            # and operators can tell a partial delivery from an error or a full
+            # success.
+            if [[ "$merge_block_kind" == "partial" ]]; then
+                log_warn "Merge blocked for PR #$pr_number: partial delivery / unresolved review"
+                comment_pr "$pr_number" "Merge Blocked — Partial Delivery" \
+                    "🚫 Auto-merge was blocked because not all implementation tasks completed or the PR review never reached an approved verdict. This PR has been left **open** for a human to review and merge (or push further fixes).
+
+$merge_blocked_reason${_task_summary_line:+
+
+$_task_summary_line}
+
+To override this gate and merge anyway, re-run with \`BLOCK_MERGE_ON_PARTIAL=0\`." \
+                    "default"
+                comment_issue "Merge: Blocked (Partial Delivery)" \
+                    "🚫 Merge of PR #$pr_number blocked — partial delivery. PR left open for human review.
+
+$merge_blocked_reason${_task_summary_line:+
+
+$_task_summary_line}" \
+                    "default"
+                set_final_state "completed_partial"
+                cp "$STATUS_FILE" "$LOG_BASE/status.json"
+
+                log "=========================================="
+                log "Implement Issue Complete (partial delivery — merge blocked)"
+                log "=========================================="
+                log "Issue: #$ISSUE_NUMBER"
+                log "PR: #$pr_number"
+                log "Branch: $branch"
+                log "Status: completed_partial"
+                exit 2
+            fi
+
+            # Gate A (convergence) — unchanged behaviour: merge_blocked, exit 0.
+            log_warn "Merge blocked for PR #$pr_number: unresolved quality feedback"
+            comment_pr "$pr_number" "Merge Blocked — Unresolved Quality Feedback" \
+                "🚫 Auto-merge was blocked because the internal quality loop could not resolve recurring review feedback. This PR has been left **open** for a human to review and merge (or push further fixes).
+
+$merge_blocked_reason
+
+To override this gate and merge anyway, re-run with \`BLOCK_MERGE_ON_CONVERGENCE_FAILURE=0\`." \
+                "default"
+            comment_issue "Merge: Blocked" \
+                "🚫 Merge of PR #$pr_number blocked — unresolved quality feedback. PR left open for human review.${merge_blocked_reason:+
+
+$merge_blocked_reason}${_task_summary_line:+
+
+$_task_summary_line}" \
+                "default"
+            set_final_state "merge_blocked"
+            cp "$STATUS_FILE" "$LOG_BASE/status.json"
+
+            log "=========================================="
+            log "Implement Issue Complete (merge blocked)"
+            log "=========================================="
+            log "Issue: #$ISSUE_NUMBER"
+            log "PR: #$pr_number"
+            log "Branch: $branch"
+            log "Status: merge_blocked"
+            exit 0
+        fi
+
+        log "Merging PR #$pr_number into $BASE_BRANCH..."
+        log "merge_pr: posting merge-in-progress comment on issue"
+        comment_issue "Merge: Merging" \
+            "🔀 Merging PR #$pr_number into \`$BASE_BRANCH\`..." \
+            "default"
+        log "merge_pr: merge-in-progress comment posted"
+        log "merge_pr: invoking merge-mr.sh for PR #$pr_number"
+
+        local _merge_exit
+        timeout "$MERGE_MR_STEP_TIMEOUT" "$PLATFORM_DIR/merge-mr.sh" \
+            "$pr_number" >>"${LOG_FILE:-/dev/null}" 2>&1
+        _merge_exit=$?
+        if (( _merge_exit == 124 )); then
+            _handle_merge_pr_timeout "merge-mr.sh" "$MERGE_MR_STEP_TIMEOUT"
+        elif (( _merge_exit != 0 )); then
+            log "merge_pr: merge-mr.sh failed for PR #$pr_number"
+            log_error "Failed to merge PR #$pr_number"
+            comment_issue "Merge: Failed" \
+                "❌ Failed to merge PR #$pr_number. Manual intervention required." \
+                "default"
+            set_final_state "error"
+            exit 1
+        fi
+
+        log "merge_pr: merge-mr.sh succeeded for PR #$pr_number"
+        log "PR #$pr_number merged successfully. Switching to $BASE_BRANCH..."
+
+        log "merge_pr: git fetch origin"
+        timeout "$MERGE_GIT_TIMEOUT" git fetch origin \
+            >>"${LOG_FILE:-/dev/null}" 2>&1
+        _merge_exit=$?
+        if (( _merge_exit == 124 )); then
+            _handle_merge_pr_timeout "git fetch origin" "$MERGE_GIT_TIMEOUT"
+        elif (( _merge_exit != 0 )); then
+            log_error "merge_pr: git fetch origin failed (exit $_merge_exit)"
+            comment_issue "Merge: Git Error" \
+                "❌ \`git fetch origin\` failed (exit ${_merge_exit}) after merging PR #${pr_number}. Manual recovery may be needed." \
+                "default"
+            set_final_state "error"
+            exit 1
+        fi
+
+        log "merge_pr: git checkout $BASE_BRANCH"
+        timeout "$MERGE_GIT_TIMEOUT" git checkout "$BASE_BRANCH" \
+            >>"${LOG_FILE:-/dev/null}" 2>&1
+        _merge_exit=$?
+        if (( _merge_exit == 124 )); then
+            _handle_merge_pr_timeout "git checkout $BASE_BRANCH" "$MERGE_GIT_TIMEOUT"
+        elif (( _merge_exit != 0 )); then
+            log_error "merge_pr: git checkout $BASE_BRANCH failed (exit $_merge_exit)"
+            comment_issue "Merge: Git Error" \
+                "❌ \`git checkout $BASE_BRANCH\` failed (exit ${_merge_exit}) after merging PR #${pr_number}. Manual recovery may be needed." \
+                "default"
+            set_final_state "error"
+            exit 1
+        fi
+
+        log "merge_pr: git pull"
+        timeout "$MERGE_GIT_TIMEOUT" git pull >>"${LOG_FILE:-/dev/null}" 2>&1
+        _merge_exit=$?
+        if (( _merge_exit == 124 )); then
+            _handle_merge_pr_timeout "git pull" "$MERGE_GIT_TIMEOUT"
+        elif (( _merge_exit != 0 )); then
+            log_error "merge_pr: git pull failed (exit $_merge_exit)"
+            comment_issue "Merge: Git Error" \
+                "❌ \`git pull\` failed (exit ${_merge_exit}) after merging PR #${pr_number}. Manual recovery may be needed." \
+                "default"
+            set_final_state "error"
+            exit 1
+        fi
+
+        log "merge_pr: git fetch/checkout/pull complete"
+        log "Now on $BASE_BRANCH (up to date)"
+
+        if [[ "${QUIET:-false}" != "true" ]]; then
+            log "merge_pr: posting merge-complete comment on issue"
+            # Include the task summary on this terminal exit path too (issue
+            # #577) so a full-success merge still reports what was delivered.
+            local _merge_summary_line
+            _merge_summary_line=$(_format_task_summary_line)
+            local _merge_comment
+            _merge_comment=$(cat <<EOF
+## Merge: Complete
+###### *Posted by \`implement-issue-orchestrator\`*
+
+✅ PR #$pr_number merged into \`$BASE_BRANCH\` successfully.${_merge_summary_line:+
+
+$_merge_summary_line}
+EOF
+)
+            timeout "$MERGE_COMMENT_TIMEOUT" "$PLATFORM_DIR/comment-issue.sh" \
+                "$ISSUE_NUMBER" "$_merge_comment" \
+                2>>"${LOG_FILE:-/dev/stderr}"
+            _merge_exit=$?
+            (( _merge_exit == 124 )) \
+                && _handle_merge_pr_timeout \
+                    "comment-issue.sh" "$MERGE_COMMENT_TIMEOUT"
+        fi
+
+        set_stage_completed "merge_pr"
+        set_final_state "completed"
+    fi
+
+    # -------------------------------------------------------------------------
+    # STAGE: DEPLOY VERIFY (post-merge)
+    # Deploys to a configured target environment (test/nas/staging) and polls
+    # the health URL until the service is live, then runs a verification prompt
+    # against the deployed environment.
+    # Runs AFTER merge so the NAS always builds from the merged origin/main.
+    # Gated on: (a) DEPLOY_VERIFY_CMD set in platform.sh, AND
+    #           (b) issue has env:test/env:nas/env:staging label OR body
+    #               contains a "## Deploy Verification" section.
+    # Scope gate uses git diff HEAD~1..HEAD (post-merge diff) so the scope
+    # reflects the actual merged commit rather than the pre-merge branch diff.
+    # -------------------------------------------------------------------------
+    if [[ -n "$RESUME_MODE" ]] && is_stage_completed "deploy_verify"; then
+        log "Skipping deploy_verify stage (already completed)"
+    else
+        if ! should_run_deploy_verify "$ISSUE_NUMBER"; then
+            log "Skipping deploy_verify stage: gate conditions not met"
+            set_stage_started "deploy_verify"
+            if [[ -n "${DEPLOY_VERIFY_CMD:-}" ]]; then
+                comment_issue "Deploy Verify: Skipped" \
+                    "⏭️ Deploy verification skipped (no \`env:*\` label or \`## Deploy Verification\` section found)." \
+                    "default"
+            fi
+            set_stage_completed "deploy_verify"
+        else
+            set_stage_started "deploy_verify"
+
+            # Select deploy command via three-tier scope gate:
+            # frontend-only → --health-only; backend + migrations →
+            # DEPLOY_VERIFY_CMD (full NAS); backend logic-only →
+            # DEPLOY_LOCAL_CMD when set, else DEPLOY_VERIFY_CMD.
+            # Diff uses HEAD~1..HEAD (post-merge) so scope reflects the
+            # actual merged commit, not the pre-merge branch diff.
+            local changed_files deploy_cmd
+            changed_files=$(git diff HEAD~1..HEAD --name-only 2>/dev/null \
+                || true)
+            deploy_cmd=$(_select_deploy_cmd "$changed_files")
+
+            log "Triggering deploy via: $deploy_cmd"
+            comment_issue "Deploy Verify: Deploying" \
+                "🚀 Triggering deployment via \`$deploy_cmd\`..." \
+                "default"
+
+            # Run the deploy command
+            local deploy_exit=0
+            if ! bash -c "$deploy_cmd" \
+                >>"${LOG_FILE:-/dev/null}" 2>&1; then
+                deploy_exit=1
+            fi
+
+            if ((deploy_exit != 0)); then
+                log_error "Deploy command failed (exit $deploy_exit)"
+                comment_issue "Deploy Verify: Failed" \
+                    "❌ Deploy command \`$deploy_cmd\` exited with code $deploy_exit. Skipping health poll and verification." \
+                    "default"
+                # Deploy failure is intentionally non-blocking: the pipeline
+                # finishes and the failure surfaces via the issue comment.
+                # Also record a degraded-stage flag in status.json so the
+                # batch summary surfaces the failure (comments are not read
+                # by the batch orchestrator).
+                DEGRADED_STAGES+=("deploy_verify:deploy_failed:exit=$deploy_exit")
+                set_stage_completed "deploy_verify"
+            else
+                log "Deploy command succeeded"
+
+                # Poll health URL if configured; poll_health_url returns 0
+                # if the URL is empty (skip = healthy) or 2xx received.
+                local poll_interval=10
+                local max_retries=$(( \
+                    ${DEPLOY_VERIFY_TIMEOUT_SECS:-900} / poll_interval ))
+                local health_ok=false
+                if [[ -n "${DEPLOY_VERIFY_HEALTH_URL:-}" ]]; then
+                    log "Polling health URL: $DEPLOY_VERIFY_HEALTH_URL" \
+                        "(${poll_interval}s intervals, $max_retries retries max)"
+                else
+                    log "No DEPLOY_VERIFY_HEALTH_URL configured —" \
+                        "skipping health poll"
+                fi
+                if poll_health_url \
+                    "${DEPLOY_VERIFY_HEALTH_URL:-}" \
+                    "$max_retries" \
+                    "$poll_interval"; then
+                    health_ok=true
+                else
+                    log_error "Health check failed after $max_retries" \
+                        "attempts ($(( max_retries * poll_interval / 60 )) min)"
+                    comment_issue "Deploy Verify: Health Timeout" \
+                        "❌ Health endpoint \`$DEPLOY_VERIFY_HEALTH_URL\` did not return 2xx after $max_retries attempts ($(( max_retries * poll_interval / 60 )) min). Deployment may have failed." \
+                        "default"
+                    # Non-blocking: flag in status.json so the batch summary
+                    # surfaces the health timeout, not just the issue comment.
+                    DEGRADED_STAGES+=("deploy_verify:health_timeout:attempts=$max_retries")
+                    set_stage_completed "deploy_verify"
+                fi
+
+                # Run verification prompt if health check passed
+                if $health_ok; then
+                    log "Running deploy verification prompt"
+
+                    # Extract Deploy Verification section from issue body
+                    local deploy_verify_section=""
+                    local issue_body_file="$LOG_BASE/context/issue-body.md"
+                    if [[ -f "$issue_body_file" ]]; then
+                        deploy_verify_section=$(awk \
+                            '/^## Deploy Verification/{found=1; next}
+                             found && /^## /{exit}
+                             found{print}' \
+                            "$issue_body_file")
+                    fi
+
+                    local deploy_verify_prompt
+                    deploy_verify_prompt="Verify the deployment for issue #$ISSUE_NUMBER against the live environment.
+
+DEPLOYED ENVIRONMENT:
+- Deploy command: $deploy_cmd
+- Health URL: ${DEPLOY_VERIFY_HEALTH_URL:-N/A}
+- Health status: passed
+
+ISSUE ACCEPTANCE CRITERIA:
+$(awk '/^## Acceptance Criteria/{found=1; next} found && /^## /{exit} found{print}' \
+    "$issue_body_file" 2>/dev/null || printf '%s' '(not found)')
+
+DEPLOY VERIFICATION INSTRUCTIONS:
+${deploy_verify_section:-No specific deploy verification instructions in the issue. Verify the deployment is functional by checking health endpoints and basic functionality.}
+
+STEPS:
+1. Confirm the health endpoint returns a 2xx response
+2. Test the key functionality described in the acceptance criteria against the live URL
+3. Check for any error logs or degraded behavior
+4. Report status as 'success', 'error', or 'partial' with a detailed summary"
+
+                    local deploy_verify_result
+                    deploy_verify_result=$(run_stage \
+                        "deploy-verify" \
+                        "$deploy_verify_prompt" \
+                        "implement-issue-deploy-verify.json" \
+                        "default")
+                    _halt_if_budget_exceeded
+
+                    local dv_status dv_health dv_summary
+                    dv_status=$(printf '%s' "$deploy_verify_result" \
+                        | jq -r '.output.status // "unknown"')
+                    dv_health=$(printf '%s' "$deploy_verify_result" \
+                        | jq -r '.output.health_status // "unknown"')
+                    dv_summary=$(printf '%s' "$deploy_verify_result" \
+                        | jq -r \
+                        '.output.summary // "Deploy verification completed"')
+
+                    local dv_icon="✅"
+                    [[ "$dv_status" == "error" ]] && dv_icon="❌"
+                    [[ "$dv_status" == "partial" ]] && dv_icon="⚠️"
+
+                    comment_issue "Deploy Verify" \
+                        "$dv_icon **Status:** $dv_status | **Health:** $dv_health
+
+$dv_summary" \
+                        "default"
+
+                    # Non-blocking: record a degraded-stage flag in
+                    # status.json for error/partial verdicts so the batch
+                    # summary surfaces the result beyond the issue comment.
+                    if [[ "$dv_status" == "error" \
+                        || "$dv_status" == "partial" ]]; then
+                        DEGRADED_STAGES+=("deploy_verify:verify_$dv_status")
+                    fi
+
+                    if [[ "$dv_status" == "error" ]]; then
+                        log_error "Deploy verification failed"
+                    else
+                        log "Deploy verification: $dv_status"
+                    fi
+
+                    set_stage_completed "deploy_verify"
+                fi
+            fi
+        fi
+    fi
+
+    set_final_state "completed"
+
+    # Record degraded stages in status.json
+    if (( ${#DEGRADED_STAGES[@]} > 0 )); then
+        local degraded_json
+        degraded_json=$(printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" | jq -R . | jq -s .)
+        jq --argjson degraded "$degraded_json" '.degraded_stages = $degraded' "$STATUS_FILE" > "$STATUS_FILE.tmp" && mv "$STATUS_FILE.tmp" "$STATUS_FILE"
+    fi
+
+    # Copy final status to log dir
+    cp "$STATUS_FILE" "$LOG_BASE/status.json"
+
+    log "=========================================="
+    log "Implement Issue Complete"
+    log "=========================================="
+    log "Issue: #$ISSUE_NUMBER"
+    log "PR: #$pr_number"
+    log "Branch: $branch"
+    log "Status: completed"
+
+    exit 0
+}
+
+# Run main
+main "$@"

--- a/plugins/pipeline-core/scripts/issue-body-lib.sh
+++ b/plugins/pipeline-core/scripts/issue-body-lib.sh
@@ -1,0 +1,658 @@
+#!/usr/bin/env bash
+#
+# issue-body-lib.sh - Validation helpers for pipeline issue bodies
+#
+# Sourceable library (no main()).  Exposes three public functions:
+#
+#   valid_agents
+#       Prints the set of known agent names — one per line, sorted and
+#       unique — derived from the .claude/agents/*.md definitions.
+#
+#   lint_task_lines <body>
+#       Preflight lint for the "Implementation Tasks" section — emits one
+#       "<cause>\t<line>" record (cause: format / agent-unresolved /
+#       path-unresolved) per in-section line a parse would silently drop or
+#       degrade.  Makes 0-task / mis-extracted parses loud and actionable.
+#
+#   assert_issue_valid <body>
+#       Validates an issue body string against seven structural criteria:
+#         1. at least one parseable (open) task line
+#         2. every task agent resolves to a known agent (or "default")
+#         3. every file path referenced in a task resolves (file exists or
+#            its parent directory exists)
+#         4. an "Acceptance Criteria" section is present (any heading depth)
+#         5. a "Deploy Verification" section exists if and only if (any heading depth)
+#            DEPLOY_VERIFY_CMD is set
+#         6. task granularity — no M/L task references more than two distinct
+#            file paths (decomposable tasks must be split into S sub-tasks)
+#         7. every open task references at least one file path (a task with
+#            zero path tokens is rejected — the #1 explore-stage token sink)
+#       Additionally emits a non-failing stderr WARNING reporting the
+#       M/L-vs-S task count whenever the body has any non-S task.
+#       Returns 0 when valid; prints one diagnostic per failure to stderr
+#       and returns 1 otherwise.
+#
+# Configuration (environment overrides, mainly for testing):
+#   ISSUE_BODY_AGENTS_DIR   agents directory (default: <lib>/../agents)
+#   ISSUE_BODY_REPO_ROOT    repo root for path resolution (default: .)
+#   DEPLOY_VERIFY_CMD       deploy verification gate (see criterion 5)
+#
+# Task-parsing, agent-normalization, and path-extraction logic is extracted
+# from implement-issue-orchestrator.sh:
+#   _normalize_agent_name          (legacy remap + .md resolution)
+#   _extract_task_files_from_desc  (path token extraction)
+#
+
+# Idempotent source guard — re-sourcing is a no-op so readonly constants and
+# repeated `source` calls never error.
+[[ -n "${_ISSUE_BODY_LIB_SOURCED:-}" ]] && return 0
+_ISSUE_BODY_LIB_SOURCED=1
+
+# Known file extensions used to qualify bare filename tokens — mirrors
+# KNOWN_FILE_EXTENSIONS in the orchestrator (version strings, domains, etc.
+# are excluded).
+readonly ISSUE_BODY_KNOWN_EXTS='sh|bats|bash|ts|tsx|js|jsx|mjs|cjs|py|go|rb|rs|java|kt|swift|json|yaml|yml|toml|sql|md|css|html|tf'
+
+# Canonical "Implementation Tasks" heading matcher (issue #584 parity) — the
+# SINGLE source of truth for both library parsers, which both route section
+# slicing through _issue_body_tasks_section.  Behaviour, applied IDENTICALLY at
+# every mirror site:
+#   * ERE, UNANCHORED at the tail — annotated headings such as
+#     "## Implementation Tasks (draft)" are recognised (do NOT re-add a `$`).
+#   * Case-insensitive — folded at the call site (bash: nocasematch; awk:
+#     tolower($0); grep: -i).
+#   * CRLF-tolerant — the caller strips carriage returns before matching.
+# The orchestrator mirrors this exact behaviour via ISSUE_TASKS_HEADING_ERE in
+# implement-issue-orchestrator.sh; a parity test (test-parser-parity.bats)
+# guards the two against drift.
+readonly ISSUE_BODY_TASKS_HEADING_RE='^##+[[:space:]]+Implementation Tasks'
+
+# Resolve this library's own directory so the default agents dir can be
+# located relative to it.
+_issue_body_lib_dir() {
+	local src="${BASH_SOURCE[0]}"
+	local dir="${src%/*}"
+	(cd "$dir" 2>/dev/null && pwd)
+}
+
+#
+# Maps a file path to the specialist agent best suited for that file type.
+# Validates the candidate against ISSUE_BODY_AGENTS_DIR and degrades to
+# "default" when no .md definition exists.
+#
+# Arguments:
+#   $1 - file path (empty string → returns "default")
+# Outputs:
+#   Validated agent name on stdout (always a defined agent or "default")
+#
+_infer_agent_from_path() {
+	local file_path="${1:-}"
+
+	if [[ -z "$file_path" ]]; then
+		printf '%s' "default"
+		return
+	fi
+
+	# Strip :line/:function suffix (e.g. "file.sh:330-334" → "file.sh") before
+	# extracting the extension — callers commonly pass File:Line references.
+	local bare_path="${file_path%%:*}"
+	local ext="${bare_path##*.}"
+	local candidate
+
+	case "$ext" in
+		sh|bats|bash)
+			candidate="bash-script-craftsman"
+			;;
+		ts|tsx|js|jsx|mjs|cjs)
+			# Disambiguate frontend vs backend via FRONTEND_PATH_PATTERNS
+			# (pipe-separated globs from platform.sh).
+			#   Patterns set + path matches → react-frontend-developer
+			#   Patterns set + no match     → fastify-backend-developer
+			#   Patterns unset              → ambiguous → default
+			if [[ -n "${FRONTEND_PATH_PATTERNS:-}" ]]; then
+				local pattern
+				local IFS='|'
+				for pattern in ${FRONTEND_PATH_PATTERNS}; do
+					# shellcheck disable=SC2254
+					case "$file_path" in
+						$pattern)
+							candidate="react-frontend-developer"
+							break
+							;;
+					esac
+				done
+				candidate="${candidate:-fastify-backend-developer}"
+			else
+				candidate="default"
+			fi
+			;;
+		*)
+			candidate="default"
+			;;
+	esac
+
+	# "default" is always valid — no .md definition required.
+	if [[ "$candidate" == "default" ]]; then
+		printf '%s' "default"
+		return
+	fi
+
+	# Degrade to "default" when the inferred agent has no local .md definition.
+	local agents_dir
+	agents_dir="${ISSUE_BODY_AGENTS_DIR:-$(_issue_body_lib_dir)/../agents}"
+	if [[ ! -f "${agents_dir}/${candidate}.md" ]]; then
+		candidate="default"
+	fi
+
+	printf '%s' "$candidate"
+}
+
+#
+# Prints the known agent names — one per line, sorted-unique — derived from
+# the .claude/agents/*.md definitions.
+#
+valid_agents() {
+	local agents_dir="${ISSUE_BODY_AGENTS_DIR:-$(_issue_body_lib_dir)/../agents}"
+	local file name
+
+	for file in "$agents_dir"/*.md; do
+		[[ -f "$file" ]] || continue
+		name="${file##*/}"
+		name="${name%.md}"
+		printf '%s\n' "$name"
+	done | sort -u
+}
+
+#
+# Applies legacy→current agent-name remapping (mirrors the orchestrator's
+# _normalize_agent_name allowlist).  Never deletes old entries so historical
+# issue bodies keep parsing cleanly.
+#
+# Arguments:
+#   $1 - raw agent name
+# Outputs:
+#   Remapped agent name on stdout
+#
+_issue_body_remap_agent() {
+	local name="$1"
+	case "$name" in
+		test-engineer) name="playwright-test-developer" ;;
+	esac
+	printf '%s' "$name"
+}
+
+#
+# Extracts candidate file paths from a task description (mirrors the
+# orchestrator's _extract_task_files_from_desc).
+#
+# Arguments:
+#   $1 - task description string
+# Outputs:
+#   Newline-separated, sorted-unique file paths (empty if none found)
+#
+_issue_body_extract_paths() {
+	local desc="$1"
+	local grep_pat
+	# Only backtick-quoted tokens are treated as paths.  Bare tokens are
+	# deliberately NOT matched: free-text like "fix input/output handling"
+	# would otherwise be read as the path "input/output", fail validation,
+	# and silently drop a legitimate follow-up.  Real follow-up bodies always
+	# wrap file paths in backticks, so this loses no genuine paths.
+	# Qualify only when path-like ('/') or extension-bearing.
+	# Literal backticks below are markdown delimiters, not substitution.
+	# shellcheck disable=SC2016
+	grep_pat='`[a-zA-Z0-9_.-]*/[a-zA-Z0-9_./-]+`'
+	grep_pat+='|`[a-zA-Z0-9_.-]+\.'"($ISSUE_BODY_KNOWN_EXTS)"'`'
+	printf '%s' "$desc" \
+		| grep -oE "$grep_pat" \
+		| sed 's/`//g' \
+		| sort -u
+}
+
+#
+# Extracts the S/M/L complexity hint from a task description.  The hint is the
+# first `**(S)**` / `**(M)**` / `**(L)**` marker (case-insensitive) in the
+# description.  A description with no marker defaults to "M" — mirroring the
+# orchestrator's hint-less default (implement-issue-orchestrator.sh:3834),
+# which treats an unsized task as medium.
+#
+# Arguments:
+#   $1 - task description string
+# Outputs:
+#   One of "S", "M", or "L" on stdout
+#
+_issue_body_task_complexity() {
+	local desc="$1"
+	local hint="M"
+	if [[ "$desc" =~ \*\*\(([SsMmLl])\)\*\* ]]; then
+		hint="${BASH_REMATCH[1]}"
+	fi
+	# Normalize to uppercase without relying on bash-4 case conversion.
+	case "$hint" in
+		s) hint="S" ;;
+		m) hint="M" ;;
+		l) hint="L" ;;
+	esac
+	printf '%s' "$hint"
+}
+
+#
+# Counts the distinct file paths referenced in a task description for the
+# granularity criterion.  The canonical Task Format appends an optional
+# ":Lnn"/":nn-mm" line-range suffix to each backtick-quoted path
+# (e.g. `src/app.ts:L45-80`).  `_issue_body_extract_paths` cannot match those
+# tokens because its path char-class excludes ':', so the suffix is stripped
+# here first — this also collapses `file.ts:L10` and `file.ts:L90` to a single
+# distinct path, matching the "distinct file paths" intent.
+#
+# Arguments:
+#   $1 - task description string
+# Outputs:
+#   Distinct path count (integer) on stdout
+#
+_issue_body_task_path_count() {
+	local desc="$1"
+	local stripped
+	stripped=$(printf '%s' "$desc" \
+		| sed -E 's/(`[A-Za-z0-9_./-]+):[A-Za-z0-9_.,-]*(`)/\1\2/g')
+	_issue_body_extract_paths "$stripped" | grep -c '.' || true
+}
+
+#
+# Parses open task lines from an issue body, emitting one
+# "agent<TAB>description" record per task (mirrors the canonical and
+# fallback patterns of the orchestrator's _parse_task_lines).  Checked [x]
+# tasks are treated as complete and skipped.
+#
+# Only lines inside an "Implementation Tasks" heading section are matched
+# (any heading level: ##, ###, etc.) — see the in-function
+# section-extraction loop below.  The section ends at the next heading of
+# any level (## or deeper).
+#
+# Caller audit (confirmed no dependency on whole-body parsing):
+#   assert_issue_valid() [issue-body-lib.sh:292]
+#       Passes the full issue body but consumes only the section-scoped
+#       output.  It never relied on task lines from other sections.
+#   BATS tests [implement-issue-test/test-issue-body-lib.bats]
+#       All invocations either supply a body that contains an
+#       "Implementation Tasks" heading, or explicitly assert that
+#       section-less / out-of-section lines yield no output.  None
+#       depend on the pre-scoping, whole-body-parsing behaviour.
+#
+# Arguments:
+#   $1 - issue body text
+# Outputs:
+#   Tab-separated agent/description records on stdout
+#
+#
+# Extracts the raw text of the "Implementation Tasks" section from an issue
+# body — the single source of truth for section slicing shared by
+# _issue_body_parse_tasks and lint_task_lines so the two stay behaviourally
+# identical.
+#
+# Hardening (issue #584):
+#   * CRLF tolerance — strips carriage returns first so a Windows/gh CRLF
+#     body cannot leak "\r" into descriptions or defeat the $-anchored
+#     task regexes (the heading matcher is deliberately UNANCHORED — see
+#     ISSUE_BODY_TASKS_HEADING_RE — so annotated headings still match).
+#   * Case-insensitive heading — matches "## Implementation Tasks",
+#     "## implementation tasks", etc. via a locally-scoped nocasematch
+#     (bash-3.2-safe; ${x,,} is deliberately avoided elsewhere in this lib).
+#
+# The section spans from the "Implementation Tasks" heading (any depth:
+# ##, ###, …) up to the next ## or deeper heading (or end of body).
+#
+# Arguments:
+#   $1 - issue body text
+# Outputs:
+#   Section text on stdout (may be empty when the section has no lines)
+# Returns:
+#   0 when an "Implementation Tasks" heading was found, 1 otherwise
+#
+_issue_body_tasks_section() {
+	local body="$1"
+	# Strip carriage returns so CRLF bodies parse identically to LF bodies.
+	body="${body//$'\r'/}"
+	# Normalize gh API's backslash-escaped backticks.
+	body="${body//\\\`/\`}"
+
+	# Case-insensitive heading match — save/restore nocasematch so callers
+	# are unaffected.  Only the heading detection needs it; the task-line
+	# regexes below run case-sensitively (agent names, [x] markers).
+	local _ci_saved
+	_ci_saved=$(shopt -p nocasematch)
+	shopt -s nocasematch
+
+	local in_section=false
+	local section=""
+	local line
+	while IFS= read -r line; do
+		if [[ "$line" =~ $ISSUE_BODY_TASKS_HEADING_RE ]]; then
+			in_section=true
+			continue
+		fi
+		if $in_section; then
+			# Any new ## or deeper heading ends the section.
+			if [[ "$line" =~ ^##+[[:space:]] ]]; then
+				break
+			fi
+			section+="${line}"$'\n'
+		fi
+	done <<< "$body"
+
+	eval "$_ci_saved"
+
+	$in_section || return 1
+	printf '%s' "$section"
+	return 0
+}
+
+_issue_body_parse_tasks() {
+	local body="$1"
+
+	# Extract only the lines under "Implementation Tasks" (any heading
+	# level: ##, ###, etc.), stopping at the next ## or deeper heading (or
+	# end of body).  Lines from other sections
+	# (Acceptance Criteria, Notes, Deploy Verification, etc.) are never
+	# matched as tasks, preventing false positives from prose that happens
+	# to resemble a task line.  No "Implementation Tasks" heading (any
+	# depth) — emit nothing.
+	local section
+	section=$(_issue_body_tasks_section "$body") || return 0
+
+	# Backtick-bearing regex must live in a variable — bash cannot escape a
+	# backtick inside an inline [[ =~ ]] pattern reliably.
+	local bt='`'
+	local re_bare_agent="^- (\[ \] )?${bt}([^${bt}]+)${bt} (.+)\$"
+
+	local agent desc
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		[[ "$line" =~ \[x\] ]] && continue
+
+		agent=""
+		desc=""
+
+		# Canonical:  - [ ] `[agent]` desc   OR   - `[agent]` desc
+		if [[ "$line" =~ ^-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+
+		# Fallback 1: missing backticks — - [ ] [agent] desc
+		elif [[ "$line" =~ ^-\ (\[\ \]\ )?\[([^\]\ ]+)\]\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+
+		# Fallback 2: asterisk bullet — * [ ] `[agent]` desc
+		elif [[ "$line" =~ ^\*\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+
+		# Fallback 3: leading whitespace — <ws>- [ ] `[agent]` desc
+		elif [[ "$line" =~ ^[[:space:]]+-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+
+		# Fallback 4: missing square brackets — - [ ] `agent` desc
+		elif [[ "$line" =~ $re_bare_agent ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+
+		else
+			continue
+		fi
+
+		printf '%s\t%s\n' "$agent" "$desc"
+	done <<< "$section"
+}
+
+#
+# Preflight lint for the "Implementation Tasks" section (issue #584).
+#
+# Emits one tab-separated rejection record — "<cause>\t<line>" — for every
+# in-section candidate line that a downstream parse would silently drop or
+# silently degrade.  This makes the failure classes the mirrored parsers hide
+# LOUD and actionable:
+#
+#   format            the line matches no task pattern (canonical or any of
+#                     the four fuzzy fallbacks) — e.g. a prose "Task 1: …"
+#                     line or a bullet with neither backticks nor brackets.
+#                     _parse_task_lines / _issue_body_parse_tasks would
+#                     `continue` past it with no diagnostic.
+#   agent-unresolved  the line parses, but its agent name resolves to neither
+#                     a known agent nor "default" — the parser would silently
+#                     degrade it to "default".
+#   path-unresolved   the line parses, but a backtick-quoted file path it
+#                     references neither exists nor has an existing parent
+#                     directory (mirrors assert_issue_valid criterion 3).
+#
+# Well-formed tasks emit nothing.  Blank lines, checked [x] tasks, and
+# "Affected files:" continuation lines are skipped (never candidates).  One
+# record per line, cause priority: format > agent-unresolved > path-unresolved.
+#
+# Section slicing (CRLF tolerance + case-insensitive heading) is shared with
+# _issue_body_parse_tasks via _issue_body_tasks_section, so the lint sees
+# exactly the lines the parser would.
+#
+# Arguments:
+#   $1 - issue body text
+# Outputs:
+#   Zero or more "<cause>\t<line>" records on stdout
+# Returns:
+#   0 always (a lint report is informational, not a failure signal)
+#
+lint_task_lines() {
+	local body="$1"
+	local repo_root="${ISSUE_BODY_REPO_ROOT:-.}"
+
+	# No "Implementation Tasks" heading — nothing to lint.
+	local section
+	section=$(_issue_body_tasks_section "$body") || return 0
+
+	local valid_set
+	valid_set=$(valid_agents)
+
+	local bt='`'
+	local re_bare_agent="^- (\[ \] )?${bt}([^${bt}]+)${bt} (.+)\$"
+
+	local line agent desc remapped path parent unresolved_path
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		# Checked [x] tasks are complete; the parser skips them, so does lint.
+		[[ "$line" =~ \[x\] ]] && continue
+		# "Affected files:" continuation lines are metadata, not candidates.
+		[[ "$line" =~ ^[[:space:]]*[Aa]ffected[[:space:]][Ff]iles: ]] && continue
+
+		agent=""
+		desc=""
+
+		# Same pattern ladder as _issue_body_parse_tasks — a line that matches
+		# none of these is a format rejection.
+		if [[ "$line" =~ ^-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+		elif [[ "$line" =~ ^-\ (\[\ \]\ )?\[([^\]\ ]+)\]\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+		elif [[ "$line" =~ ^\*\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+		elif [[ "$line" =~ ^[[:space:]]+-\ (\[\ \]\ )?\`\[([^\]]+)\]\`\ (.+)$ ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+		elif [[ "$line" =~ $re_bare_agent ]]; then
+			agent="${BASH_REMATCH[2]}"
+			desc="${BASH_REMATCH[3]}"
+		else
+			printf 'format\t%s\n' "$line"
+			continue
+		fi
+
+		# Criterion-2 mirror: agent must resolve to a known agent or "default".
+		remapped=$(_issue_body_remap_agent "$agent")
+		if [[ "$remapped" != "default" ]] \
+			&& ! grep -qxF "$remapped" <<< "$valid_set"; then
+			printf 'agent-unresolved\t%s\n' "$line"
+			continue
+		fi
+
+		# Criterion-3 mirror: every referenced path must resolve.
+		unresolved_path=""
+		while IFS= read -r path; do
+			[[ -z "$path" ]] && continue
+			if [[ "$path" == */* ]]; then
+				parent="${path%/*}"
+			else
+				parent="."
+			fi
+			if [[ ! -e "$repo_root/$path" && ! -d "$repo_root/$parent" ]]; then
+				unresolved_path="$path"
+				break
+			fi
+		done < <(_issue_body_extract_paths "$desc")
+
+		if [[ -n "$unresolved_path" ]]; then
+			printf 'path-unresolved\t%s\n' "$line"
+			continue
+		fi
+	done <<< "$section"
+
+	return 0
+}
+
+#
+# Validates an issue body against the structural criteria.
+#
+# Hard criteria (any failure → stderr diagnostic + return 1):
+#   1. at least one parseable open task line
+#   2. every task agent resolves to a known agent (or "default")
+#   3. every referenced file path resolves (file exists or parent dir exists)
+#   4. an "Acceptance Criteria" section is present
+#   5. a "Deploy Verification" section iff DEPLOY_VERIFY_CMD is set
+#   6. task granularity — no M/L task references more than two distinct file
+#      paths (a decomposable task that should be split into S sub-tasks)
+#   7. every open task references at least one file path — a task whose
+#      description yields zero path tokens is rejected (the diagnostic names
+#      the offending task).  Checked [x] tasks are exempt (the parser skips
+#      them, so only OPEN tasks reach this gate)
+#
+# Soft advisory (never fails the body):
+#   * emits a stderr WARNING reporting the M/L-vs-S task count whenever the
+#     body contains at least one non-S task
+#
+# Arguments:
+#   $1 - issue body text
+# Outputs:
+#   One diagnostic per hard failure, plus the optional task-mix warning, on
+#   stderr
+# Returns:
+#   0 when valid, 1 otherwise
+#
+assert_issue_valid() {
+	local body="$1"
+	local repo_root="${ISSUE_BODY_REPO_ROOT:-.}"
+	local -a errors=()
+
+	local valid_set
+	valid_set=$(valid_agents)
+
+	local tasks
+	tasks=$(_issue_body_parse_tasks "$body")
+
+	# Criterion 1: at least one parseable open task.
+	if [[ -z "$tasks" ]]; then
+		errors+=("no parseable task lines found")
+	fi
+
+	# Criteria 2, 3, 6 & 7: agents resolve, path suffixes resolve, granularity,
+	# and every open task carries at least one file path.
+	local agent desc remapped path parent complexity path_count
+	local -i s_count=0 nons_count=0
+	while IFS=$'\t' read -r agent desc; do
+		[[ -z "$agent" ]] && continue
+
+		# Criterion 2: agent resolves to a known agent or "default".
+		remapped=$(_issue_body_remap_agent "$agent")
+		if [[ "$remapped" != "default" ]] \
+			&& ! grep -qxF "$remapped" <<< "$valid_set"; then
+			errors+=("unknown agent: $agent")
+		fi
+
+		# Criterion 3: every referenced path resolves.
+		while IFS= read -r path; do
+			[[ -z "$path" ]] && continue
+			if [[ "$path" == */* ]]; then
+				parent="${path%/*}"
+			else
+				parent="."
+			fi
+			if [[ ! -e "$repo_root/$path" \
+				&& ! -d "$repo_root/$parent" ]]; then
+				errors+=("unresolved path: $path")
+			fi
+		done < <(_issue_body_extract_paths "$desc")
+
+		# Distinct file-path count (":Lnn"-suffix aware — reuses #581's
+		# _issue_body_task_path_count so a lone `file.ts:L10-40` still counts as
+		# one path).  Computed once and shared by criteria 7 and 6.
+		path_count=$(_issue_body_task_path_count "$desc")
+
+		# Criterion 7: every open task must reference at least one file path.
+		# A task with zero path tokens forces the implement stage to scan the
+		# codebase blind — the #1 token sink the explore skill warns about.
+		# The parser already skips checked [x] tasks, so only OPEN tasks are
+		# gated here; the diagnostic names the offending task.
+		if (( path_count == 0 )); then
+			errors+=("task has no file path: ${desc}")
+		fi
+
+		# Criterion 6: task granularity.  Tally the S/non-S mix for the
+		# advisory warning, and hard-fail any M/L task that names more than
+		# two distinct file paths — a decomposable task the explore step
+		# should have split into S sub-tasks.
+		complexity=$(_issue_body_task_complexity "$desc")
+		if [[ "$complexity" == "S" ]]; then
+			s_count=$((s_count + 1))
+		else
+			nons_count=$((nons_count + 1))
+			if (( path_count > 2 )); then
+				errors+=("task granularity: (${complexity}) task references ${path_count} distinct file paths (>2); split into S sub-tasks — ${desc}")
+			fi
+		fi
+	done <<< "$tasks"
+
+	# Advisory (never fails the body): report the non-S task mix so operators
+	# see the M/L-vs-S balance and are nudged toward S-only decomposition.
+	if (( nons_count > 0 )); then
+		printf 'assert_issue_valid: WARNING: %d non-S task(s) (M/L) vs %d S task(s); prefer splitting M/L into S sub-tasks\n' \
+			"$nons_count" "$s_count" >&2
+	fi
+
+	# Criterion 4: Acceptance Criteria section present.
+	if ! grep -qE '^##+ Acceptance Criteria' <<< "$body"; then
+		errors+=("missing 'Acceptance Criteria' section")
+	fi
+
+	# Criterion 5: Deploy Verification iff DEPLOY_VERIFY_CMD set.
+	local has_deploy=false
+	if grep -qE '^##+ Deploy Verification' <<< "$body"; then
+		has_deploy=true
+	fi
+	if [[ -n "${DEPLOY_VERIFY_CMD:-}" ]]; then
+		if [[ "$has_deploy" == false ]]; then
+			errors+=("DEPLOY_VERIFY_CMD set but no 'Deploy Verification' section")
+		fi
+	elif [[ "$has_deploy" == true ]]; then
+		errors+=("'Deploy Verification' section present but DEPLOY_VERIFY_CMD unset")
+	fi
+
+	if ((${#errors[@]} > 0)); then
+		local err
+		for err in "${errors[@]}"; do
+			printf 'assert_issue_valid: %s\n' "$err" >&2
+		done
+		return 1
+	fi
+
+	return 0
+}

--- a/plugins/pipeline-core/scripts/lint-test-assertions.sh
+++ b/plugins/pipeline-core/scripts/lint-test-assertions.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+#
+# lint-test-assertions.sh — Deterministic linter for hollow assertion patterns
+#
+# Scans test files for three hollow-assertion patterns and emits structured
+# JSON findings for use by the pipeline's test-validation stage.
+#
+# Usage: lint-test-assertions.sh <file1> [<file2> …]
+#
+# Detects:
+#   mock-timing-perf    — performance.now() threshold on a mocked function
+#   constant-arithmetic — expect() wraps compile-time constant arithmetic
+#   self-referential-matcher — toBe/toEqual compares same property on two objects
+#
+# Environment:
+#   LINT_TEST_ASSERTIONS  Set to 0 to disable; defaults to 1 (enabled)
+#
+# Output (stdout):
+#   JSON array: [{file,line,pattern,snippet,severity}, …]
+#   Emits [] when no findings or when the linter is disabled.
+#
+# Exit codes:
+#   0  Success (with or without findings; no-args emits [] and exits 0)
+#
+
+set -u
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+
+_err() {
+	printf '%s: %s\n' "$SCRIPT_NAME" "$*" >&2
+}
+
+usage() {
+	cat <<EOF
+Usage: $SCRIPT_NAME <file1> [<file2> …]
+
+Scan test files for hollow assertion patterns; emit JSON findings.
+
+Patterns:
+  mock-timing-perf    performance.now() threshold against a mocked function
+  constant-arithmetic expect() argument is compile-time constant arithmetic
+  self-referential-matcher  toBe/toEqual compares identical property from two objects
+
+Environment:
+  LINT_TEST_ASSERTIONS  0 disables the linter (default: 1)
+EOF
+}
+
+# -----------------------------------------------------------------------
+# _ltrim <string>
+# Print string with leading whitespace stripped.
+# -----------------------------------------------------------------------
+_ltrim() {
+	local s="$1"
+	printf '%s' "${s#"${s%%[![:space:]]*}"}"
+}
+
+# -----------------------------------------------------------------------
+# _emit_finding <tmpdir> <file> <lineno> <pattern> <snippet> <severity>
+# Append one JSON finding object to <tmpdir>/findings.jsonl.
+# -----------------------------------------------------------------------
+_emit_finding() {
+	local tmpdir="$1" file="$2" lineno="$3"
+	local pattern="$4" snippet="$5" severity="$6"
+	jq -n \
+		--arg    file     "$file"     \
+		--argjson line    "$lineno"   \
+		--arg    pattern  "$pattern"  \
+		--arg    snippet  "$snippet"  \
+		--arg    severity "$severity" \
+		'{file:$file,line:$line,pattern:$pattern,
+		  snippet:$snippet,severity:$severity}' \
+		>> "$tmpdir/findings.jsonl"
+}
+
+# -----------------------------------------------------------------------
+# _scan_constant_arithmetic <file> <tmpdir>
+# Flag expect(<const_expr>) where the argument is purely numeric literals
+# combined with arithmetic operators — no runtime values involved.
+# Example: expect(30000/5).toBe(6000)
+# Example: expect(413+369.4 < 1024).toBe(true)
+# Two-signal: first operand AND operator AND second operand are all numeric.
+# -----------------------------------------------------------------------
+_scan_constant_arithmetic() {
+	local file="$1" tmpdir="$2"
+	local rawline lineno snippet
+
+	while IFS= read -r rawline; do
+		lineno="${rawline%%:*}"
+		snippet="$(_ltrim "${rawline#*:}")"
+		_emit_finding "$tmpdir" "$file" "$lineno" \
+			"constant-arithmetic" "$snippet" "minor"
+	done < <(grep -nE \
+		'expect\([[:space:]]*[0-9][0-9.]*[[:space:]]*[-+*/][[:space:]]*[0-9]' \
+		"$file" 2>/dev/null)
+}
+
+# -----------------------------------------------------------------------
+# _scan_self_referential <file> <tmpdir>
+# Flag expect(OBJ1.PROP).toBe(OBJ2.PROP) / .toEqual() where PROP is the
+# same identifier on both sides — both values share the same source key,
+# so the assertion passes even when both are wrong.
+# Example: expect(result1.userThreshold).toBe(result2.userThreshold)
+# -----------------------------------------------------------------------
+_scan_self_referential() {
+	local file="$1" tmpdir="$2"
+	local rawline lineno snippet obj1 obj2 prop1 prop2 stem1 stem2
+	# Regex helpers: expect(OBJ.PROP).toBe/toEqual(OBJ2.PROP)
+	local ident re_grep re_obj1 re_obj2 re1 re2
+	ident='[A-Za-z_][A-Za-z0-9_]*'
+	re_grep="expect\(${ident}\.${ident}\)\.to(Be|Equal)\(${ident}\.${ident}\)"
+	re_obj1="s/.*expect\(([A-Za-z_][A-Za-z0-9_]*)\.${ident}\).*/\1/"
+	# greedy .* safe: re_grep guarantees exactly one
+	# expect(OBJ.PROP).to{Be|Equal}(OBJ.PROP) match per input line
+	re_obj2="s/.*\.to(Be|Equal)\(([A-Za-z_][A-Za-z0-9_]*)\.${ident}\).*/\2/"
+	re1="s/.*expect\(${ident}\.([A-Za-z_][A-Za-z0-9_]*)\).*/\1/"
+	re2="s/.*\.to(Be|Equal)\(${ident}\.([A-Za-z_][A-Za-z0-9_]*)\).*/\2/"
+
+	while IFS= read -r rawline; do
+		lineno="${rawline%%:*}"
+		snippet="$(_ltrim "${rawline#*:}")"
+
+		# Extract object identifiers from expect(OBJ.PROP) and .toBe(OBJ.PROP)
+		obj1=$(printf '%s' "$snippet" | sed -E "$re_obj1")
+		obj2=$(printf '%s' "$snippet" | sed -E "$re_obj2")
+
+		# Extract property name from expect(OBJ.PROP)
+		prop1=$(printf '%s' "$snippet" | sed -E "$re1")
+
+		# Extract property from .toBe(OBJ.PROP) or .toEqual(OBJ.PROP)
+		prop2=$(printf '%s' "$snippet" | sed -E "$re2")
+
+		# Object stems: strip a trailing numeric suffix so paired variables
+		# like result1/result2 collapse to the same stem ("result"), while
+		# distinct sources (actual vs expectedSnapshot) keep different stems.
+		stem1=$(printf '%s' "$obj1" | sed -E 's/[0-9]+$//')
+		stem2=$(printf '%s' "$obj2" | sed -E 's/[0-9]+$//')
+
+		# Flag only when the SAME property is compared across two objects that
+		# share a stem — i.e. likely the same source (self-referential).  When
+		# the object stems differ, the assertion compares distinct sources and
+		# has a real reference value, so it is NOT hollow.
+		# KNOWN LIMITATION: single-letter distinct variable names (e.g. a, b)
+		# each yield a different single-character stem after digit-stripping, so
+		# the stem equality check below never fires for them.  Two single-letter
+		# names that actually reference the same source will therefore NOT be
+		# flagged as self-referential by this check.
+		if [[ "$prop1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] && \
+		   [[ "$prop2" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] && \
+		   [[ "$prop1" == "$prop2" ]] && \
+		   [[ -n "$stem1" && "$stem1" == "$stem2" ]]; then
+			_emit_finding "$tmpdir" "$file" "$lineno" \
+				"self-referential-matcher" "$snippet" "minor"
+		fi
+	done < <(grep -nE "$re_grep" "$file" 2>/dev/null)
+}
+
+# -----------------------------------------------------------------------
+# _scan_mock_timing_perf <file> <tmpdir>
+# Flag performance.now() timing assertions against mocked functions.
+# Three-signal gate (reduces false positives):
+#   1. File contains jest.mock() or vi.mock()
+#   2. Line contains performance.now()
+#   3. toBeLessThan[OrEqual]( appears within ±10 lines of signal 2
+# Example: const t=performance.now(); await mockedFn();
+#          expect(performance.now()-t).toBeLessThan(200)
+# -----------------------------------------------------------------------
+_scan_mock_timing_perf() {
+	local file="$1" tmpdir="$2"
+	local window=10
+
+	# Signal 1: skip files with no mock declarations
+	grep -qE '(jest|vi)\.mock\(' "$file" 2>/dev/null || return 0
+
+	local rawline lineno snippet start end
+	while IFS= read -r rawline; do
+		lineno="${rawline%%:*}"
+		snippet="$(_ltrim "${rawline#*:}")"
+
+		start=$(( lineno - window < 1 ? 1 : lineno - window ))
+		end=$(( lineno + window ))
+
+		# Signal 3: toBeLessThan[OrEqual] within the window
+		if sed -n "${start},${end}p" "$file" 2>/dev/null | \
+			grep -qE 'toBeLessThan(OrEqual)?\('; then
+			_emit_finding "$tmpdir" "$file" "$lineno" \
+				"mock-timing-perf" "$snippet" "minor"
+		fi
+	done < <(grep -nE 'performance\.now\(\)' "$file" 2>/dev/null)
+}
+
+# -----------------------------------------------------------------------
+# main
+# -----------------------------------------------------------------------
+main() {
+	if [[ $# -eq 0 ]]; then
+		# No input files is a benign no-op: emit an empty findings array
+		# and exit 0 so callers (and the pipeline) treat "nothing to lint"
+		# as success rather than a usage error.
+		printf '[]\n'
+		return 0
+	fi
+
+	# Env-var disable gate
+	if [[ "${LINT_TEST_ASSERTIONS:-1}" == "0" ]]; then
+		printf '[]\n'
+		return 0
+	fi
+
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '${tmpdir}'" EXIT
+
+	touch "$tmpdir/findings.jsonl"
+
+	local file
+	for file in "$@"; do
+		if [[ ! -f "$file" ]]; then
+			_err "file not found: $file"
+			continue
+		fi
+
+		_scan_constant_arithmetic "$file" "$tmpdir"
+		_scan_self_referential    "$file" "$tmpdir"
+		_scan_mock_timing_perf    "$file" "$tmpdir"
+	done
+
+	if [[ ! -s "$tmpdir/findings.jsonl" ]]; then
+		printf '[]\n'
+		return 0
+	fi
+
+	jq -s '.' "$tmpdir/findings.jsonl"
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/model-config.sh
+++ b/plugins/pipeline-core/scripts/model-config.sh
@@ -1,0 +1,510 @@
+#!/usr/bin/env bash
+#
+# model-config.sh - Tier-to-model mapping for orchestrator pipeline
+#
+# Data-only: tier-to-model table, stage-to-tier tables,
+# complexity-to-tier table, model-escalation table, and the ordered
+# stage-prefix list.  Decision logic for retry and model-fallback
+# lives in the companion skills:
+#   plugins/pipeline-core/skills/retry-policy/SKILL.md
+#   plugins/pipeline-core/skills/model-fallback/SKILL.md
+#
+# Usage: source this file, then call resolve_model <stage> [complexity]
+#
+
+# Idempotent sourcing guard — skip re-definition on repeated source.
+[[ -z "${_MODEL_CONFIG_LOADED+set}" ]] || return 0
+readonly _MODEL_CONFIG_LOADED=1
+
+# =============================================================================
+# TIER-TO-MODEL TABLE
+# =============================================================================
+#
+# Semantic tiers mapped to concrete model names.
+# Change models here — propagates to all stages automatically.
+#
+# light    → haiku   (mechanical: parse, template, simplify)
+# standard → sonnet  (judgment: review, fix, match)
+# advanced → opus    (deep reasoning: complex implementation)
+#
+# Lookup: _tier_to_model <tier>
+# Decision logic: plugins/pipeline-core/skills/model-fallback/SKILL.md
+
+readonly _MODEL_light="haiku"
+readonly _MODEL_standard="sonnet"
+readonly _MODEL_advanced="opus"
+readonly _MODEL_default="opus"    # fallback for unknown tiers
+
+# =============================================================================
+# PER-MODEL PRICE TABLE
+# =============================================================================
+#
+# USD price per 1,000,000 tokens, by tier. Source: Anthropic published
+# pricing, cached 2026-07-21 (see plugins/pipeline-core skill "claude-api"
+# section "Current Models").
+#
+#   Tier    Input   Output
+#   haiku   $1.00   $5.00
+#   sonnet  $3.00   $15.00
+#   opus    $5.00   $25.00
+#
+# Cache write/read are not separately published per-tier; they scale off the
+# tier's input price using the documented multipliers (shared/prompt-caching.md):
+#   cache write (5m TTL, the CLI default) = 1.25x input
+#   cache read                            = 0.1x  input
+#
+# Update this table when Anthropic pricing changes — it is the single place
+# cost math lives; _model_cost is the only function that reads it.
+#
+# Lookup: _model_cost <model> <input> <output> [cache_creation] [cache_read]
+
+readonly _PRICE_INPUT_haiku="1.00"
+readonly _PRICE_OUTPUT_haiku="5.00"
+readonly _PRICE_CACHE_WRITE_haiku="1.25"
+readonly _PRICE_CACHE_READ_haiku="0.10"
+
+readonly _PRICE_INPUT_sonnet="3.00"
+readonly _PRICE_OUTPUT_sonnet="15.00"
+readonly _PRICE_CACHE_WRITE_sonnet="3.75"
+readonly _PRICE_CACHE_READ_sonnet="0.30"
+
+readonly _PRICE_INPUT_opus="5.00"
+readonly _PRICE_OUTPUT_opus="25.00"
+readonly _PRICE_CACHE_WRITE_opus="6.25"
+readonly _PRICE_CACHE_READ_opus="0.50"
+
+# Fallback for unknown/unrecognized models — priced at opus rates so an
+# unrecognized model never silently undercounts spend.
+readonly _PRICE_INPUT_default="$_PRICE_INPUT_opus"
+readonly _PRICE_OUTPUT_default="$_PRICE_OUTPUT_opus"
+readonly _PRICE_CACHE_WRITE_default="$_PRICE_CACHE_WRITE_opus"
+readonly _PRICE_CACHE_READ_default="$_PRICE_CACHE_READ_opus"
+
+# =============================================================================
+# COMPLEXITY-TO-TIER TABLE
+# =============================================================================
+#
+# Task complexity hints (S/M/L) from issue parsing override stage defaults.
+#
+# S, M → standard → sonnet  (judgment tier)
+# L    → advanced → opus    (deep-reasoning tier)
+#
+# Lookup: _complexity_to_tier <hint>
+# Decision logic: plugins/pipeline-core/skills/model-fallback/SKILL.md
+
+readonly _COMPLEXITY_S="standard"
+readonly _COMPLEXITY_M="standard"
+readonly _COMPLEXITY_L="advanced"
+
+# =============================================================================
+# MODEL ESCALATION TABLE
+# =============================================================================
+#
+# Next model up in the haiku → sonnet → opus escalation chain.
+# opus → opus signals the ceiling (no further escalation).
+#
+# Lookup: _next_model_up <model>
+# Retry decisions:    plugins/pipeline-core/skills/retry-policy/SKILL.md
+# Fallback decisions: plugins/pipeline-core/skills/model-fallback/SKILL.md
+
+readonly _NEXT_MODEL_haiku="sonnet"
+readonly _NEXT_MODEL_sonnet="opus"
+readonly _NEXT_MODEL_opus="opus"
+readonly _NEXT_MODEL_default="opus"   # fallback for unknown models
+
+# =============================================================================
+# STAGE-TO-TIER TABLES
+# =============================================================================
+#
+# Each orchestrator stage maps to a tier based on its cognitive demands.
+#
+# light    — mechanical: parse markdown, run commands, fill templates
+# standard — judgment: reviews, fixes, pattern matching
+#
+# (No stage defaults to advanced; complexity hint upgrades to advanced.)
+#
+# Lookup: _stage_to_tier <stage>
+# Decision logic: plugins/pipeline-core/skills/model-fallback/SKILL.md
+
+readonly -a _LIGHT_STAGES=(
+	parse-issue validate-plan triage
+	test research simplify
+	e2e-verify deploy-verify
+	complete docs acceptance-test
+)
+
+readonly -a _STANDARD_STAGES=(
+	implement task-review fix test-iter review
+	pr pr-review pr-fix
+	spec-review code-review
+	fix-e2e fix-acceptance-test fix-deploy-verify
+)
+
+# =============================================================================
+# STAGE PREFIX MATCHING TABLE
+# =============================================================================
+#
+# Orchestrator stage names follow the pattern: <base>-<suffix>
+# e.g. "implement-task-1", "review-task-1-iter-2", "fix-tests-iter-1"
+#
+# Listed longest-first so _match_stage_prefix finds the most specific
+# match: "spec-review-iter-1" matches "spec-review" (11 chars) over
+# "review" (6 chars).
+#
+# Lookup: _match_stage_prefix <stage_name>
+
+readonly -a _STAGE_PREFIXES=(
+	fix-acceptance-test acceptance-test validate-plan
+	fix-deploy-verify deploy-verify spec-review code-review
+	task-review parse-issue e2e-verify
+	pr-review implement simplify research complete
+	pr-fix fix-e2e review test-iter test docs fix pr
+	triage
+)
+
+# =============================================================================
+# TURN BUDGET OVERRIDES
+# =============================================================================
+#
+# Stage-type-aware turn limits cap the --max-turns flag passed to claude(1).
+# Operators can tune these via environment variables without modifying the
+# orchestrator source.
+#
+# Defaults below were calibrated against tools/analyze-turns.sh run on
+# 3,768 stage logs (second calibration, 2026-05-21; 157× more data
+# than the initial 2026-05-13 calibration on 24 logs):
+#
+#   === Turns-Used Distribution by Stage Type ===
+#       (3,768 stage logs; simplify N=777, fix-review N=700)
+#
+#     Stage               N    p50    p90   Max
+#     -------------------------------------------
+#     simplify           777   11.0   13.0    31
+#     fix-review         700   19.0   30.0    64
+#
+#   simplify p90=13 → cap at 15 (p90+2 headroom; prior cap of 12 was
+#   below the true p90 — pile-up at 11 was the natural ceiling, pile-up
+#   at 13 marked sonnet escalations hitting the haiku cap).
+#
+#   fix-review p90=30 → cap at 30 (prior cap of 20 caused pile-up at
+#   21 as sonnet escalated to opus; pile-up at 26 was the opus natural
+#   ceiling; raising to 30 eliminates ~90% of opus escalations).
+#
+#   Note: num_turns is capped by each run's --max-turns budget so
+#   p90/Max understate true demand when a cap is hit. Pile-ups at a
+#   value mark a budget ceiling, not natural workload — size budgets
+#   above the pile-up, not at the observed p90.
+#   To regenerate: tools/analyze-turns.sh logs/implement-issue
+#
+# simplify-* stages (haiku model, light-tier):
+#   Default: 15 turns   Env: MAX_TURNS_SIMPLIFY
+#   Targeted edits — more scope than parse, less than full implement.
+#
+# fix-* / fix-review-* stages (sonnet model, standard-tier):
+#   Default: 30 turns   Env: MAX_TURNS_FIX_REVIEW
+#   Targeted corrections — less scope than implement/review.
+#
+# pr stage (sonnet model, standard-tier):
+#   Default: 10 turns   Env: MAX_TURNS_PR
+#   Push + create MR; default is 10 rather than 5 to accommodate a
+#   rebase-before-push when the branch has drifted from main.
+#
+# pr-review budget is intentionally fixed and NOT affected by env vars:
+#   pr-review: 10 turns (focused diff analysis)
+#
+# Decision logic: implement-issue-orchestrator.sh
+# (search for MAX_TURNS_SIMPLIFY / MAX_TURNS_FIX_REVIEW / MAX_TURNS_PR)
+# =============================================================================
+
+# =============================================================================
+# PER-LOOP WALL-CLOCK BUDGETS
+# =============================================================================
+#
+# The PR-review loop has its own wall-clock budget so it cannot be starved by
+# earlier stages consuming the global MAX_ORCHESTRATOR_WALL_TIME budget.
+# The budget is derived from the diff-size-scaled per-iteration timeout, so
+# "at least one full iteration completes" is structurally guaranteed.
+#
+# PR-review loop budget:
+#   Formula:  pr_review_timeout × max(profile_max_iter, 1)
+#               + PR_REVIEW_WALL_TIME_SLACK
+#   Default:  2520s  (1200 × 2 + 120; covers a 200+ line diff at full
+#                     iterations with the default 120s slack)
+#   Env vars:
+#     PR_REVIEW_WALL_BUDGET      — full override (seconds); when set,
+#                                  replaces the formula entirely
+#     PR_REVIEW_WALL_TIME_SLACK  — slack added on top of the per-iteration
+#                                  budget (default 120s)
+#
+#   pr_review_timeout and profile_max_iter both come from get_pr_review_config()
+#   + apply_profile_to_pr_review_max_iter() — they scale with diff size:
+#     <50 lines  → 360s,  max_iter=1 (fixed)           → budget = 360  + slack
+#     <200 lines → 600s,  max_iter=MAX_PR_REVIEW_ITERATIONS → budget = 600  × max(iter,1) + slack
+#     200+ lines → 1200s, max_iter=MAX_PR_REVIEW_ITERATIONS → budget = 1200 × max(iter,1) + slack
+#   For minimal pipeline profile, max_iter is capped at 1 regardless of diff size.
+#   The default 2520s covers the worst case (200+ line diff, 2 iterations,
+#   120s slack).  On smaller diffs the computed budget is tighter.
+#   PR_REVIEW_WALL_BUDGET overrides the computed value entirely when set.
+#
+#   This budget is checked IN ADDITION TO the global clock — the loop exits
+#   when either guard fires.  Within its own budget, the loop is protected
+#   from global-clock exhaustion caused by earlier stages.
+#
+# Test loop budget:
+#   Formula:  test_iter_timeout × max(TEST_LOOP_PLANNED_ITERATIONS, 1)
+#               + TEST_ITER_WALL_TIME_SLACK
+#   Default:  2820s  (900 × 3 + 120; covers 3 full test iterations with
+#                     the default 120s slack)
+#   Env vars:
+#     TEST_LOOP_WALL_BUDGET          — full override (seconds); when set,
+#                                      replaces the formula entirely
+#     TEST_LOOP_PLANNED_ITERATIONS   — sane planned iteration count used
+#                                      in the formula (default 3; intentionally
+#                                      smaller than MAX_TEST_ITERATIONS=7)
+#     TEST_ITER_WALL_TIME_SLACK      — slack added on top of the per-iteration
+#                                      budget (default 120s)
+#
+#   test_iter_timeout comes from get_stage_timeout("test-iter") = 900s.
+#   TEST_LOOP_PLANNED_ITERATIONS defaults to 3 — a sane expected iteration
+#   count that is structurally smaller than the hard cap MAX_TEST_ITERATIONS=7.
+#   Operators can raise it via env without changing the hard cap.
+#
+#   This budget is checked IN ADDITION TO the global clock — the loop exits
+#   when either guard fires.  Within its own budget, the loop is protected
+#   from global-clock exhaustion caused by earlier stages.
+#
+# Global orchestrator wall-clock budget (MAX_ORCHESTRATOR_WALL_TIME):
+#   Default = sum of all per-phase budgets so the global cap never fires
+#   while an inner loop is within its own budget.
+#   Formula: calc_orchestrator_wall_time()
+#     = calc_test_loop_budget()
+#       + PR-review worst-case (1200s × max(MAX_PR_REVIEW_ITERATIONS,1)
+#                               + PR_REVIEW_WALL_TIME_SLACK)
+#       + overhead (validate_plan 1800 + implement 1800 + task-review 900
+#                   + test 600 + pr-create 600 = 5700s)
+#   Default: 12840s (4620 + 2520 + 5700)
+#   Enforced at the complexity-adjustment step (after env vars take effect).
+#   Env vars:
+#     MAX_ORCHESTRATOR_WALL_TIME — initial base (default 12840s; raised to
+#                                  the phase-budget sum if env value is less)
+#   After the phase-budget floor, per-L-task bumps (1800s each) are added
+#   on top, capped at 4× the phase-budget-floored base value.
+#
+# Decision logic / enforcement: implement-issue-orchestrator.sh
+# (search for PR_REVIEW_WALL_BUDGET / check_pr_review_wall_timeout,
+#  TEST_LOOP_WALL_BUDGET / check_test_loop_wall_timeout / calc_test_loop_budget,
+#  and calc_orchestrator_wall_time / MAX_ORCHESTRATOR_WALL_TIME)
+# =============================================================================
+
+# =============================================================================
+# LOOKUP FUNCTIONS
+# =============================================================================
+#
+# Thin wrappers over the data tables above.  All retry / escalation
+# decision logic lives in the skills; these functions only look up data.
+
+# _tier_to_model <tier>
+# Prints the model name for the given semantic tier.
+# Unknown tiers fall back to _MODEL_default (opus).
+_tier_to_model() {
+	local _var="_MODEL_${1//[^a-zA-Z]/}"
+	printf '%s' "${!_var:-$_MODEL_default}"
+}
+
+# _stage_to_tier <stage>
+# Prints the tier for an exact stage name.
+# Returns empty string for unknown stages.
+_stage_to_tier() {
+	local _s
+	for _s in "${_LIGHT_STAGES[@]}"; do
+		[[ "$_s" == "${1:-}" ]] || continue
+		printf '%s' "light"
+		return 0
+	done
+	for _s in "${_STANDARD_STAGES[@]}"; do
+		[[ "$_s" == "${1:-}" ]] || continue
+		printf '%s' "standard"
+		return 0
+	done
+	printf '%s' ""
+}
+
+# _complexity_to_tier <hint>
+# Prints the tier for S/M/L complexity hint.
+# Returns empty string for unknown hints.
+_complexity_to_tier() {
+	local _var="_COMPLEXITY_${1//[^a-zA-Z]/}"
+	printf '%s' "${!_var:-}"
+}
+
+# _match_stage_prefix <stage_name>
+# Prints the longest known prefix that matches the stage name.
+# Returns 1 and prints nothing for unknown stage names.
+_match_stage_prefix() {
+	local _stage_name="$1" _prefix
+	for _prefix in "${_STAGE_PREFIXES[@]}"; do
+		[[ "$_stage_name" == "$_prefix" || \
+			"$_stage_name" == "$_prefix-"* ]] || continue
+		printf '%s' "$_prefix"
+		return 0
+	done
+	return 1
+}
+
+# _next_model_up <model>
+# Prints the next model up in the escalation chain.
+# opus stays at opus (ceiling); unknown models fall back to opus.
+# Full decision logic: plugins/pipeline-core/skills/model-fallback/SKILL.md
+_next_model_up() {
+	local _var="_NEXT_MODEL_${1//[^a-zA-Z]/}"
+	printf '%s' "${!_var:-$_NEXT_MODEL_default}"
+}
+
+# _model_cost <model> <input_tokens> <output_tokens> \
+#             [cache_creation_tokens] [cache_read_tokens]
+# Prints the USD cost (6 decimal places) for the given model/tier and token
+# counts, using the price table above.
+#
+# <model> matches on tier name ("haiku"/"sonnet"/"opus") or any string
+# containing one as a substring (e.g. a concrete model ID such as
+# "claude-opus-4-8") — so callers can pass either the CLI's --model alias or
+# the model string a CLI JSON response echoes back. Unrecognized models fall
+# back to the opus price table (_PRICE_*_default) — see AC4.
+#
+# Missing token-count arguments default to 0. Non-numeric arguments are
+# rejected by awk's arithmetic context and print 0.000000 rather than
+# erroring, so a bad upstream value degrades to zero cost instead of
+# corrupting status.json.
+_model_cost() {
+	local _model="${1:-}"
+	local _input="${2:-0}" _output="${3:-0}"
+	local _cache_write="${4:-0}" _cache_read="${5:-0}"
+	local _tier
+
+	case "$_model" in
+		*opus*) _tier="opus" ;;
+		*sonnet*) _tier="sonnet" ;;
+		*haiku*) _tier="haiku" ;;
+		*) _tier="default" ;;
+	esac
+
+	local _price_input_var="_PRICE_INPUT_${_tier}"
+	local _price_output_var="_PRICE_OUTPUT_${_tier}"
+	local _price_cache_write_var="_PRICE_CACHE_WRITE_${_tier}"
+	local _price_cache_read_var="_PRICE_CACHE_READ_${_tier}"
+
+	awk \
+		-v input="$_input" -v output="$_output" \
+		-v cache_write="$_cache_write" -v cache_read="$_cache_read" \
+		-v price_input="${!_price_input_var}" \
+		-v price_output="${!_price_output_var}" \
+		-v price_cache_write="${!_price_cache_write_var}" \
+		-v price_cache_read="${!_price_cache_read_var}" \
+		'BEGIN {
+			cost = (input + 0) * price_input \
+				+ (output + 0) * price_output \
+				+ (cache_write + 0) * price_cache_write \
+				+ (cache_read + 0) * price_cache_read
+			cost = cost / 1000000
+			printf "%.6f\n", cost
+		}'
+}
+
+# =============================================================================
+# resolve_model() - Determine the model for a given stage and complexity
+# =============================================================================
+#
+# Arguments:
+#   $1 - stage name (e.g. "implement-task-1", "review-task-1-iter-2")
+#   $2 - optional complexity hint (S, M, or L)
+#
+# Output:
+#   Prints the model name to stdout (haiku, sonnet, or opus)
+#
+# Logic:
+#   1. Match stage name against known prefixes (longest match wins)
+#   2. Look up default tier for that stage
+#   3. If complexity hint provided and tier is not light, override
+#   4. Fall back to advanced (opus) for unknown stages
+#
+
+resolve_model() {
+	local stage_name="${1:-}"
+	local complexity="${2:-}"
+	local tier="" matched_prefix="" complexity_tier=""
+
+	# Match stage name against known prefixes
+	[[ -n "$stage_name" ]] && \
+		matched_prefix=$(_match_stage_prefix "$stage_name") || true
+	[[ -n "$matched_prefix" ]] && \
+		tier=$(_stage_to_tier "$matched_prefix") || true
+
+	# Fall back to advanced for unknown stages
+	tier="${tier:-advanced}"
+
+	# Apply complexity hint — light-tier stages are always haiku;
+	# complexity hints are ignored for them.  The quality loop forwards
+	# task-level complexity to implement, review, and fix stages so
+	# model selection scales with task size.
+	[[ -n "$complexity" && "$tier" != "light" ]] && \
+		complexity_tier=$(_complexity_to_tier "$complexity") || true
+	[[ -n "$complexity_tier" ]] && tier="$complexity_tier" || true
+
+	printf '%s\n' "$(_tier_to_model "$tier")"
+}
+
+# =============================================================================
+# USAGE-AWARE MODEL SELECTION (effective_model / effective_fallback)
+# =============================================================================
+#
+# Wraps resolve_model with a check against claude-usage.sh's
+# is_model_exhausted.  When the picked model is exhausted (per-model
+# bucket full and overage isn't absorbing), escalates via _next_model_up
+# until a non-exhausted model is found or the opus ceiling is reached.
+#
+# When claude-usage.sh isn't loaded OR no sessionKey is configured,
+# is_model_exhausted returns false for everything and these wrappers
+# behave identically to resolve_model / _next_model_up — zero regression
+# for users who haven't opted into usage polling.
+#
+
+_usage_aware_escalate() {
+	local model="$1" original="$1" next _reset _msg
+	declare -F is_model_exhausted >/dev/null 2>&1 || {
+		printf '%s\n' "$model"
+		return 0
+	}
+
+	# _next_model_up returns the same model at the opus ceiling, which
+	# terminates the loop unconditionally — no infinite spin if every
+	# tier is exhausted.
+	while is_model_exhausted "$model"; do
+		next=$(_next_model_up "$model")
+		[[ "$next" == "$model" ]] && break
+		model="$next"
+	done
+
+	# Surface the escalation so operators can correlate cost spikes with
+	# bucket exhaustion.  Logged via the orchestrator's log if available,
+	# else stderr — see _usage_log in claude-usage.sh.
+	[[ "$model" != "$original" ]] && \
+		declare -F model_reset_at >/dev/null 2>&1 && {
+			_reset=$(model_reset_at "$original")
+			_msg="Usage gate: $original exhausted"
+			_msg+=" (resets ${_reset}) — escalating to $model"
+			_usage_log "$_msg"
+		} || true
+
+	printf '%s\n' "$model"
+}
+
+# effective_model(stage, complexity) — resolve_model with usage gating.
+effective_model() {
+	_usage_aware_escalate "$(resolve_model "$@")"
+}
+
+# effective_fallback(model) — _next_model_up with usage gating.
+# Used to compute the --fallback-model arg for the Claude CLI.
+effective_fallback() {
+	_usage_aware_escalate "$(_next_model_up "$1")"
+}

--- a/plugins/pipeline-core/scripts/platform/adf-to-markdown.py
+++ b/plugins/pipeline-core/scripts/platform/adf-to-markdown.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Convert Jira ADF (Atlassian Document Format) JSON to markdown.
+
+Reads a Jira workitem JSON from stdin (as returned by acli --json),
+outputs JSON { title, body, status } with body as markdown text.
+"""
+
+import json
+import re
+import sys
+
+
+def wiki_to_md(text):
+    """Convert Jira wiki markup fragments to markdown.
+
+    Handles common patterns that appear when acli stores description text
+    as a single ADF paragraph containing wiki markup rather than structured nodes.
+    """
+    lines = text.split("\n")
+    result = []
+    for line in lines:
+        # h1. through h6. headings
+        m = re.match(r"^h([1-6])\.\s+(.*)", line)
+        if m:
+            level = int(m.group(1))
+            result.append("#" * level + " " + m.group(2))
+        else:
+            result.append(line)
+    return "\n".join(result)
+
+
+def adf_to_md(node):
+    """Recursively convert an ADF node to markdown."""
+    if isinstance(node, str):
+        return node
+    if not isinstance(node, dict):
+        return ""
+
+    t = node.get("type", "")
+    content = node.get("content", [])
+    text = node.get("text", "")
+
+    # Inline text with marks
+    if t == "text":
+        marks = [m["type"] for m in node.get("marks", [])]
+        if "code" in marks:
+            return "`" + text + "`"
+        if "strong" in marks:
+            return "**" + text + "**"
+        if "em" in marks:
+            return "*" + text + "*"
+        return text
+
+    # Block nodes
+    hashes = {1: "#", 2: "##", 3: "###", 4: "####", 5: "#####", 6: "######"}
+    if t == "doc":
+        return "\n".join(adf_to_md(c) for c in content)
+    if t == "heading":
+        level = node.get("attrs", {}).get("level", 2)
+        prefix = hashes.get(level, "##")
+        inline = "".join(adf_to_md(c) for c in content)
+        return prefix + " " + inline
+    if t == "paragraph":
+        return "".join(adf_to_md(c) for c in content)
+    if t == "bulletList":
+        items = []
+        for item in content:
+            item_text = "\n".join(adf_to_md(c) for c in item.get("content", []))
+            items.append("- " + item_text)
+        return "\n".join(items)
+    if t == "orderedList":
+        items = []
+        for i, item in enumerate(content, 1):
+            item_text = "\n".join(adf_to_md(c) for c in item.get("content", []))
+            items.append(str(i) + ". " + item_text)
+        return "\n".join(items)
+    if t == "listItem":
+        return "\n".join(adf_to_md(c) for c in content)
+    if t == "codeBlock":
+        lang = node.get("attrs", {}).get("language", "")
+        code = "".join(adf_to_md(c) for c in content)
+        return "```" + lang + "\n" + code + "\n```"
+
+    # Fallback: recurse into content
+    return "".join(adf_to_md(c) for c in content)
+
+
+def main():
+    data = json.load(sys.stdin)
+    fields = data.get("fields", {})
+    desc = fields.get("description", "")
+
+    if isinstance(desc, dict):
+        body = adf_to_md(desc)
+    elif isinstance(desc, str):
+        body = desc
+    else:
+        body = ""
+
+    # Post-process: convert any remaining wiki markup to markdown.
+    # This handles cases where acli stores wiki markup as raw text
+    # inside ADF paragraph nodes rather than as structured heading nodes.
+    body = wiki_to_md(body)
+
+    result = {
+        "title": fields.get("summary", ""),
+        "body": body,
+        "status": fields.get("status", {}).get("name", ""),
+    }
+    json.dump(result, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/pipeline-core/scripts/platform/comment-issue.sh
+++ b/plugins/pipeline-core/scripts/platform/comment-issue.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Usage: comment-issue.sh <issue-number-or-key> "Comment body" [repo]
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLATFORM_CONFIG="$SCRIPT_DIR/../../config/platform.sh"
+if [[ -f "$PLATFORM_CONFIG" ]]; then source "$PLATFORM_CONFIG"; fi
+
+ISSUE="$1" COMMENT="$2" REPO_ARG="${3:-}"
+
+case "${TRACKER:-github}" in
+  github)
+    if [[ -n "$REPO_ARG" ]]; then
+      gh issue comment "$ISSUE" -R "$REPO_ARG" --body "$COMMENT"
+    else
+      gh issue comment "$ISSUE" --body "$COMMENT"
+    fi
+    ;;
+  jira)
+    # Convert markdown to Atlassian Document Format (ADF) JSON
+    ADF_COMMENT=$(printf '%s' "$COMMENT" | python3 "$SCRIPT_DIR/markdown-to-adf.py")
+    acli jira workitem comment create --key "$ISSUE" --body "$ADF_COMMENT"
+    ;;
+esac

--- a/plugins/pipeline-core/scripts/platform/comment-mr.sh
+++ b/plugins/pipeline-core/scripts/platform/comment-mr.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Usage: comment-mr.sh <mr-number> "Comment body" [repo]
+# Adds a comment to a PR (GitHub) or MR (GitLab)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLATFORM_CONFIG="$SCRIPT_DIR/../../config/platform.sh"
+if [[ -f "$PLATFORM_CONFIG" ]]; then source "$PLATFORM_CONFIG"; fi
+
+MR="$1" COMMENT="$2" REPO_ARG="${3:-}"
+
+case "${GIT_HOST:-github}" in
+  github)
+    if [[ -n "$REPO_ARG" ]]; then
+      gh pr comment "$MR" -R "$REPO_ARG" --body "$COMMENT"
+    else
+      gh pr comment "$MR" --body "$COMMENT"
+    fi
+    ;;
+  gitlab) glab mr note "$MR" --message "$COMMENT" ;;
+esac

--- a/plugins/pipeline-core/scripts/platform/create-followup-issue.sh
+++ b/plugins/pipeline-core/scripts/platform/create-followup-issue.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Usage: create-followup-issue.sh --title TITLE --description DESC
+#          --task-description TASK_DESC --file-path FILE_PATH
+#          --pr-number PR_NUM --issue-number ISSUE_NUM --reviewer REVIEWER
+#          [--labels LABELS] [--type precise|vague]
+#
+# Delegates body construction (agent inference + fail-closed validation) to the
+# shared generator at ../create-followup-issue.sh — the single source of truth
+# for agent inference and assert_issue_valid — then deduplicates and creates the
+# issue via create-issue.sh (which establishes the parent link through the
+# GitHub sub-issues REST API).
+#
+# Returns: created issue number on stdout.
+# Exits 1 on duplicate found or on a body that fails validation; 3 on a missing
+# required argument or an unknown option.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+TITLE="" DESCRIPTION="" TASK_DESCRIPTION="" FILE_PATH=""
+PR_NUMBER="" ISSUE_NUMBER="" REVIEWER="" LABELS="" TYPE="precise"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)            TITLE="$2"; shift 2 ;;
+    --description)      DESCRIPTION="$2"; shift 2 ;;
+    --task-description) TASK_DESCRIPTION="$2"; shift 2 ;;
+    --file-path)        FILE_PATH="$2"; shift 2 ;;
+    --pr-number)        PR_NUMBER="$2"; shift 2 ;;
+    --issue-number)     ISSUE_NUMBER="$2"; shift 2 ;;
+    --reviewer)         REVIEWER="$2"; shift 2 ;;
+    --labels)           LABELS="$2"; shift 2 ;;
+    --type)             TYPE="$2"; shift 2 ;;
+    --) shift; break ;;
+    # Reject mistyped flags loudly instead of swallowing them (and their
+    # value) — a swallowed flag surfaces later as a confusing "required" error.
+    -*) echo "ERROR: unknown option: $1" >&2; exit 3 ;;
+    *) shift ;;
+  esac
+done
+
+for required in TITLE DESCRIPTION FILE_PATH PR_NUMBER ISSUE_NUMBER REVIEWER; do
+  [[ -z "${!required}" ]] && { echo "ERROR: --$(echo "$required" | tr '[:upper:]' '[:lower:]' | tr '_' '-') is required" >&2; exit 3; }
+done
+
+# Deduplication check — skip if a similar open issue already exists
+TITLE_LOWER=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]')
+EXISTING=$(gh issue list --search "$TITLE" --state open \
+  --json number,title \
+  | jq -r --arg t "$TITLE_LOWER" '.[] | select(.title | ascii_downcase | contains($t)) | .number' \
+  | head -1)
+if [[ -n "$EXISTING" ]]; then
+  echo "Skipping duplicate: similar open issue already exists (#$EXISTING for \"$TITLE\")" >&2
+  exit 1
+fi
+
+# Delegate body construction to the shared generator — the single source of
+# agent inference and the home of assert_issue_valid.  It exits non-zero
+# (printing nothing) when the body fails validation, so a bad body never
+# reaches issue creation.
+GENERATOR="$SCRIPT_DIR/../create-followup-issue.sh"
+GEN_ARGS=(
+  --title "$TITLE"
+  --description "$DESCRIPTION"
+  --file-path "$FILE_PATH"
+  --pr-number "$PR_NUMBER"
+  --issue-number "$ISSUE_NUMBER"
+  --reviewer "$REVIEWER"
+  --type "$TYPE"
+)
+[[ -n "$TASK_DESCRIPTION" ]] && GEN_ARGS+=(--task-description "$TASK_DESCRIPTION")
+
+if ! BODY=$("$GENERATOR" "${GEN_ARGS[@]}"); then
+  echo "ERROR: follow-up body failed validation; issue not created" >&2
+  exit 1
+fi
+
+# Labels are applied at creation time, not in the body — vague items get the
+# needs-explore label so an explore sweep picks them up.
+if [[ "$TYPE" == "vague" ]]; then
+  FINAL_LABELS="${LABELS:+$LABELS,}needs-explore"
+else
+  FINAL_LABELS="$LABELS"
+fi
+
+ARGS=(--title "$TITLE" --body "$BODY" --parent "#${ISSUE_NUMBER}")
+[[ -n "$FINAL_LABELS" ]] && ARGS+=(--labels "$FINAL_LABELS")
+
+"$SCRIPT_DIR/create-issue.sh" "${ARGS[@]}"

--- a/plugins/pipeline-core/scripts/platform/create-issue.sh
+++ b/plugins/pipeline-core/scripts/platform/create-issue.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Usage: create-issue.sh --title "Title" --body "Body" [--labels "bug,critical"] [--parent "EPIC-KEY"]
+# Returns: issue number or key on stdout (e.g., "42" or "KIN-123")
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../config/platform.sh"
+
+TITLE="" BODY="" LABELS="" PARENT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title) TITLE="$2"; shift 2 ;;
+    --body) BODY="$2"; shift 2 ;;
+    --labels) LABELS="$2"; shift 2 ;;
+    --parent) PARENT="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+[[ -z "$TITLE" ]] && { echo "ERROR: --title is required" >&2; exit 3; }
+
+# Validate bodies with <!-- pipeline-autocreated --> or ## Implementation Tasks.
+if [[ "$BODY" == *"<!-- pipeline-autocreated -->"* ]] || \
+  [[ "$BODY" == *"## Implementation Tasks"* ]]; then
+  # shellcheck source=../issue-body-lib.sh
+  source "$SCRIPT_DIR/../issue-body-lib.sh"
+  if ! assert_issue_valid "$BODY"; then
+    echo "ERROR: body failed structural validation — issue not created" >&2
+    exit 1
+  fi
+fi
+
+case "$TRACKER" in
+  github)
+    ARGS=(gh issue create --title "$TITLE" --body "$BODY")
+    [[ -n "$LABELS" ]] && ARGS+=(--label "$LABELS")
+    if ! issue_url=$("${ARGS[@]}" 2>/dev/null); then
+      exit 1
+    fi
+    if [[ ! "$issue_url" =~ ^https://github\.com/.+/issues/[0-9]+$ ]]; then
+      exit 1
+    fi
+    issue_num="${issue_url##*/}"
+    printf '%s\n' "$issue_num"
+    if [[ -n "$PARENT" ]]; then
+      parent_num="${PARENT#\#}"
+      if [[ ! "$parent_num" =~ ^[0-9]+$ ]]; then
+        printf 'WARNING: --parent %s is not numeric; skipping sub-issue link\n' \
+          "$PARENT" >&2
+      elif [[ ! "$issue_num" =~ ^[0-9]+$ ]]; then
+        printf 'WARNING: issue_num %s is not numeric; skipping link\n' \
+          "$issue_num" >&2
+      elif [[ "$issue_url" != https://github.com/* ]]; then
+        printf \
+          'WARNING: issue_url %s lacks required https://github.com/ prefix; skipping link\n' \
+          "$issue_url" >&2
+      else
+        repo_part="${issue_url#https://github.com/}"
+        repo="${repo_part%/issues/*}"
+        child_id=$(gh api "repos/$repo/issues/$issue_num" \
+          --jq '.id' 2>/dev/null) || true
+        if [[ -n "$child_id" ]]; then
+          gh api -X POST "repos/$repo/issues/$parent_num/sub_issues" \
+            -F "sub_issue_id=$child_id" >/dev/null 2>&1 || \
+            printf 'WARNING: failed to link #%s as sub-issue of #%s\n' \
+              "$issue_num" "$parent_num" >&2
+        else
+          printf 'WARNING: could not fetch ID for issue #%s; skipping link\n' \
+            "$issue_num" >&2
+        fi
+      fi
+    fi
+    ;;
+  jira)
+    ARGS=(acli jira workitem create
+      --project "$JIRA_PROJECT"
+      --type "$JIRA_DEFAULT_ISSUE_TYPE"
+      --summary "$TITLE")
+
+    # Convert markdown body to ADF and write to temp file (avoids arg length limits)
+    if [[ -n "$BODY" ]]; then
+      TMPFILE="$(mktemp)"
+      trap 'rm -f "$TMPFILE"' EXIT
+      printf '%s' "$BODY" | python3 "$SCRIPT_DIR/markdown-to-adf.py" > "$TMPFILE"
+      ARGS+=(--description-file "$TMPFILE")
+    fi
+
+    [[ -n "$PARENT" ]] && ARGS+=(--parent "$PARENT")
+    [[ -n "$LABELS" ]] && ARGS+=(--label "$LABELS")
+
+    OUTPUT=$("${ARGS[@]}" 2>&1) || {
+      echo "ERROR: acli failed: $OUTPUT" >&2
+      if [[ "$OUTPUT" == *"unauthorized"* ]] || [[ "$OUTPUT" == *"auth"* ]]; then
+        echo "HINT: Run 'acli jira auth login' to authenticate" >&2
+      fi
+      exit 1
+    }
+    echo "$OUTPUT" | grep -oE '[A-Z]+-[0-9]+'
+    ;;
+esac

--- a/plugins/pipeline-core/scripts/platform/create-mr.sh
+++ b/plugins/pipeline-core/scripts/platform/create-mr.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Usage: create-mr.sh --source "branch" --target "main" --title "Title" --body "Body"
+# Returns: MR/PR number on stdout
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../config/platform.sh"
+
+SOURCE="" TARGET="" TITLE="" BODY=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source) SOURCE="$2"; shift 2 ;;
+    --target) TARGET="$2"; shift 2 ;;
+    --title) TITLE="$2"; shift 2 ;;
+    --body) BODY="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+case "$GIT_HOST" in
+  github)
+    gh pr create --head "$SOURCE" --base "$TARGET" --title "$TITLE" --body "$BODY" \
+      2>/dev/null | grep -oE '[0-9]+$'
+    ;;
+  gitlab)
+    glab mr create --source-branch "$SOURCE" --target-branch "$TARGET" \
+      --title "$TITLE" --description "$BODY" --squash-on-merge --no-editor \
+      2>/dev/null | grep -oE '![0-9]+' | tr -d '!'
+    ;;
+esac

--- a/plugins/pipeline-core/scripts/platform/find-mr.sh
+++ b/plugins/pipeline-core/scripts/platform/find-mr.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Usage: find-mr.sh --branch "branch-name" [--state open]
+# Returns: MR/PR number if found, empty string if not
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../config/platform.sh"
+
+BRANCH="" STATE="open"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch) BRANCH="$2"; shift 2 ;;
+    --state) STATE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+case "$GIT_HOST" in
+  github)
+    gh pr list --head "$BRANCH" --state "$STATE" --json number --jq '.[0].number // empty'
+    ;;
+  gitlab)
+    glab mr list --source-branch "$BRANCH" --output json 2>/dev/null \
+      | jq -r '.[0].iid // empty'
+    ;;
+esac

--- a/plugins/pipeline-core/scripts/platform/list-issues.sh
+++ b/plugins/pipeline-core/scripts/platform/list-issues.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Usage: list-issues.sh [--jql "JQL query"] [--state open] [--assignee @me] [--labels "bug"]
+# Returns: JSON array of { id, title, status }
+# For GitHub: uses gh issue list flags
+# For Jira: uses JQL (auto-built from flags or explicit --jql)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../config/platform.sh"
+
+JQL="" STATE="open" ASSIGNEE="" LABELS=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --jql) JQL="$2"; shift 2 ;;
+    --state) STATE="$2"; shift 2 ;;
+    --assignee) ASSIGNEE="$2"; shift 2 ;;
+    --labels) LABELS="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+case "$TRACKER" in
+  github)
+    ARGS=(gh issue list --state "$STATE" --json number,title,state --limit 100)
+    [[ -n "$ASSIGNEE" ]] && ARGS+=(--assignee "$ASSIGNEE")
+    [[ -n "$LABELS" ]] && ARGS+=(--label "$LABELS")
+    "${ARGS[@]}" | jq '[.[] | { id: (.number | tostring), title, status: .state }]'
+    ;;
+  jira)
+    if [[ -z "$JQL" ]]; then
+      JQL="project = $JIRA_PROJECT AND status != Done ORDER BY priority DESC"
+    fi
+    acli jira list-issues --jql "$JQL" --outputFormat json 2>/dev/null \
+      | jq '[.[] | { id: .key, title: .fields.summary, status: .fields.status.name }]'
+    ;;
+esac

--- a/plugins/pipeline-core/scripts/platform/markdown-to-adf.py
+++ b/plugins/pipeline-core/scripts/platform/markdown-to-adf.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Convert markdown text to Atlassian Document Format (ADF) JSON.
+
+Reads markdown from stdin, writes ADF JSON to stdout.
+Handles the subset of markdown produced by the orchestrator's comment_issue().
+
+ADF spec: https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
+"""
+
+import json
+import re
+import sys
+
+
+def text_node(text):
+    """Create a plain text node."""
+    return {"type": "text", "text": text}
+
+
+def text_node_mark(text, mark_type):
+    """Create a text node with a mark (bold, italic, code, etc.)."""
+    return {"type": "text", "text": text, "marks": [{"type": mark_type}]}
+
+
+def convert_inline_to_nodes(text):
+    """Convert inline markdown to ADF inline nodes.
+
+    Handles: **bold**, `code`, [text](url)
+    Returns a list of ADF inline nodes.
+    """
+    nodes = []
+    pos = 0
+
+    # Pattern matches: **bold**, `code`, [text](url)
+    pattern = re.compile(
+        r"(\*\*(.+?)\*\*)"      # bold
+        r"|(`([^`]+)`)"          # inline code
+        r"|(\[([^\]]+)\]\(([^)]+)\))"  # link
+    )
+
+    for m in pattern.finditer(text):
+        # Add any text before this match
+        if m.start() > pos:
+            nodes.append(text_node(text[pos:m.start()]))
+
+        if m.group(2):  # bold
+            nodes.append(text_node_mark(m.group(2), "strong"))
+        elif m.group(4):  # inline code
+            nodes.append(text_node_mark(m.group(4), "code"))
+        elif m.group(6):  # link
+            nodes.append({
+                "type": "text",
+                "text": m.group(6),
+                "marks": [{"type": "link", "attrs": {"href": m.group(7)}}]
+            })
+
+        pos = m.end()
+
+    # Add remaining text
+    if pos < len(text):
+        nodes.append(text_node(text[pos:]))
+
+    # If nothing was parsed, return the whole string as text
+    if not nodes and text:
+        nodes.append(text_node(text))
+
+    return nodes
+
+
+def paragraph(text):
+    """Create a paragraph node from markdown text."""
+    if not text.strip():
+        return None
+    return {
+        "type": "paragraph",
+        "content": convert_inline_to_nodes(text)
+    }
+
+
+def heading(level, text):
+    """Create a heading node."""
+    return {
+        "type": "heading",
+        "attrs": {"level": level},
+        "content": convert_inline_to_nodes(text)
+    }
+
+
+def bullet_list_item(text, depth=1):
+    """Create a bullet list item node."""
+    return {
+        "type": "listItem",
+        "content": [{
+            "type": "paragraph",
+            "content": convert_inline_to_nodes(text)
+        }]
+    }
+
+
+def ordered_list_item(text):
+    """Create an ordered list item node."""
+    return {
+        "type": "listItem",
+        "content": [{
+            "type": "paragraph",
+            "content": convert_inline_to_nodes(text)
+        }]
+    }
+
+
+def code_block(code_lines, language=""):
+    """Create a code block node."""
+    node = {
+        "type": "codeBlock",
+        "content": [text_node("\n".join(code_lines))]
+    }
+    if language:
+        node["attrs"] = {"language": language}
+    return node
+
+
+def status_node(text, color="neutral"):
+    """Create a status/lozenge node (for emoji status indicators)."""
+    return {
+        "type": "status",
+        "attrs": {"text": text, "color": color}
+    }
+
+
+def md_to_adf(text):
+    """Convert markdown text to ADF document."""
+    lines = text.split("\n")
+    content = []
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Code block fences
+        m = re.match(r"^```(\w*)$", line)
+        if m:
+            lang = m.group(1)
+            code_lines = []
+            i += 1
+            while i < len(lines) and not re.match(r"^```$", lines[i]):
+                code_lines.append(lines[i])
+                i += 1
+            content.append(code_block(code_lines, lang))
+            i += 1  # skip closing ```
+            continue
+
+        # Headings
+        m = re.match(r"^(#{1,6})\s+(.*)", line)
+        if m:
+            level = len(m.group(1))
+            content.append(heading(level, m.group(2)))
+            i += 1
+            continue
+
+        # Horizontal rule
+        if re.match(r"^---+$", line):
+            content.append({"type": "rule"})
+            i += 1
+            continue
+
+        # Unordered list — collect consecutive items
+        m = re.match(r"^(\s*)- (.*)", line)
+        if m:
+            items = []
+            while i < len(lines):
+                m = re.match(r"^(\s*)- (.*)", lines[i])
+                if not m:
+                    break
+                items.append(bullet_list_item(m.group(2)))
+                i += 1
+            content.append({
+                "type": "bulletList",
+                "content": items
+            })
+            continue
+
+        # Ordered list — collect consecutive items
+        m = re.match(r"^(\s*)\d+\.\s+(.*)", line)
+        if m:
+            items = []
+            while i < len(lines):
+                m = re.match(r"^(\s*)\d+\.\s+(.*)", lines[i])
+                if not m:
+                    break
+                items.append(ordered_list_item(m.group(2)))
+                i += 1
+            content.append({
+                "type": "orderedList",
+                "content": items
+            })
+            continue
+
+        # Checkbox items (- [ ] or - [x]) — treat as bullet list
+        m = re.match(r"^- \[[ x]\] (.*)", line)
+        if m:
+            items = []
+            while i < len(lines):
+                m = re.match(r"^- \[([x ])\] (.*)", lines[i])
+                if not m:
+                    break
+                checked = m.group(1) == "x"
+                prefix = "\u2705 " if checked else "\u2B1C "
+                items.append(bullet_list_item(prefix + m.group(2)))
+                i += 1
+            content.append({
+                "type": "bulletList",
+                "content": items
+            })
+            continue
+
+        # Empty lines — skip
+        if not line.strip():
+            i += 1
+            continue
+
+        # Regular paragraph
+        p = paragraph(line)
+        if p:
+            content.append(p)
+        i += 1
+
+    return {
+        "version": 1,
+        "type": "doc",
+        "content": content
+    }
+
+
+def main():
+    text = sys.stdin.read()
+    adf = md_to_adf(text)
+    json.dump(adf, sys.stdout, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/pipeline-core/scripts/platform/markdown-to-wiki.py
+++ b/plugins/pipeline-core/scripts/platform/markdown-to-wiki.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Convert markdown text to Jira wiki markup.
+
+Reads markdown from stdin, writes Jira wiki markup to stdout.
+Handles the subset of markdown produced by the orchestrator's comment_issue().
+"""
+
+import re
+import sys
+
+
+def md_to_wiki(text):
+    """Convert markdown to Jira wiki markup."""
+    lines = text.split("\n")
+    result = []
+    in_code_block = False
+    code_lang = ""
+
+    for line in lines:
+        # Code block fences
+        m = re.match(r"^```(\w*)$", line)
+        if m:
+            if not in_code_block:
+                code_lang = m.group(1)
+                if code_lang:
+                    result.append("{code:" + code_lang + "}")
+                else:
+                    result.append("{code}")
+                in_code_block = True
+            else:
+                result.append("{code}")
+                in_code_block = False
+            continue
+
+        # Inside code blocks, pass through unchanged
+        if in_code_block:
+            result.append(line)
+            continue
+
+        # Headings: ## Title -> h2. Title
+        m = re.match(r"^(#{1,6})\s+(.*)", line)
+        if m:
+            level = len(m.group(1))
+            result.append("h%d. %s" % (level, convert_inline(m.group(2))))
+            continue
+
+        # Unordered list items: - item -> * item
+        m = re.match(r"^(\s*)- (.*)", line)
+        if m:
+            indent = m.group(1)
+            # Nested depth: each 2 spaces = one extra *
+            depth = len(indent) // 2 + 1
+            result.append("*" * depth + " " + convert_inline(m.group(2)))
+            continue
+
+        # Ordered list items: 1. item -> # item
+        m = re.match(r"^(\s*)\d+\.\s+(.*)", line)
+        if m:
+            indent = m.group(1)
+            depth = len(indent) // 2 + 1
+            result.append("#" * depth + " " + convert_inline(m.group(2)))
+            continue
+
+        # Regular lines
+        result.append(convert_inline(line))
+
+    return "\n".join(result)
+
+
+def convert_inline(text):
+    """Convert inline markdown formatting to wiki markup."""
+    # Bold: **text** -> *text*
+    text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text)
+    # Italic: *text* -> _text_ (but not inside bold which is now *text*)
+    # Handle _text_ style italic first (pass through as-is, already wiki format)
+    # For *text* italic, we need to be careful not to conflict with bold
+    # Since we already converted **bold** to *bold*, remaining single * pairs are italic
+    # Actually, after bold conversion, single *text* IS the bold in wiki markup
+    # So we need to handle italic differently - use _text_ in the orchestrator
+    # For now, skip italic conversion to avoid conflicts with bold
+
+    # Inline code: `text` -> {{text}}
+    text = re.sub(r"`([^`]+)`", r"{{\1}}", text)
+
+    # Links: [text](url) -> [text|url]
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"[\1|\2]", text)
+
+    return text
+
+
+def main():
+    text = sys.stdin.read()
+    sys.stdout.write(md_to_wiki(text))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/pipeline-core/scripts/platform/merge-mr.sh
+++ b/plugins/pipeline-core/scripts/platform/merge-mr.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Usage: merge-mr.sh <mr-number>
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../config/platform.sh"
+
+MR="$1"
+
+wait_for_mergeable() {
+  local pr="$1"
+  local interval=10
+  local max=90
+  local elapsed=0
+
+  while [ "$elapsed" -lt "$max" ]; do
+    local state
+    state=$(gh pr view "$pr" --json mergeable --jq '.mergeable' 2>/dev/null || echo "UNKNOWN")
+
+    case "$state" in
+      MERGEABLE)
+        return 0
+        ;;
+      CONFLICTING)
+        echo "PR has unresolvable merge conflicts" >&2
+        return 1
+        ;;
+      *)
+        echo "Waiting for PR #$pr to become mergeable (state: $state, ${elapsed}s elapsed)..." >&2
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+        ;;
+    esac
+  done
+
+  echo "Timed out waiting for GitHub to compute mergeability" >&2
+  return 1
+}
+
+case "$GIT_HOST" in
+  github)
+    wait_for_mergeable "$MR" || exit 1
+    case "$MERGE_STYLE" in
+      squash) gh pr merge "$MR" --squash --delete-branch ;;
+      merge) gh pr merge "$MR" --merge --delete-branch ;;
+      rebase) gh pr merge "$MR" --rebase --delete-branch ;;
+    esac
+    ;;
+  gitlab)
+    case "$MERGE_STYLE" in
+      squash) glab mr merge "$MR" --squash --remove-source-branch --yes ;;
+      merge) glab mr merge "$MR" --remove-source-branch --yes ;;
+      rebase) glab mr merge "$MR" --rebase --remove-source-branch --yes ;;
+    esac
+    ;;
+esac

--- a/plugins/pipeline-core/scripts/platform/read-issue.sh
+++ b/plugins/pipeline-core/scripts/platform/read-issue.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Usage: read-issue.sh <issue-number-or-key>
+# Returns: JSON { title, body, status }
+# Body is always returned as plain markdown text.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../config/platform.sh"
+
+ISSUE="$1"
+
+case "$TRACKER" in
+  github)
+    gh issue view "$ISSUE" --json title,body,state \
+      | jq '{ title, body, status: .state }'
+    ;;
+  jira)
+    # acli returns description as ADF (Atlassian Document Format) JSON.
+    # Pipe through adf-to-markdown.py to convert to { title, body, status }.
+    acli jira workitem view "$ISSUE" --fields summary,description,status --json 2>/dev/null \
+      | python3 "$SCRIPT_DIR/adf-to-markdown.py"
+    ;;
+esac

--- a/plugins/pipeline-core/scripts/platform/read-mr-comments.sh
+++ b/plugins/pipeline-core/scripts/platform/read-mr-comments.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Usage: read-mr-comments.sh <mr-number>
+# Returns: JSON array of comment bodies
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../config/platform.sh"
+
+MR="$1"
+
+case "$GIT_HOST" in
+  github) gh pr view "$MR" --json comments --jq '[.comments[].body]' ;;
+  gitlab) glab mr note list "$MR" --output json 2>/dev/null | jq '[.[].body]' ;;
+esac

--- a/plugins/pipeline-core/scripts/platform/transition-issue.sh
+++ b/plugins/pipeline-core/scripts/platform/transition-issue.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Usage: transition-issue.sh <issue-number-or-key> [transition-name]
+# GitHub: closes the issue
+# Jira: transitions to the named state (defaults to JIRA_DONE_TRANSITION)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../../config/platform.sh"
+
+ISSUE="$1"
+TRANSITION="${2:-$JIRA_DONE_TRANSITION}"
+
+case "$TRACKER" in
+  github) gh issue close "$ISSUE" ;;
+  jira) acli jira workitem transition --key "$ISSUE" --status "$TRANSITION" ;;
+esac

--- a/plugins/pipeline-core/scripts/post-batch-validate.sh
+++ b/plugins/pipeline-core/scripts/post-batch-validate.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+#
+# post-batch-validate.sh
+# Post-batch validation: maps a batch number to a validation tier, builds Docker
+# if needed, runs unit tests, and runs targeted or full E2E tests.
+#
+# Usage:
+#   ./.claude/scripts/post-batch-validate.sh --batch N
+#
+# Exit codes:
+#   0 — all tests passed
+#   1 — unit test failure
+#   2 — E2E failure after fix attempts
+#   3 — usage / configuration error
+#
+
+set -uo pipefail
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../config/platform.sh"
+
+HEALTH_URL="http://localhost:30004/health"
+HEALTH_TIMEOUT=120      # seconds to poll /health after Docker rebuild
+HEALTH_INTERVAL=5       # seconds between health poll attempts
+
+# =============================================================================
+# PORTABLE TIMEOUT (macOS does not ship GNU timeout)
+# =============================================================================
+
+if ! command -v timeout &>/dev/null; then
+    timeout() {
+        local duration="$1"; shift
+        perl -e '
+            use POSIX ":sys_wait_h";
+            alarm shift @ARGV;
+            $SIG{ALRM} = sub { kill 15, $pid; waitpid($pid, 0); exit 124 };
+            $pid = fork // die "fork: $!";
+            if ($pid == 0) { exec @ARGV; die "exec: $!" }
+            waitpid($pid, 0);
+            exit ($? >> 8);
+        ' "$duration" "$@"
+    }
+fi
+
+# =============================================================================
+# TIER MAP
+#
+# Tier names:
+#   unit-only           — npm test only; no Docker rebuild, no E2E
+#   build+unit          — Docker rebuild + npm test; no E2E
+#   unit+targeted-E2E   — Docker rebuild + npm test + targeted playwright project
+#   unit+full-E2E       — Docker rebuild + npm test + full-journey playwright project
+#
+# Batch → tier assignment:
+#   1-3    unit-only
+#   4      unit+targeted-E2E  (project: batch-4-regression)
+#   5-9    build+unit
+#   10     unit+targeted-E2E  (project: batch-10-regression)
+#   11+    unit+full-E2E      (project: full-journey)
+# =============================================================================
+
+map_batch_to_tier() {
+    local batch="$1"
+    if (( batch >= 1 && batch <= 3 )); then
+        echo "unit-only"
+    elif (( batch == 4 )); then
+        echo "unit+targeted-E2E"
+    elif (( batch >= 5 && batch <= 9 )); then
+        echo "build+unit"
+    elif (( batch == 10 )); then
+        echo "unit+targeted-E2E"
+    else
+        echo "unit+full-E2E"
+    fi
+}
+
+map_batch_to_e2e_project() {
+    local batch="$1"
+    case "$batch" in
+        4)  echo "batch-4-regression" ;;
+        10) echo "batch-10-regression" ;;
+        *)  echo "full-journey" ;;
+    esac
+}
+
+# =============================================================================
+# ARGUMENT PARSING
+# =============================================================================
+
+usage() {
+    cat <<EOF
+Usage: $0 --batch N
+
+Options:
+  --batch N   Batch number (required, positive integer)
+  --help      Show this help
+
+Exit codes:
+  0  All tests passed
+  1  Unit test failure
+  2  E2E failure after fix attempts
+  3  Usage / configuration error
+EOF
+    exit 3
+}
+
+BATCH_NUMBER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --batch)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --batch requires a value" >&2; exit 3; }
+            BATCH_NUMBER="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "ERROR: Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+if [[ -z "$BATCH_NUMBER" ]]; then
+    echo "ERROR: --batch N is required" >&2
+    usage
+fi
+
+if ! [[ "$BATCH_NUMBER" =~ ^[0-9]+$ ]] || (( BATCH_NUMBER < 1 )); then
+    echo "ERROR: --batch must be a positive integer, got: $BATCH_NUMBER" >&2
+    exit 3
+fi
+
+# =============================================================================
+# DERIVE TIER AND E2E PROJECT
+# =============================================================================
+
+TIER=$(map_batch_to_tier "$BATCH_NUMBER")
+E2E_PROJECT=$(map_batch_to_e2e_project "$BATCH_NUMBER")
+
+echo "=== post-batch-validate: batch=$BATCH_NUMBER tier=$TIER ==="
+
+# =============================================================================
+# DOCKER REBUILD (all tiers except unit-only)
+# =============================================================================
+
+needs_docker_rebuild() {
+    [[ "$TIER" != "unit-only" ]]
+}
+
+poll_health() {
+    local deadline=$(( $(date +%s) + HEALTH_TIMEOUT ))
+    echo "Polling $HEALTH_URL (timeout ${HEALTH_TIMEOUT}s)..."
+    while (( $(date +%s) < deadline )); do
+        if curl -sf "$HEALTH_URL" >/dev/null 2>&1; then
+            echo "Health check passed."
+            return 0
+        fi
+        sleep "$HEALTH_INTERVAL"
+    done
+    echo "ERROR: Health check timed out after ${HEALTH_TIMEOUT}s" >&2
+    return 1
+}
+
+if needs_docker_rebuild; then
+    echo "--- Docker rebuild: frontend ---"
+    docker-compose build --no-cache frontend || {
+        echo "ERROR: docker-compose build failed" >&2
+        exit 1
+    }
+    docker-compose up -d frontend || {
+        echo "ERROR: docker-compose up failed" >&2
+        exit 1
+    }
+    poll_health || exit 1
+fi
+
+# =============================================================================
+# UNIT TESTS
+# =============================================================================
+
+echo "--- Unit tests: npm test ---"
+npm test || {
+    echo "ERROR: Unit tests failed" >&2
+    exit 1
+}
+
+echo "Unit tests passed."
+
+# =============================================================================
+# E2E TESTS (unit+targeted-E2E and unit+full-E2E tiers only)
+# =============================================================================
+
+needs_e2e() {
+    [[ "$TIER" == "unit+targeted-E2E" || "$TIER" == "unit+full-E2E" ]]
+}
+
+if needs_e2e; then
+    echo "--- E2E tests: project=$E2E_PROJECT ---"
+
+    E2E_EXIT=0
+    npx playwright test --project="$E2E_PROJECT" --reporter=json || E2E_EXIT=$?
+
+    if (( E2E_EXIT != 0 )); then
+        echo "E2E tests failed (exit $E2E_EXIT). Invoking test-fix-loop..." >&2
+
+        FIX_EXIT=0
+        bash "$SCRIPT_DIR/test-fix-loop.sh" \
+            --max-iterations 2 \
+            --branch main || FIX_EXIT=$?
+
+        if (( FIX_EXIT != 0 )); then
+            echo "ERROR: E2E tests still failing after fix attempts" >&2
+            exit 2
+        fi
+
+        echo "E2E tests passed after fix loop."
+    else
+        echo "E2E tests passed."
+    fi
+fi
+
+echo "=== post-batch-validate: PASSED (batch=$BATCH_NUMBER tier=$TIER) ==="
+exit 0

--- a/plugins/pipeline-core/scripts/prompts/triage-prompt.sh
+++ b/plugins/pipeline-core/scripts/prompts/triage-prompt.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# triage-prompt.sh — build_prompt() for the triage classifier
+#
+# Defines a single function with no external dependencies. Source this file
+# wherever a triage prompt is needed.
+#
+# ─── Prompt File Convention ───────────────────────────────────────────────────
+# Each file in this directory follows the pattern:
+#
+#   prompts/<stage>-prompt.sh
+#
+# Rules for skill/pipeline authors adding a new stage prompt:
+#   1. Name the file  prompts/<stage>-prompt.sh  (e.g. implement-prompt.sh)
+#   2. Define exactly one function — build_prompt() — with no global side-effects
+#   3. Accept stage-specific arguments as positional parameters ($1, $2, …)
+#   4. Declare no globals; output the prompt text to stdout via cat <<HEREDOC
+#   5. Source the file once from the orchestrator, before first use:
+#        # shellcheck source=prompts/<stage>-prompt.sh
+#        source "$SCRIPT_DIR/prompts/<stage>-prompt.sh"
+#
+# This keeps all stage prompt logic isolated from the orchestrator and easy to
+# unit-test independently.
+# ──────────────────────────────────────────────────────────────────────────────
+
+build_prompt() {
+	local issue_body="$1"
+	cat <<TRIAGE_PROMPT
+You are the triage classifier for an issue-implementation pipeline. Classify
+the GitHub issue below into one of two routes:
+
+  "fast-path" — surgical, test-only, well-specified change. Pipeline runs:
+                branch -> implement -> commit -> PR -> squash-merge. Skips
+                test loop, code review, deploy verify, docs.
+  "full"      — default. Runs the full verification pipeline.
+
+Be CONSERVATIVE. False negatives (missing a fast-path opportunity) cost time.
+False positives (skipping verification when it was needed) cost quality. Bias
+hard toward "full" whenever uncertain.
+
+Check ALL SIX criteria. Every criterion must be true for "fast-path". If ANY
+criterion is false, route is "full".
+
+CRITERIA:
+
+1. test_only_scope — All file paths in the issue's Implementation Tasks
+   section match: tests/**, playwright/**, **/*.spec.ts, **/*.test.ts,
+   **/*.e2e.ts. Any reference to apps/, packages/, src/, .claude/, or
+   migration files disqualifies.
+
+2. surgical_size — Estimated diff under 30 lines net, across no more than
+   3 files.
+
+3. established_pattern — The change applies a pattern that already exists in
+   the codebase. Identify the pattern as a grep-able regex and place it in
+   "established_pattern_grep". The shell wrapper will run \`git grep -lE\` and
+   verify >= 3 matching files. Set to null if you cannot identify one
+   specific regex (this criterion then fails).
+
+4. precise_specification — Issue body has an "## Implementation Tasks"
+   section AND each task names specific file paths AND (line numbers OR
+   exact code snippets).
+
+5. benign_failure_mode — Worst outcome of a wrong change is "a test still
+   fails" or "a test skips" — NOT "production breaks", "data corrupts", or
+   "users see incorrect behavior". Test files always pass; production code
+   never passes.
+
+6. no_security_concerns — Skip fast-path for: auth flows, RBAC, encryption,
+   secret handling, input validation, CORS, CSP, session management, token
+   handling. Auth tests deserve review even if test-only.
+
+CONFIDENCE: high (all criteria clearly evaluated) | medium (some criteria
+required inference) | low (vague issue). If confidence is medium or low,
+route MUST be "full".
+
+OUTPUT: schema-enforced JSON with route, criteria.{test_only_scope,
+surgical_size, established_pattern, precise_specification,
+benign_failure_mode, no_security_concerns}.{passed, reason},
+established_pattern_grep, confidence, disqualifying_criterion, summary,
+status.
+
+ISSUE BODY:
+<<<
+${issue_body}
+>>>
+TRIAGE_PROMPT
+}

--- a/plugins/pipeline-core/scripts/resolve-pipeline-root.sh
+++ b/plugins/pipeline-core/scripts/resolve-pipeline-root.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# resolve-pipeline-root.sh — self-locating pipeline scripts/schemas root resolver.
+#
+# Pipeline orchestration scripts + JSON schemas live in one of two layouts:
+#   - the marketplace plugin bundle:  plugins/pipeline-core/scripts/
+#   - repo-local (pipeline repo + mid-transition consumers):  .claude/scripts/
+#
+# This helper resolves a file relative to whichever layout the caller is running
+# from WITHOUT depending on $CLAUDE_PLUGIN_ROOT being exported at runtime.
+#
+# Why not CLAUDE_PLUGIN_ROOT? Per issue #599 (Task 1 verification): that variable
+# is UNSET in the model's Bash-tool shell. It is only a path-substitution
+# placeholder the harness expands inside hooks.json command strings — NOT an env
+# var exported to scripts a skill instructs the model to run. So the resolver
+# SELF-LOCATES via ${BASH_SOURCE[0]} and treats CLAUDE_PLUGIN_ROOT only as an
+# optional hint (use-if-set-and-present, never a hard dependency).
+#
+# Because this library ships as a sibling of the orchestrator scripts and the
+# schemas/ directory, the directory it lives in IS the pipeline scripts root —
+# identically in the plugin bundle and in the repo-local .claude/scripts/ layout.
+# That makes the repo-local fallback inherent: no big-bang cutover needed.
+#
+# Usage:
+#   source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+#   schema="$(resolve_pipeline_file schemas/stage-result.json)" || {
+#       echo "schema not found" >&2; exit 1;
+#   }
+#
+# resolve_pipeline_file <relative/path>
+#   Prints the first existing absolute path for <relative/path>, searching:
+#     1. $CLAUDE_PLUGIN_ROOT/scripts/<rel>  — optional hint; only when the var is
+#        non-empty AND the file exists there.
+#     2. <dir-of-this-library>/<rel>        — self-location via BASH_SOURCE; the
+#        canonical path for both layouts.
+#   On a hit: prints the absolute path and returns 0.
+#   On a miss (or empty argument): prints nothing and returns non-zero.
+
+# Idempotent sourcing guard — skip re-definition on repeated source.
+if [[ -z "${_RESOLVE_PIPELINE_ROOT_SOURCED:-}" ]]; then
+    _RESOLVE_PIPELINE_ROOT_SOURCED=1
+
+    # Directory this library lives in, captured once at source time. At the top
+    # level of the file, ${BASH_SOURCE[0]} is this file's own path regardless of
+    # who sourced it, so this pins the pipeline scripts root for later calls even
+    # if the caller's own BASH_SOURCE context changes.
+    _PIPELINE_SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    # resolve_pipeline_file <relative/path>
+    resolve_pipeline_file() {
+        local rel="$1"
+        [[ -n "$rel" ]] || return 1
+
+        # 1. Optional CLAUDE_PLUGIN_ROOT hint. Used only when the var is set AND
+        #    the file actually exists under it — never a hard runtime dependency.
+        if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -e "${CLAUDE_PLUGIN_ROOT}/scripts/${rel}" ]]; then
+            printf '%s\n' "${CLAUDE_PLUGIN_ROOT}/scripts/${rel}"
+            return 0
+        fi
+
+        # 2. Self-location: sibling of this library. Canonical for the plugin
+        #    bundle and the repo-local .claude/scripts/ layout alike.
+        if [[ -e "${_PIPELINE_SCRIPTS_DIR}/${rel}" ]]; then
+            printf '%s\n' "${_PIPELINE_SCRIPTS_DIR}/${rel}"
+            return 0
+        fi
+
+        return 1
+    }
+fi

--- a/plugins/pipeline-core/scripts/run-batches-all.sh
+++ b/plugins/pipeline-core/scripts/run-batches-all.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+#
+# run-batches-all.sh
+# Sequential wrapper that runs all batches defined in IMPLEMENTATION_BATCHES.md.
+#
+# For each batch:
+#   1. git tag -f batch-N-start
+#   2. .claude/scripts/batch-orchestrator.sh --issues "..." --branch main
+#   3. .claude/scripts/post-batch-validate.sh --batch N
+#
+# Stops on first non-zero exit and prints a summary.
+#
+# Usage:
+#   ./.claude/scripts/run-batches-all.sh
+#   ./.claude/scripts/run-batches-all.sh --start-batch 7
+#   ./.claude/scripts/run-batches-all.sh --help
+#
+# Exit codes:
+#   0  All batches passed
+#   1  A batch or validation step failed (see summary)
+#   3  Usage / configuration error
+#
+
+set -uo pipefail
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+LOG_DIR="$REPO_ROOT/logs/run-batches-all-$TIMESTAMP"
+
+# =============================================================================
+# BATCH DEFINITIONS — issue lists sourced from IMPLEMENTATION_BATCHES.md
+#
+# Batches 1-6 are already complete; included so --start-batch works correctly
+# and git tags are placed for provenance.
+# =============================================================================
+
+# Using parallel arrays for bash 3 compatibility (macOS default bash)
+BATCH_NUMS=(1 2 3 4 5 6 7 8 9 10 11)
+BATCH_ISSUES_1="1389,1263,1391,1392,1319"
+BATCH_ISSUES_2="1298,1292,1285,1388"
+BATCH_ISSUES_3="1339,1340,1351,1338,1372"
+BATCH_ISSUES_4="1399,1394,1405,1406,1400"
+BATCH_ISSUES_5="1396,1397,1273,1271,1264"
+BATCH_ISSUES_6="1417,1410,1408,1378,1379,1369,1282"
+BATCH_ISSUES_7="1281,1331,1349,1259,1420"
+BATCH_ISSUES_8="1257,1307,1416,1386,1436,1434"
+BATCH_ISSUES_9="1251,1303,1305,1252,1454"
+BATCH_ISSUES_10="1270,1296,1326"
+BATCH_ISSUES_11="1422,1423,1424"
+
+TOTAL_BATCHES=11
+
+get_batch_issues() {
+    local n="$1"
+    local varname="BATCH_ISSUES_$n"
+    echo "${!varname}"
+}
+
+# =============================================================================
+# ARGUMENT PARSING
+# =============================================================================
+
+usage() {
+    cat <<EOF
+Usage: $0 [--start-batch N]
+
+Options:
+  --start-batch N   Resume from batch N (default: 1)
+  --help            Show this help
+
+Exit codes:
+  0  All batches passed
+  1  A batch or validation step failed
+  3  Usage / configuration error
+EOF
+    exit 3
+}
+
+START_BATCH=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --start-batch)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --start-batch requires a value" >&2; exit 3; }
+            START_BATCH="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "ERROR: Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+if ! [[ "$START_BATCH" =~ ^[0-9]+$ ]] || (( START_BATCH < 1 )) || (( START_BATCH > TOTAL_BATCHES )); then
+    echo "ERROR: --start-batch must be between 1 and $TOTAL_BATCHES, got: $START_BATCH" >&2
+    exit 3
+fi
+
+# =============================================================================
+# SETUP
+# =============================================================================
+
+mkdir -p "$LOG_DIR"
+
+SUMMARY_FILE="$LOG_DIR/summary.txt"
+FAILED_BATCH=""
+FAILED_STEP=""
+
+log() {
+    local msg="$1"
+    echo "$msg" | tee -a "$SUMMARY_FILE"
+}
+
+log "=== run-batches-all: start (batches $START_BATCH–$TOTAL_BATCHES) ==="
+log "Log directory: $LOG_DIR"
+log "Timestamp: $TIMESTAMP"
+log ""
+
+cd "$REPO_ROOT"
+
+# =============================================================================
+# MAIN LOOP
+# =============================================================================
+
+for (( batch=START_BATCH; batch<=TOTAL_BATCHES; batch++ )); do
+    ISSUES="$(get_batch_issues "$batch")"
+    BATCH_LOG_DIR="$LOG_DIR/batch-$batch"
+    mkdir -p "$BATCH_LOG_DIR"
+
+    log "--- Batch $batch/$TOTAL_BATCHES: issues=$ISSUES ---"
+
+    # -------------------------------------------------------------------------
+    # Step 1: git tag
+    # -------------------------------------------------------------------------
+    log "[batch $batch] git tag -f batch-$batch-start"
+    if ! git tag -f "batch-$batch-start" >> "$BATCH_LOG_DIR/git-tag.log" 2>&1; then
+        log "ERROR: git tag failed for batch $batch"
+        FAILED_BATCH="$batch"
+        FAILED_STEP="git-tag"
+        break
+    fi
+
+    # -------------------------------------------------------------------------
+    # Step 2: batch-orchestrator.sh
+    # -------------------------------------------------------------------------
+    ORCHESTRATOR_LOG="$BATCH_LOG_DIR/batch-orchestrator.log"
+    log "[batch $batch] batch-orchestrator.sh --issues \"$ISSUES\" --branch main"
+
+    ORCHESTRATOR_EXIT=0
+    "$SCRIPT_DIR/batch-orchestrator.sh" \
+        --issues "$ISSUES" \
+        --branch main \
+        2>&1 | tee "$ORCHESTRATOR_LOG" || ORCHESTRATOR_EXIT=$?
+
+    if (( ORCHESTRATOR_EXIT != 0 )); then
+        log "ERROR: batch-orchestrator.sh failed (exit $ORCHESTRATOR_EXIT) for batch $batch"
+        FAILED_BATCH="$batch"
+        FAILED_STEP="batch-orchestrator"
+        break
+    fi
+
+    # -------------------------------------------------------------------------
+    # Step 3: post-batch-validate.sh
+    # -------------------------------------------------------------------------
+    VALIDATE_LOG="$BATCH_LOG_DIR/post-batch-validate.log"
+    log "[batch $batch] post-batch-validate.sh --batch $batch"
+
+    VALIDATE_EXIT=0
+    "$SCRIPT_DIR/post-batch-validate.sh" \
+        --batch "$batch" \
+        2>&1 | tee "$VALIDATE_LOG" || VALIDATE_EXIT=$?
+
+    if (( VALIDATE_EXIT != 0 )); then
+        log "ERROR: post-batch-validate.sh failed (exit $VALIDATE_EXIT) for batch $batch"
+        FAILED_BATCH="$batch"
+        FAILED_STEP="post-batch-validate"
+        break
+    fi
+
+    log "[batch $batch] PASSED"
+    log ""
+done
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+
+log ""
+log "=== run-batches-all: SUMMARY ==="
+
+if [[ -n "$FAILED_BATCH" ]]; then
+    log "FAILED at batch $FAILED_BATCH (step: $FAILED_STEP)"
+    log "To resume: $0 --start-batch $FAILED_BATCH"
+    log "Logs: $LOG_DIR"
+    log ""
+    log "Batches completed: $(( FAILED_BATCH - START_BATCH )) of $(( TOTAL_BATCHES - START_BATCH + 1 ))"
+    exit 1
+else
+    COMPLETED=$(( TOTAL_BATCHES - START_BATCH + 1 ))
+    log "All $COMPLETED batches passed (batches $START_BATCH–$TOTAL_BATCHES)"
+    log "Logs: $LOG_DIR"
+    exit 0
+fi

--- a/plugins/pipeline-core/scripts/schemas/escalation-policy.json
+++ b/plugins/pipeline-core/scripts/schemas/escalation-policy.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "escalation-policy skill output: route a completed stage_result to accept, escalate, bail, or retry_same",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["accept", "escalate", "bail", "retry_same"],
+      "description": "Routing decision for the pipeline"
+    },
+    "model": {
+      "type": "string",
+      "enum": ["haiku", "sonnet", "opus"],
+      "description": "Target model when action==escalate; omitted otherwise"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable routing rationale for logging and diagnostics"
+    }
+  },
+  "required": ["action", "reason"]
+}

--- a/plugins/pipeline-core/scripts/schemas/explore-research.json
+++ b/plugins/pipeline-core/scripts/schemas/explore-research.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["status", "summary"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["success", "partial", "error"]
+    },
+    "summary": {
+      "type": "string",
+      "description": "Concise summary of research findings (2-5 sentences)"
+    },
+    "affected_files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "what_needs_changing"],
+        "properties": {
+          "path": { "type": "string" },
+          "what_needs_changing": { "type": "string" }
+        }
+      }
+    },
+    "current_behavior": {
+      "type": "string",
+      "description": "What happens now"
+    },
+    "desired_behavior": {
+      "type": "string",
+      "description": "What should happen"
+    },
+    "patterns_to_follow": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Existing codebase patterns the implementation should follow"
+    },
+    "data_findings": {
+      "type": "string",
+      "description": "Raw data or measurements relevant to the investigation"
+    }
+  },
+  "additionalProperties": false
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-complete.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-complete.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {"enum": ["success", "error", "max_iterations"]},
+    "pr_number": {"type": "integer"},
+    "branch": {"type": "string"},
+    "decisions": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "reviews_passed": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "summary": {"type": "string"},
+    "error": {"type": ["string", "null"]}
+  },
+  "required": ["status", "summary"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-deploy-verify.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-deploy-verify.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Structured output from deploy and verification phase of implement-issue workflow",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["success", "error", "partial"],
+      "description": "Overall status of deployment and verification"
+    },
+    "deployment_target": {
+      "type": "string",
+      "description": "The target environment where the code was deployed (e.g., staging, production, local)"
+    },
+    "health_status": {
+      "type": "string",
+      "enum": ["healthy", "degraded", "failed", "unknown"],
+      "description": "Status of the deployed application health checks"
+    },
+    "verification_results": {
+      "type": "object",
+      "description": "Results from verification tests and checks",
+      "properties": {
+        "tests_passed": {
+          "type": "boolean",
+          "description": "Whether all tests passed"
+        },
+        "acceptance_criteria_met": {
+          "type": "boolean",
+          "description": "Whether all acceptance criteria are satisfied"
+        },
+        "details": {
+          "type": "string",
+          "description": "Detailed verification information"
+        }
+      }
+    },
+    "issues": {
+      "type": "array",
+      "description": "Array of any issues encountered during deployment or verification",
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "warning", "info"],
+            "description": "Severity level of the issue"
+          },
+          "message": {
+            "type": "string",
+            "description": "Description of the issue"
+          }
+        },
+        "required": ["severity", "message"]
+      }
+    },
+    "summary": {
+      "type": "string",
+      "description": "High-level summary of the deployment and verification results"
+    }
+  },
+  "required": ["status", "deployment_target", "health_status", "summary"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-e2e-validate.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-e2e-validate.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {"enum": ["passed", "failed"]},
+    "summary": {"type": "string"},
+    "container_rebuild_status": {"enum": ["success", "failed", "skipped"]},
+    "health_check_status": {"enum": ["healthy", "unhealthy", "skipped"]},
+    "tests_run": {"type": "integer"},
+    "tests_passed": {"type": "integer"},
+    "tests_failed": {"type": "integer"},
+    "screenshots_captured": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "targeted_test_files": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "test": {"type": "string"},
+          "message": {"type": "string"},
+          "screenshot": {"type": "string"}
+        }
+      }
+    }
+  },
+  "required": ["result", "summary", "container_rebuild_status", "health_check_status"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-fix.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-fix.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {"enum": ["success", "error"]},
+    "commit": {"type": "string"},
+    "files_changed": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "fixes_applied": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "summary": {"type": "string"},
+    "error": {"type": ["string", "null"]}
+  },
+  "required": ["status", "summary"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-implement.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-implement.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {"enum": ["success", "error"]},
+    "already_done": {"type": "boolean"},
+    "commit": {"type": "string"},
+    "files_changed": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "summary": {"type": "string"},
+    "error": {"type": ["string", "null"]}
+  },
+  "required": ["status", "summary"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-parse.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-parse.json
@@ -1,0 +1,45 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["success", "error", "rate_limit"],
+      "description": "Whether task extraction succeeded"
+    },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "description": { "type": "string" },
+          "agent": { "type": "string" },
+          "affected_files": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "File paths this task will modify (from 'Affected files:' line in issue)"
+          }
+        },
+        "required": ["id", "description", "agent"]
+      },
+      "description": "Extracted implementation tasks"
+    },
+    "branch": {
+      "type": "string",
+      "description": "Feature branch name"
+    },
+    "task_count": {
+      "type": "integer",
+      "description": "Number of tasks extracted"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Brief summary of extraction"
+    },
+    "error": {
+      "type": "string",
+      "description": "Error message if status is error"
+    }
+  },
+  "required": ["status"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-pr.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-pr.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {"enum": ["success", "error"]},
+    "pr_number": {"type": "integer"},
+    "pr_url": {"type": "string"},
+    "error": {"type": ["string", "null"]}
+  },
+  "required": ["status", "pr_number"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-review.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-review.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {"enum": ["approved", "changes_requested"]},
+    "comments": {"type": "string"},
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": {"enum": ["major", "minor"]},
+          "description": {"type": "string"},
+          "file": {"type": "string"},
+          "line": {"type": "integer"}
+        }
+      }
+    },
+    "summary": {"type": "string"}
+  },
+  "required": ["result", "summary"],
+  "additionalProperties": false
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-simplify.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-simplify.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {"enum": ["success", "error"]},
+    "commit": {"type": "string"},
+    "files_simplified": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "changes_made": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "summary": {"type": "string"},
+    "error": {"type": ["string", "null"]}
+  },
+  "required": ["status", "summary"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-task-review.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-task-review.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {"enum": ["passed", "failed"]},
+    "suggested_improvements": {"enum": ["yes", "no"]},
+    "comments": {"type": "string"}
+  },
+  "required": ["result", "suggested_improvements"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-test-validate.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-test-validate.json
@@ -1,0 +1,48 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {"enum": ["passed", "failed"]},
+    "total_tests": {"type": "integer"},
+    "passed_tests": {"type": "integer"},
+    "failed_tests": {"type": "integer"},
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "test": {"type": "string"},
+          "message": {"type": "string"}
+        }
+      }
+    },
+    "summary": {"type": "string"},
+    "validation_result": {"enum": ["passed", "failed", "skipped"]},
+    "validation_issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": {"enum": ["major", "minor"]},
+          "description": {"type": "string"},
+          "file": {"type": "string"}
+        }
+      }
+    },
+    "pre_existing_issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "description": {"type": "string"},
+          "file": {"type": "string"}
+        }
+      }
+    },
+    "validation_summary": {"type": "string"},
+    "e2e_result": {"enum": ["passed", "failed", "skipped"]},
+    "e2e_summary": {"type": "string"},
+    "bats_result": {"enum": ["passed", "failed", "skipped"]},
+    "bats_summary": {"type": "string"}
+  },
+  "required": ["result", "summary", "validation_result"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-test.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-test.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {"enum": ["passed", "failed"]},
+    "total_tests": {"type": "integer"},
+    "passed_tests": {"type": "integer"},
+    "failed_tests": {"type": "integer"},
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "test": {"type": "string"},
+          "message": {"type": "string"}
+        }
+      }
+    },
+    "summary": {"type": "string"}
+  },
+  "required": ["result", "summary"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-triage.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-triage.json
@@ -1,0 +1,99 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["success", "error", "rate_limit"],
+      "description": "Whether triage classification succeeded"
+    },
+    "route": {
+      "type": "string",
+      "enum": ["fast-path", "full"],
+      "description": "Pipeline route. 'fast-path' = surgical pipeline (branch → implement → commit → PR → squash-merge). 'full' = standard pipeline with all verification stages."
+    },
+    "criteria": {
+      "type": "object",
+      "description": "Per-criterion evaluation. ALL six must be passed=true for fast-path.",
+      "properties": {
+        "test_only_scope": {
+          "type": "object",
+          "properties": {
+            "passed": { "type": "boolean" },
+            "reason": { "type": "string" }
+          },
+          "required": ["passed", "reason"]
+        },
+        "surgical_size": {
+          "type": "object",
+          "properties": {
+            "passed": { "type": "boolean" },
+            "reason": { "type": "string" }
+          },
+          "required": ["passed", "reason"]
+        },
+        "established_pattern": {
+          "type": "object",
+          "properties": {
+            "passed": { "type": "boolean" },
+            "reason": { "type": "string" }
+          },
+          "required": ["passed", "reason"]
+        },
+        "precise_specification": {
+          "type": "object",
+          "properties": {
+            "passed": { "type": "boolean" },
+            "reason": { "type": "string" }
+          },
+          "required": ["passed", "reason"]
+        },
+        "benign_failure_mode": {
+          "type": "object",
+          "properties": {
+            "passed": { "type": "boolean" },
+            "reason": { "type": "string" }
+          },
+          "required": ["passed", "reason"]
+        },
+        "no_security_concerns": {
+          "type": "object",
+          "properties": {
+            "passed": { "type": "boolean" },
+            "reason": { "type": "string" }
+          },
+          "required": ["passed", "reason"]
+        }
+      },
+      "required": [
+        "test_only_scope",
+        "surgical_size",
+        "established_pattern",
+        "precise_specification",
+        "benign_failure_mode",
+        "no_security_concerns"
+      ]
+    },
+    "established_pattern_grep": {
+      "type": ["string", "null"],
+      "description": "Grep-able regex identifying the pattern this change applies. Shell wrapper runs `git grep -lE` and verifies ≥3 matching files. Null when no specific pattern can be identified (criterion 3 fails)."
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["high", "medium", "low"],
+      "description": "Classifier confidence. medium/low forces route='full' regardless of criteria."
+    },
+    "disqualifying_criterion": {
+      "type": ["string", "null"],
+      "description": "Name of the criterion that forced route='full'. Null when all criteria passed AND route is 'fast-path'."
+    },
+    "summary": {
+      "type": "string",
+      "description": "One-sentence explanation of the routing decision."
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Error message when status='error'."
+    }
+  },
+  "required": ["status"]
+}

--- a/plugins/pipeline-core/scripts/schemas/implement-issue.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Structured output from implement-issue skill for batch processing",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["success", "error", "rate_limit"],
+      "description": "Final status of the implementation attempt"
+    },
+    "pr_number": {
+      "type": "integer",
+      "description": "PR number if created successfully"
+    },
+    "branch": {
+      "type": "string",
+      "description": "Feature branch name (e.g., issue-123-fix-auth)"
+    },
+    "error": {
+      "type": "string",
+      "description": "Error message if status is error or rate_limit"
+    },
+    "stage": {
+      "type": "string",
+      "enum": ["fetch", "research", "plan", "implement", "test", "review", "pr"],
+      "description": "Stage where error occurred (only present on error)"
+    }
+  },
+  "required": ["status"]
+}

--- a/plugins/pipeline-core/scripts/schemas/model-fallback-output.json
+++ b/plugins/pipeline-core/scripts/schemas/model-fallback-output.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "model-fallback skill output: next model tier to try, or null when at the opus ceiling",
+  "properties": {
+    "next_model": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["haiku", "sonnet", "opus"],
+          "description": "The next model tier to use; only present when at_ceiling is false"
+        },
+        {
+          "type": "null",
+          "description": "null when at_ceiling is true — no further fallback is possible"
+        }
+      ]
+    },
+    "at_ceiling": {
+      "type": "boolean",
+      "description": "true when current_model is opus or error_kind is non-escalatable (permission_denied, schema_not_found, max_turns_exhausted_at_ceiling)"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable rationale for the decision"
+    }
+  },
+  "required": ["next_model", "at_ceiling", "reason"]
+}

--- a/plugins/pipeline-core/scripts/schemas/model-fallback.json
+++ b/plugins/pipeline-core/scripts/schemas/model-fallback.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "model-fallback skill output: next model to escalate to, or at-ceiling indication",
+  "properties": {
+    "next_model": {
+      "type": ["string", "null"],
+      "enum": ["haiku", "sonnet", "opus", null],
+      "description": "Model to escalate to, or null when no further escalation is possible"
+    },
+    "at_ceiling": {
+      "type": "boolean",
+      "description": "True when current_model is opus or the error_kind makes escalation impossible"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable escalation rationale"
+    }
+  },
+  "required": ["next_model", "at_ceiling", "reason"]
+}

--- a/plugins/pipeline-core/scripts/schemas/pipeline-event.json
+++ b/plugins/pipeline-core/scripts/schemas/pipeline-event.json
@@ -1,0 +1,342 @@
+{
+  "description": "Append-only JSONL event envelope for the pipeline event stream. Each line is one event.",
+  "type": "object",
+  "required": ["ts", "run_id", "event"],
+  "properties": {
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp when the event was emitted"
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Unique run identifier, e.g. issue-158-20260409-183459"
+    },
+    "stage": {
+      "type": "string",
+      "description": "Pipeline stage name, e.g. triage, implement, test, review"
+    },
+    "event": {
+      "type": "string",
+      "enum": [
+        "escalation",
+        "retry",
+        "model_call",
+        "rate_limit_hit",
+        "schema_validation_fail",
+        "status_change",
+        "stage_start",
+        "stage_end",
+        "batch_start",
+        "batch_end",
+        "issue_start",
+        "issue_end",
+        "batch_paused",
+        "cost_trend_warning",
+        "budget_exceeded"
+      ],
+      "description": "Event type discriminator"
+    },
+    "task": {
+      "type": "integer",
+      "description": "Task number within the stage, when applicable (omitted for stage-level events)"
+    }
+  },
+  "oneOf": [
+    {
+      "description": "Model escalation — a lower-tier model was replaced by a higher-tier model mid-stage",
+      "properties": {
+        "event": { "const": "escalation" },
+        "reason": {
+          "type": "string",
+          "enum": ["timeout", "empty_output", "max_turns_exhausted", "structured_error", "double_timeout"],
+          "description": "Why escalation was triggered"
+        },
+        "from_model": {
+          "type": "string",
+          "description": "Model being replaced, e.g. haiku"
+        },
+        "to_model": {
+          "type": "string",
+          "description": "Replacement model, e.g. sonnet"
+        },
+        "consecutive_timeouts": {
+          "type": "integer",
+          "description": "Number of consecutive timeouts that led to this escalation"
+        }
+      },
+      "required": ["event", "reason", "from_model", "to_model"]
+    },
+    {
+      "description": "Retry attempt after a transient failure",
+      "properties": {
+        "event": { "const": "retry" },
+        "reason": {
+          "type": "string",
+          "enum": ["timeout", "empty_output", "rate_limit", "schema_validation_fail"],
+          "description": "Why the retry was triggered"
+        },
+        "attempt": {
+          "type": "integer",
+          "description": "Current attempt number (1-based)"
+        },
+        "max_attempts": {
+          "type": "integer",
+          "description": "Maximum allowed attempts before escalation or failure"
+        }
+      },
+      "required": ["event", "reason", "attempt", "max_attempts"]
+    },
+    {
+      "description": "An individual Claude API call was made",
+      "properties": {
+        "event": { "const": "model_call" },
+        "model": {
+          "type": "string",
+          "description": "Model ID used for this call, e.g. claude-haiku-4-5"
+        },
+        "stage_attempt": {
+          "type": "integer",
+          "description": "Which attempt within the stage this call belongs to (1-based)"
+        },
+        "turns_used": {
+          "type": "integer",
+          "description": "Number of agentic turns consumed"
+        },
+        "exit_reason": {
+          "type": "string",
+          "enum": ["success", "timeout", "max_turns", "error"],
+          "description": "How the call terminated"
+        }
+      },
+      "required": ["event", "model", "stage_attempt"]
+    },
+    {
+      "description": "A rate limit (HTTP 429 or quota exhaustion) was encountered",
+      "properties": {
+        "event": { "const": "rate_limit_hit" },
+        "model": {
+          "type": ["string", "null"],
+          "description": "Model that triggered the rate limit, if known"
+        },
+        "retry_after_seconds": {
+          "type": "integer",
+          "description": "Seconds to wait before retrying, from Retry-After header"
+        }
+      },
+      "required": ["event"]
+    },
+    {
+      "description": "Structured output from a Claude call failed JSON Schema validation",
+      "properties": {
+        "event": { "const": "schema_validation_fail" },
+        "schema": {
+          "type": "string",
+          "description": "Schema filename against which validation was attempted, e.g. implement-issue-triage.json"
+        },
+        "errors": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Validation error messages"
+        }
+      },
+      "required": ["event", "schema", "errors"]
+    },
+    {
+      "description": "The orchestrator run state transitioned (e.g. initializing → running → completed)",
+      "properties": {
+        "event": { "const": "status_change" },
+        "from_state": {
+          "type": "string",
+          "enum": ["initializing", "running", "completed", "failed"],
+          "description": "Previous orchestrator state"
+        },
+        "to_state": {
+          "type": "string",
+          "enum": ["initializing", "running", "completed", "failed"],
+          "description": "New orchestrator state"
+        }
+      },
+      "required": ["event", "from_state", "to_state"]
+    },
+    {
+      "description": "A pipeline stage began execution",
+      "properties": {
+        "event": { "const": "stage_start" },
+        "model": {
+          "type": "string",
+          "description": "Model selected for this stage"
+        },
+        "route": {
+          "type": ["string", "null"],
+          "enum": ["fast-path", "full", null],
+          "description": "Pipeline route in effect at stage start, if known"
+        }
+      },
+      "required": ["event", "model"]
+    },
+    {
+      "description": "A pipeline stage finished execution",
+      "properties": {
+        "event": { "const": "stage_end" },
+        "status": {
+          "type": "string",
+          "enum": ["success", "error", "rate_limit"],
+          "description": "Outcome of the stage"
+        },
+        "duration_seconds": {
+          "type": "number",
+          "description": "Wall-clock seconds from stage_start to stage_end"
+        },
+        "error_kind": {
+          "type": "string",
+          "description": "Machine-readable error classification, present when status is error"
+        },
+        "input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Uncached input tokens billed for this stage (issue #580)"
+        },
+        "output_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Output tokens generated for this stage (issue #580)"
+        },
+        "cache_creation_input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Input tokens written to the prompt cache (issue #580)"
+        },
+        "cache_read_input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Input tokens served from the prompt cache (issue #580)"
+        },
+        "estimated_cost": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Estimated USD cost for this stage (issue #580)"
+        }
+      },
+      "required": ["event", "status"]
+    },
+    {
+      "description": "A batch run began processing its issue list",
+      "properties": {
+        "event": { "const": "batch_start" }
+      },
+      "required": ["event"]
+    },
+    {
+      "description": "A batch run finished processing all issues",
+      "properties": {
+        "event": { "const": "batch_end" },
+        "outcome": {
+          "type": "string",
+          "enum": ["completed", "circuit_breaker", "failed"],
+          "description": "How the batch terminated"
+        }
+      },
+      "required": ["event", "outcome"]
+    },
+    {
+      "description": "Processing began for a single issue within a batch",
+      "properties": {
+        "event": { "const": "issue_start" },
+        "issue_num": {
+          "type": "string",
+          "description": "Issue number being processed, e.g. 158"
+        }
+      },
+      "required": ["event", "issue_num"]
+    },
+    {
+      "description": "Processing finished for a single issue within a batch",
+      "properties": {
+        "event": { "const": "issue_end" },
+        "issue_num": {
+          "type": "string",
+          "description": "Issue number that finished processing"
+        },
+        "outcome": {
+          "type": "string",
+          "enum": ["success", "failed"],
+          "description": "Whether the issue was processed successfully"
+        }
+      },
+      "required": ["event", "issue_num", "outcome"]
+    },
+    {
+      "description": "The batch was paused by the circuit breaker due to consecutive failures",
+      "properties": {
+        "event": { "const": "batch_paused" },
+        "consecutive_failures": {
+          "type": "integer",
+          "description": "Number of consecutive issue failures that triggered the circuit breaker"
+        },
+        "max_failures": {
+          "type": "integer",
+          "description": "Configured threshold that was exceeded"
+        }
+      },
+      "required": ["event", "consecutive_failures", "max_failures"]
+    },
+    {
+      "description": "Advisory cost/token trend guard fired — the batch's MT/issue exceeded the rolling baseline by the configured factor (issue #585). Non-blocking.",
+      "properties": {
+        "event": { "const": "cost_trend_warning" },
+        "latest_mt_per_issue": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Latest batch megatokens per completed issue"
+        },
+        "baseline_mt_per_issue": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Rolling baseline megatokens per issue over the window"
+        },
+        "factor": {
+          "type": "number",
+          "description": "Configured warn factor (COST_TREND_FACTOR)"
+        },
+        "window": {
+          "type": "integer",
+          "description": "Configured rolling window size (COST_TREND_WINDOW)"
+        }
+      },
+      "required": ["event", "latest_mt_per_issue", "baseline_mt_per_issue"]
+    },
+    {
+      "description": "A per-run or per-batch token/cost budget ceiling was exceeded; the run or batch halted with state budget_exceeded (issue #583). Terminal — never escalated or retried.",
+      "properties": {
+        "event": { "const": "budget_exceeded" },
+        "scope": {
+          "type": "string",
+          "enum": ["run", "batch"],
+          "description": "Whether the per-run or per-batch ceiling was breached"
+        },
+        "used_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Cumulative tokens consumed at the breach"
+        },
+        "max_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Configured token ceiling (0 = disabled)"
+        },
+        "used_cost_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Cumulative cost in USD at the breach"
+        },
+        "max_cost_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Configured cost ceiling in USD (0 = disabled)"
+        }
+      },
+      "required": ["event", "scope"]
+    }
+  ]
+}

--- a/plugins/pipeline-core/scripts/schemas/pipeline-feedback.json
+++ b/plugins/pipeline-core/scripts/schemas/pipeline-feedback.json
@@ -1,0 +1,43 @@
+{
+  "description": "Schema for pipeline feedback records — structured observations about classification or routing errors for offline analysis and prompt improvement.",
+  "type": "object",
+  "required": ["timestamp", "kind", "issue", "observed", "expected"],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp when the feedback was recorded"
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "triage_misclassification",
+        "prompt_regression",
+        "criterion_drift",
+        "agent_misroute",
+        "escalation_loop"
+      ],
+      "description": "Category of pipeline failure being reported"
+    },
+    "issue": {
+      "type": "string",
+      "description": "Issue number or identifier associated with this feedback, e.g. 176"
+    },
+    "observed": {
+      "type": "string",
+      "description": "What the pipeline actually did (the incorrect or unexpected behaviour)"
+    },
+    "expected": {
+      "type": "string",
+      "description": "What the pipeline should have done (the correct or desired behaviour)"
+    },
+    "evidence_path": {
+      "type": "string",
+      "description": "Relative path to a log file, JSONL event stream, or artifact that supports this feedback (optional)"
+    },
+    "notes": {
+      "type": "string",
+      "description": "Free-form context, hypotheses, or reproduction steps (optional)"
+    }
+  }
+}

--- a/plugins/pipeline-core/scripts/schemas/process-pr.json
+++ b/plugins/pipeline-core/scripts/schemas/process-pr.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Structured output from process-pr skill for batch processing",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["merged", "changes_requested", "merge_blocked", "error", "rate_limit"],
+      "description": "Final status of PR processing"
+    },
+    "follow_up_issues": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Issue numbers created as follow-ups from code review"
+    },
+    "error": {
+      "type": "string",
+      "description": "Error message if status is error or rate_limit"
+    }
+  },
+  "required": ["status"]
+}

--- a/plugins/pipeline-core/scripts/schemas/retry-policy.json
+++ b/plugins/pipeline-core/scripts/schemas/retry-policy.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "retry-policy skill output: retry same tier, escalate, or bail permanently",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["retry", "escalate", "bail"],
+      "description": "Decision: retry at same tier, escalate to higher tier, or bail permanently"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable rationale for the decision"
+    },
+    "backoff_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Milliseconds to wait before retrying; only present when action==retry and error_kind==rate_limit"
+    }
+  },
+  "required": ["action", "reason"]
+}

--- a/plugins/pipeline-core/scripts/schemas/skill-frontmatter.json
+++ b/plugins/pipeline-core/scripts/schemas/skill-frontmatter.json
@@ -1,0 +1,142 @@
+{
+  "description": "JSON schema for SKILL.md YAML frontmatter — validates the existing required fields and the five optional metadata fields added in issue #177.",
+  "type": "object",
+  "required": ["name", "description", "inputs", "outputs", "side_effects", "composes", "failure_modes"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Canonical skill identifier (matches the directory name under .claude/skills/)"
+    },
+    "description": {
+      "type": "string",
+      "description": "One-line summary used by the skill router to decide whether this skill applies"
+    },
+    "argument-hint": {
+      "type": "string",
+      "description": "Human-readable hint for the argument(s) the skill accepts, shown in skill listings"
+    },
+    "inputs": {
+      "type": "array",
+      "description": "Explicit contract for what the skill consumes; enables a meta-skill to validate args before invocation",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Input parameter name"
+          },
+          "type": {
+            "type": "string",
+            "description": "Data type of the input (e.g. string, integer, url, boolean, file_path)"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Whether this input is required; defaults to false if omitted"
+          },
+          "description": {
+            "type": "string",
+            "description": "What the input represents and how it is used"
+          }
+        }
+      }
+    },
+    "outputs": {
+      "type": "array",
+      "description": "Explicit contract for what consumers can rely on; enables piping skill outputs into other skills",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Output value name"
+          },
+          "type": {
+            "type": "string",
+            "description": "Data type of the output (e.g. string, integer, url, boolean, file_path, json)"
+          },
+          "description": {
+            "type": "string",
+            "description": "What the output represents and where it can be found"
+          }
+        }
+      }
+    },
+    "side_effects": {
+      "type": "array",
+      "description": "Declares what changes outside the conversation (files written, issues created, processes spawned) so a dry-run skill can predict impact",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Named side effect with no extra detail (e.g. 'creates_github_issue')"
+          },
+          {
+            "type": "object",
+            "description": "Named side effect with an associated path or value (e.g. {writes_log: 'logs/foo/status.json'})",
+            "minProperties": 1,
+            "maxProperties": 1,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "composes": {
+      "type": "array",
+      "description": "Names sub-skills invoked via the Skill tool; enables a graph of skill dependencies",
+      "items": {
+        "type": "string",
+        "description": "Skill name as it appears in the skills directory (e.g. 'mcp-tools', 'explore')"
+      }
+    },
+    "failure_modes": {
+      "type": "array",
+      "description": "Known ways this skill can fail and what callers should do; enables a pipeline-recovery skill to take action",
+      "items": {
+        "type": "object",
+        "required": ["id", "mitigation"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Short snake_case identifier for the failure mode (e.g. 'gh_api_unauthorized')"
+          },
+          "mitigation": {
+            "type": "string",
+            "description": "What the skill or its caller should do when this failure occurs"
+          }
+        }
+      }
+    },
+    "golden": {
+      "type": "object",
+      "description": "Golden test configuration for decision skills — declares the model, manifest path, fixture directory, and output schema used by skill-golden.sh",
+      "required": ["model", "manifest", "fixture_dir"],
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "Model tier to use for golden test runs (e.g. haiku, sonnet)"
+        },
+        "manifest": {
+          "type": "string",
+          "description": "Path to the golden manifest file (relative to repo root) listing fixture|expected_route|expected_criterion entries"
+        },
+        "fixture_dir": {
+          "type": "string",
+          "description": "Path to the directory containing fixture files (relative to repo root)"
+        },
+        "schema": {
+          "type": "string",
+          "description": "Path to the JSON schema file used to validate Claude's structured output (relative to repo root). Falls back to .claude/scripts/schemas/<skill-name>.json when omitted."
+        }
+      }
+    }
+  }
+}

--- a/plugins/pipeline-core/scripts/schemas/skill-golden-manifest.json
+++ b/plugins/pipeline-core/scripts/schemas/skill-golden-manifest.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Golden test manifest for a decision skill. Each entry pins one fixture to its expected output so prompt regressions surface before merge. Mirrors the 'fixture|expected_route|expected_criterion' pipe-delimited convention from triage-validate.sh but expressed as structured JSON.",
+  "type": "array",
+  "minItems": 0,
+  "items": {
+    "type": "object",
+    "description": "One golden test case: a fixture file mapped to the output the model must produce.",
+    "required": ["fixture", "expected_route"],
+    "additionalProperties": false,
+    "properties": {
+      "fixture": {
+        "type": "string",
+        "description": "Fixture file basename without extension, relative to the skill's fixture directory (e.g. 'issue-2836')"
+      },
+      "expected_route": {
+        "type": "string",
+        "description": "The categorical routing decision the model must return for this fixture (e.g. 'fast-path', 'full', 'escalate', 'retry')"
+      },
+      "expected_criterion": {
+        "type": "string",
+        "description": "Expected disqualifying criterion name. Use '*' when the route alone is the contract and any criterion reason is acceptable. Mutually exclusive with any_of."
+      },
+      "any_of": {
+        "type": "array",
+        "description": "Two or more acceptable criterion values for multi-correct cases — the test passes if the model returns any one of them. Mutually exclusive with expected_criterion.",
+        "minItems": 2,
+        "items": {
+          "type": "string",
+          "description": "An acceptable criterion name"
+        }
+      }
+    }
+  }
+}

--- a/plugins/pipeline-core/scripts/schemas/stage-result.json
+++ b/plugins/pipeline-core/scripts/schemas/stage-result.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Envelope returned by run_stage for every stage invocation",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["success", "error", "rate_limit"],
+      "description": "High-level outcome of the stage run"
+    },
+    "output": {
+      "description": "Parsed structured output from the Claude CLI response; null on error",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "raw": {
+      "type": "string",
+      "description": "Raw stdout from the Claude CLI call before structured output extraction"
+    },
+    "denials": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Tool names blocked by permission hooks during this stage run"
+    },
+    "model": {
+      "type": "string",
+      "description": "Model ID that produced the final output, e.g. haiku, sonnet, opus"
+    },
+    "error_kind": {
+      "type": ["string", "null"],
+      "enum": [
+        "timeout",
+        "double_timeout",
+        "schema_not_found",
+        "no_structured_output",
+        "max_turns_exhausted_at_ceiling",
+        "rate_limit",
+        "permission_denied",
+        "quality_stall",
+        "max_turns_exhausted",
+        "structured_error",
+        null
+      ],
+      "description": "Machine-readable error classification; null when status is success"
+    },
+    "elapsed_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Wall-clock milliseconds from stage invocation to return"
+    },
+    "tokens": {
+      "type": "object",
+      "description": "Per-stage token counts lifted from the CLI response usage block (issue #580). All fields default to 0 when the CLI omits usage.",
+      "properties": {
+        "input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Uncached input tokens billed for this stage"
+        },
+        "output_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Output tokens generated for this stage"
+        },
+        "cache_creation_input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Input tokens written to the prompt cache (billed at the cache-write rate)"
+        },
+        "cache_read_input_tokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Input tokens served from the prompt cache (billed at the cache-read rate)"
+        }
+      }
+    },
+    "cost": {
+      "type": "object",
+      "description": "Per-stage USD cost breakdown (issue #580). estimated_usd is the figure persisted as .stages[<stage>].estimated_cost.",
+      "properties": {
+        "reported_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "The CLI's own total_cost_usd for the stage, when present"
+        },
+        "computed_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Cost priced from the token counts via _model_cost (model-config.sh)"
+        },
+        "estimated_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Preferred cost: reported_usd when > 0, else computed_usd"
+        }
+      }
+    }
+  },
+  "required": ["status"]
+}

--- a/plugins/pipeline-core/scripts/skill-golden-lib.sh
+++ b/plugins/pipeline-core/scripts/skill-golden-lib.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+#
+# skill-golden-lib.sh
+#
+# Reusable functions for skill-golden tests — real-Claude prompt regression
+# harness for decision skills. Extracted from triage-validate.sh so the same
+# pattern can pin down every decision skill (triage-classify, escalation-
+# policy, retry-policy, model-fallback, pipeline-recovery), not just triage.
+#
+# This file is a LIBRARY — source it from a thin driver script:
+#
+#     #!/usr/bin/env bash
+#     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#     source "$SCRIPT_DIR/skill-golden-lib.sh"
+#
+#     build_prompt() {
+#         local issue_body="$1"
+#         cat <<EOF
+#     ... your skill's prompt referencing $issue_body ...
+#     EOF
+#     }
+#
+#     MANIFEST=(
+#         "fixture-a|fast-path|*"
+#         "fixture-b|full|some_criterion"
+#     )
+#
+#     sg_check_setup "$FIXTURE_DIR" "$SCHEMA_FILE" || exit 2
+#     sg_run_manifest "$FIXTURE_DIR" "$SCHEMA_FILE" "$MODEL" \
+#         build_prompt "${1:-}" "${MANIFEST[@]}"
+#     exit $?
+#
+# CONTRACT (manifest format):
+#   "fixture_basename|expected_route|expected_criterion_or_*"
+#     - fixture_basename — file under FIXTURE_DIR named "<basename>.md"
+#     - expected_route   — primary decision the skill returns under .route
+#     - expected_criterion_or_* — pinpoint criterion under
+#       .disqualifying_criterion (or "*" to accept any). Only checked when
+#       the route mismatch would otherwise be the only flip surface; a wrong
+#       criterion is a WARN, not a FAIL — the route is the contract.
+#
+# OUTPUT EXTRACTION:
+#   Mirrors run_stage() in implement-issue-orchestrator.sh: prefer
+#   .structured_output, fall back to .result (parsed if stringified JSON),
+#   then to the top-level object. If these diverge from the orchestrator,
+#   the validator stops reflecting prod — keep them in sync.
+#
+# CUSTOMIZATION (env vars, all optional):
+#   SG_CLAUDE_CLI         path to claude CLI (default "claude")
+#   SG_MAX_ATTEMPTS       Claude invocation retries on transient errors (3)
+#   SG_RETRY_BASE_SLEEP   seconds between retries, multiplied by attempt (5)
+#   SG_ROUTE_FIELD        JSON field for primary decision (default "route")
+#   SG_CRITERION_FIELD    JSON field for criterion (default
+#                         "disqualifying_criterion")
+#   SG_CONFIDENCE_FIELD   JSON field for confidence (default "confidence")
+#   SG_SUMMARY_FIELD      JSON field for summary (default "summary")
+#
+
+# Guard against double-sourcing — multiple drivers may pull this in via the
+# same parent process (skill-golden.sh --all dispatches per-skill).
+if [[ -n "${_SKILL_GOLDEN_LIB_SOURCED:-}" ]]; then
+	return 0 2>/dev/null || true
+fi
+_SKILL_GOLDEN_LIB_SOURCED=1
+
+# Defaults — set only if unset so drivers can pre-configure.
+: "${SG_CLAUDE_CLI:=claude}"
+: "${SG_MAX_ATTEMPTS:=3}"
+: "${SG_RETRY_BASE_SLEEP:=5}"
+: "${SG_ROUTE_FIELD:=route}"
+: "${SG_CRITERION_FIELD:=disqualifying_criterion}"
+: "${SG_CONFIDENCE_FIELD:=confidence}"
+: "${SG_SUMMARY_FIELD:=summary}"
+
+# =============================================================================
+# Color helpers — write ANSI escapes to stdout. Callers wrap with printf.
+# =============================================================================
+
+sg_red()    { printf '\033[31m%s\033[0m' "$1"; }
+sg_green()  { printf '\033[32m%s\033[0m' "$1"; }
+sg_yellow() { printf '\033[33m%s\033[0m' "$1"; }
+sg_dim()    { printf '\033[2m%s\033[0m' "$1"; }
+
+# =============================================================================
+# Setup checks — verify external commands and required paths exist.
+# All errors go to stderr; functions return non-zero on failure.
+# =============================================================================
+
+sg_require_cmd() {
+	local cmd="$1"
+	if ! command -v "$cmd" >/dev/null 2>&1; then
+		printf 'skill-golden: required command not found: %s\n' \
+			"$cmd" >&2
+		return 2
+	fi
+	return 0
+}
+
+# sg_check_setup FIXTURE_DIR SCHEMA_FILE
+# Verifies jq, the configured claude CLI, the schema file, and the fixture
+# directory all exist. Returns 0 on success, 2 on any failure.
+sg_check_setup() {
+	local fixture_dir="$1"
+	local schema_file="$2"
+	local rc=0
+
+	sg_require_cmd jq || rc=2
+	sg_require_cmd "$SG_CLAUDE_CLI" || rc=2
+
+	if [[ ! -f "$schema_file" ]]; then
+		printf 'skill-golden: schema not found: %s\n' \
+			"$schema_file" >&2
+		rc=2
+	fi
+
+	if [[ ! -d "$fixture_dir" ]]; then
+		printf 'skill-golden: fixture dir not found: %s\n' \
+			"$fixture_dir" >&2
+		rc=2
+	fi
+
+	return "$rc"
+}
+
+# =============================================================================
+# Manifest parser — splits "fixture|expected_route|expected_criterion" into
+# three newline-separated fields on stdout. Drivers usually parse inline with
+# `IFS='|' read -r f r c <<<"$entry"`; this function exists for tests and
+# for any caller that wants a single source of truth for the format.
+# =============================================================================
+
+sg_parse_manifest_entry() {
+	local entry="$1"
+	local fixture expected_route expected_criterion
+	IFS='|' read -r fixture expected_route expected_criterion <<<"$entry"
+	printf '%s\n%s\n%s\n' \
+		"$fixture" "$expected_route" "$expected_criterion"
+}
+
+# =============================================================================
+# Claude invocation with retry — calls the claude CLI with the prompt and
+# schema, retrying on transient errors (rate limit, overload, timeout) with
+# linear backoff. Output (stdout from claude on success, stderr from claude
+# on failure) is written to this function's stdout. Logs go to stderr.
+#
+# sg_invoke_claude PROMPT MODEL SCHEMA_FILE
+#   PROMPT      — full prompt string passed via -p
+#   MODEL       — model alias (haiku, sonnet, etc)
+#   SCHEMA_FILE — path to the JSON schema for --json-schema
+#
+# Returns:
+#   0 — claude succeeded; payload on stdout
+#   1 — claude failed after all retries; last output on stdout for diagnostics
+#   2 — schema file unreadable
+# =============================================================================
+
+sg_invoke_claude() {
+	local prompt="$1"
+	local model="$2"
+	local schema_file="$3"
+	local schema_compact output rc=0
+	local attempt=1 backoff
+
+	if ! schema_compact=$(jq -c . "$schema_file" 2>&1); then
+		printf 'skill-golden: failed to compact schema %s: %s\n' \
+			"$schema_file" "$schema_compact" >&2
+		return 2
+	fi
+
+	while ((attempt <= SG_MAX_ATTEMPTS)); do
+		# NB: capture rc separately, not via `rc=$?` after `if...fi`.
+		# Bash sets $? to 0 after a failed `if` with no `else` branch,
+		# so the post-fi capture would always read 0 and silently
+		# convert non-retryable failures into "success" returns.
+		output=$(env -u CLAUDECODE "$SG_CLAUDE_CLI" -p "$prompt" \
+			--model "$model" \
+			--dangerously-skip-permissions \
+			--output-format json \
+			--json-schema "$schema_compact" 2>&1)
+		rc=$?
+		if ((rc == 0)); then
+			printf '%s' "$output"
+			return 0
+		fi
+
+		# Retry on transient signals only. Anything else is a real
+		# error (auth, schema mismatch, missing flag) — surface it.
+		if sg_is_retryable "$output"; then
+			backoff=$((attempt * SG_RETRY_BASE_SLEEP))
+			printf 'skill-golden: transient error (attempt %d/%d), sleeping %ds\n' \
+				"$attempt" "$SG_MAX_ATTEMPTS" \
+				"$backoff" >&2
+			sleep "$backoff"
+			attempt=$((attempt + 1))
+			continue
+		fi
+
+		printf '%s' "$output"
+		return "$rc"
+	done
+
+	printf '%s' "$output"
+	return 1
+}
+
+# Pure check — does this output look like a transient/retryable error?
+# Kept small and case-insensitive; expand only when a new transient
+# signature is observed in the wild. Uses tr (not bash 4 ${var,,}) so the
+# library stays compatible with macOS-system bash 3.2.
+sg_is_retryable() {
+	local output="$1"
+	local lower
+	lower=$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')
+	case "$lower" in
+		*"rate limit"*|*"429"*|*"overloaded"* \
+			|*"overload_error"*|*"timeout"*|*"timed out"* \
+			|*"503 service unavailable"*|*"econnreset"*)
+			return 0
+			;;
+	esac
+	return 1
+}
+
+# =============================================================================
+# JSON output validation — extract the schema-validated payload from the
+# claude CLI's wrapped JSON response. Mirrors run_stage() in
+# implement-issue-orchestrator.sh; if these diverge, the validator stops
+# reflecting prod.
+#
+# sg_extract_payload OUTPUT
+#   Echoes the inner JSON object on stdout. Echoes "{}" (and writes a note to
+#   stderr) when the payload cannot be located or is not valid JSON. Always
+#   returns 0 — callers detect missing fields by inspecting the payload.
+# =============================================================================
+
+sg_extract_payload() {
+	local output="$1"
+	local payload
+
+	payload=$(printf '%s' "$output" | jq -c '
+		.structured_output
+		// (.result | if type == "string" then fromjson? else . end)
+		// .
+	' 2>/dev/null || echo '{}')
+
+	if ! printf '%s' "$payload" | jq -e . >/dev/null 2>&1; then
+		printf 'skill-golden: payload not valid JSON, treating as {}\n' >&2
+		payload='{}'
+	fi
+
+	printf '%s' "$payload"
+}
+
+# sg_get_field PAYLOAD FIELD [DEFAULT]
+#   Returns the string value of .FIELD on the payload, or DEFAULT if the
+#   field is absent. Default is "MISSING" only when the third arg is unset;
+#   passing an empty string explicitly (sg_get_field x y "") is honored —
+#   needed for optional fields like .summary where "" is a valid result.
+#   Stderr-silent. Uses --arg to avoid jq filter injection from field names.
+sg_get_field() {
+	local payload="$1"
+	local field="$2"
+	local default="${3-MISSING}"
+	local value
+	if ! value=$(printf '%s' "$payload" \
+		| jq -r --arg f "$field" --arg d "$default" \
+			'(.[$f] // $d) | tostring' \
+		2>/dev/null); then
+		value="$default"
+	fi
+	printf '%s' "$value"
+}
+
+# =============================================================================
+# Fixture runner — executes one manifest entry end-to-end: load fixture,
+# build prompt, call claude, extract payload, compare against expected.
+#
+# sg_run_fixture ENTRY FIXTURE_DIR SCHEMA_FILE MODEL PROMPT_BUILDER_FN
+#   ENTRY              — manifest line "fixture|route|criterion"
+#   FIXTURE_DIR        — directory containing "<fixture>.md"
+#   SCHEMA_FILE        — JSON schema for the skill's output
+#   MODEL              — model alias to invoke
+#   PROMPT_BUILDER_FN  — name of a shell function defined by the driver
+#                        that takes the fixture body on $1 and prints the
+#                        full prompt on stdout
+#
+# Prints one line per fixture (PASS / FAIL / WARN) to stdout. Returns:
+#   0 — PASS or WARN (route matched; criterion may have flipped)
+#   1 — FAIL (route mismatched or fixture/CLI failure)
+# =============================================================================
+
+sg_run_fixture() {
+	local entry="$1"
+	local fixture_dir="$2"
+	local schema_file="$3"
+	local model="$4"
+	local prompt_builder="$5"
+
+	local fixture expected_route expected_criterion
+	IFS='|' read -r fixture expected_route expected_criterion <<<"$entry"
+
+	# Try .md first (issue-body fixtures), then .json (structured-event
+	# fixtures such as escalation-policy stage results).
+	local body_file="$fixture_dir/${fixture}.md"
+	if [[ ! -f "$body_file" ]]; then
+		body_file="$fixture_dir/${fixture}.json"
+	fi
+	if [[ ! -f "$body_file" ]]; then
+		printf '  %s missing fixture: %s.{md,json}\n' \
+			"$(sg_red "FAIL")" "$fixture_dir/$fixture"
+		return 1
+	fi
+
+	if ! declare -F "$prompt_builder" >/dev/null 2>&1; then
+		printf '  %s %-28s prompt builder not defined: %s\n' \
+			"$(sg_red "FAIL")" "$fixture" "$prompt_builder"
+		return 1
+	fi
+
+	local body prompt output start end elapsed_ms timing_label
+	body=$(cat "$body_file")
+	prompt=$("$prompt_builder" "$body")
+
+	start=$(date +%s%N 2>/dev/null || echo 0)
+	if ! output=$(sg_invoke_claude "$prompt" "$model" "$schema_file"); then
+		printf '  %s %-28s claude invocation failed\n' \
+			"$(sg_red "FAIL")" "$fixture"
+		printf '%s\n' "$output" | head -5 | sed 's/^/      /'
+		return 1
+	fi
+	end=$(date +%s%N 2>/dev/null || echo 0)
+	elapsed_ms=$(( (end - start) / 1000000 ))
+	timing_label=$(printf '%6dms' "$elapsed_ms")
+
+	local payload route confidence criterion summary
+	payload=$(sg_extract_payload "$output")
+	route=$(sg_get_field "$payload" "$SG_ROUTE_FIELD" "MISSING")
+	confidence=$(sg_get_field "$payload" "$SG_CONFIDENCE_FIELD" "MISSING")
+	criterion=$(sg_get_field "$payload" "$SG_CRITERION_FIELD" "")
+	summary=$(sg_get_field "$payload" "$SG_SUMMARY_FIELD" "")
+
+	if [[ "$route" != "$expected_route" ]]; then
+		printf '  %s %-28s %s  expected=%s got=%s confidence=%s\n' \
+			"$(sg_red "FAIL")" "$fixture" "$timing_label" \
+			"$expected_route" "$route" "$confidence"
+		[[ -n "$summary" ]] && printf '      %s\n' \
+			"$(sg_dim "summary: $summary")"
+		return 1
+	fi
+
+	# Criterion check is secondary — the route is the contract. Mismatch
+	# is a WARN so operators see drift without flipping CI red.
+	if [[ -n "$expected_criterion" \
+		&& "$expected_criterion" != "*" \
+		&& "$criterion" != "$expected_criterion" ]]; then
+		printf '  %s %-28s %s  route=%s ok, but %s=%s expected=%s\n' \
+			"$(sg_yellow "WARN")" "$fixture" "$timing_label" \
+			"$route" "$SG_CRITERION_FIELD" \
+			"${criterion:-<empty>}" "$expected_criterion"
+		[[ -n "$summary" ]] && printf '      %s\n' \
+			"$(sg_dim "summary: $summary")"
+		return 0
+	fi
+
+	printf '  %s %-28s %s  %s=%s confidence=%s\n' \
+		"$(sg_green "PASS")" "$fixture" "$timing_label" \
+		"$SG_ROUTE_FIELD" "$route" "$confidence"
+	return 0
+}
+
+# =============================================================================
+# Manifest iteration — runs every entry, applies an optional fixture filter,
+# emits per-fixture lines, and prints a summary. Returns:
+#   0 — all matched fixtures passed (or warned)
+#   1 — at least one fixture flipped
+#   2 — filter matched no fixtures
+#
+# sg_run_manifest FIXTURE_DIR SCHEMA_FILE MODEL PROMPT_BUILDER FILTER ENTRIES...
+#   FILTER may be empty (run all). Otherwise only entries whose fixture
+#   basename equals FILTER run.
+# =============================================================================
+
+sg_run_manifest() {
+	local fixture_dir="$1"; shift
+	local schema_file="$1"; shift
+	local model="$1"; shift
+	local prompt_builder="$1"; shift
+	local filter="$1"; shift
+	# Remaining "$@" are manifest entries.
+
+	local total=0 passed=0 failed=0
+	local entry fixture run_start run_end elapsed
+
+	run_start=$(date +%s)
+
+	printf 'skill-golden: %d fixtures, model=%s\n' "$#" "$model"
+	printf '\n'
+
+	for entry in "$@"; do
+		fixture="${entry%%|*}"
+		if [[ -n "$filter" && "$fixture" != "$filter" ]]; then
+			continue
+		fi
+		total=$((total + 1))
+		if sg_run_fixture "$entry" "$fixture_dir" "$schema_file" \
+			"$model" "$prompt_builder"; then
+			passed=$((passed + 1))
+		else
+			failed=$((failed + 1))
+		fi
+	done
+
+	run_end=$(date +%s)
+	elapsed=$((run_end - run_start))
+
+	sg_print_summary "$total" "$passed" "$failed" "$elapsed" "$filter"
+}
+
+# =============================================================================
+# Reporter — prints summary line and final PASS/FAIL marker. Returns:
+#   0 — all passed
+#   1 — at least one failure
+#   2 — total == 0 (no fixtures matched)
+# =============================================================================
+
+sg_print_summary() {
+	local total="$1"
+	local passed="$2"
+	local failed="$3"
+	local elapsed="$4"
+	local filter="${5:-}"
+
+	printf '\n'
+	printf 'skill-golden: %d/%d passed in %ds\n' \
+		"$passed" "$total" "$elapsed"
+
+	if ((total == 0)); then
+		printf 'skill-golden: no fixtures matched filter: %s\n' \
+			"$filter" >&2
+		return 2
+	fi
+
+	if ((failed > 0)); then
+		printf '%s\n' "$(sg_red "FAIL")"
+		return 1
+	fi
+
+	printf '%s\n' "$(sg_green "PASS")"
+	return 0
+}
+
+# =============================================================================
+# BODY-GENERATOR GOLDEN TESTS — validate deterministic body-generator output
+# (e.g. create-followup-issue.sh) against the structural criteria from
+# issue-body-lib.sh.  Does NOT invoke Claude.
+#
+# Pre-conditions for callers:
+#   1. source issue-body-lib.sh before calling sg_validate_body.
+#   2. Export ISSUE_BODY_AGENTS_DIR, ISSUE_BODY_REPO_ROOT, and optionally
+#      DEPLOY_VERIFY_CMD to configure the validation sandbox.
+# =============================================================================
+
+# sg_validate_body BODY [LABEL]
+#   Calls assert_issue_valid on BODY and prints one PASS/FAIL line.
+#   Errors from assert_issue_valid are captured from stderr and indented
+#   under the FAIL line so the caller's stdout is clean to parse.
+#   Returns 0 when BODY passes all criteria, 1 otherwise.
+sg_validate_body() {
+	local body="$1"
+	local label="${2:-body}"
+	local errors rc=0
+
+	errors=$(assert_issue_valid "$body" 2>&1) || rc=1
+
+	if ((rc == 0)); then
+		printf '  %s %s\n' "$(sg_green "PASS")" "$label"
+	else
+		printf '  %s %s\n' "$(sg_red "FAIL")" "$label"
+		printf '%s\n' "$errors" | sed 's/^/      /'
+	fi
+
+	return "$rc"
+}

--- a/plugins/pipeline-core/scripts/skill-golden.sh
+++ b/plugins/pipeline-core/scripts/skill-golden.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+#
+# skill-golden.sh — generalized golden test runner for decision skills
+#
+# Usage:
+#   skill-golden.sh <skill-name>            run all fixtures for one skill
+#   skill-golden.sh <skill-name> <fixture>  run single fixture by basename
+#   skill-golden.sh --all                   run every skill with a manifest
+#
+# Golden test config is read from <SKILLS_DIR>/<skill>/SKILL.md frontmatter,
+# where SKILLS_DIR defaults to plugins/pipeline-core/skills (falling back to
+# the legacy .claude/skills layout):
+#
+#   golden:
+#     model:       haiku
+#     manifest:    plugins/pipeline-core/skills/<skill>/golden.manifest.txt
+#     fixture_dir: .claude/scripts/implement-issue-test/fixtures/<skill>
+#     schema:      .claude/scripts/schemas/<skill>.json
+#
+# Paths in SKILL.md frontmatter are relative to the repository root.
+#
+# Prompt building: <SKILLS_DIR>/<skill>/prompt-builder.sh is sourced when
+# present; it must define a build_prompt() shell function that accepts the
+# fixture body on $1 and prints the full Claude prompt on stdout.  Skills
+# without a prompt-builder.sh are skipped with a warning so a partially-wired
+# suite does not block CI.
+#
+# Discovery (--all): scans <SKILLS_DIR>/*/golden.manifest.txt.  Skills that
+# have a manifest but are missing other required config (schema, prompt builder)
+# are skipped with a warning; only fixture-level failures propagate to exit 1.
+#
+# Environment:
+#   SKILLS_DIR     root of skill directories
+#                  (default: $SCRIPT_DIR/../skills relative to this script)
+#   SG_CLAUDE_CLI  path to claude CLI (default: claude)
+#
+# Exit codes:
+#   0 — all tested fixtures passed (skipped skills do not count as failures)
+#   1 — at least one fixture failed
+#   2 — setup / usage error
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)" || exit 2
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)" || exit 2
+readonly SCRIPT_DIR REPO_ROOT
+
+# Prefer the post-git-mv plugin layout (plugins/pipeline-core/skills/) and
+# fall back to the legacy .claude/skills/ layout so this works on both sides
+# of the restructure.
+if [[ -z "${SKILLS_DIR:-}" ]]; then
+	if [[ -d "$REPO_ROOT/plugins/pipeline-core/skills" ]]; then
+		SKILLS_DIR="$REPO_ROOT/plugins/pipeline-core/skills"
+	else
+		SKILLS_DIR="$SCRIPT_DIR/../skills"
+	fi
+fi
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/skill-golden-lib.sh" || {
+	printf '%s: cannot source skill-golden-lib.sh\n' "$SCRIPT_NAME" >&2
+	exit 2
+}
+
+# ---------------------------------------------------------------------------
+# die — print error to stderr and exit 2
+# ---------------------------------------------------------------------------
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 2
+}
+
+# ---------------------------------------------------------------------------
+# usage
+# ---------------------------------------------------------------------------
+usage() {
+	cat <<EOF
+Usage: $SCRIPT_NAME <skill-name> [fixture]
+       $SCRIPT_NAME --all
+
+Run real-Claude golden tests for decision skills.
+
+Arguments:
+    <skill-name>    Skill directory name under .claude/skills/
+    <fixture>       Optional: run only this fixture basename (no extension)
+    --all           Discover and run all skills with golden.manifest.txt
+
+Environment:
+    SKILLS_DIR      Root of skill directories
+                    (default: \$SCRIPT_DIR/../skills)
+    SG_CLAUDE_CLI   Path to claude CLI (default: claude)
+
+Exit codes:
+    0   all tested fixtures passed; skipped skills do not count as failures
+    1   at least one fixture failed
+    2   setup error (missing skill, manifest, schema, or usage error)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# read_golden_field SKILL_FILE FIELD
+#
+# Extracts one field from the golden: block of a SKILL.md YAML frontmatter.
+# Prints the value on stdout. Exits (Ruby) 1 if the field is absent or the
+# file / frontmatter cannot be parsed — bash callers treat a non-zero exit
+# as "field not present" and keep the default.
+# ---------------------------------------------------------------------------
+read_golden_field() {
+	local skill_file="$1"
+	local field="$2"
+
+	ruby - "$skill_file" "$field" 2>/dev/null <<'RUBYEOF'
+require 'yaml'
+content = File.read(ARGV[0]) rescue exit(1)
+m = content.match(/\A---[ \t]*\r?\n(.*?)^---[ \t]*\r?$/m)
+exit(1) unless m
+begin
+  data = Psych.safe_load(m[1])
+rescue
+  exit(1)
+end
+exit(1) unless data.is_a?(Hash)
+golden = data['golden']
+exit(1) unless golden.is_a?(Hash)
+val = golden[ARGV[1]]
+exit(1) if val.nil?
+print val.to_s
+RUBYEOF
+}
+
+# ---------------------------------------------------------------------------
+# resolve_path RAW
+#
+# Turns a repo-root-relative path from SKILL.md frontmatter into an absolute
+# path.  Absolute paths are returned unchanged.
+# ---------------------------------------------------------------------------
+resolve_path() {
+	local raw="$1"
+	case "$raw" in
+		/*) printf '%s' "$raw" ;;
+		*)  printf '%s/%s' "$REPO_ROOT" "$raw" ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# parse_manifest MANIFEST_FILE
+#
+# Reads manifest entries from MANIFEST_FILE, skipping blank lines and lines
+# whose first non-whitespace character is '#'.  Prints one entry per line.
+# ---------------------------------------------------------------------------
+parse_manifest() {
+	local file="$1"
+	local line
+	while IFS= read -r line; do
+		[[ "$line" =~ ^[[:space:]]*$ ]]  && continue
+		[[ "$line" =~ ^[[:space:]]*'#' ]] && continue
+		printf '%s\n' "$line"
+	done < "$file"
+}
+
+# ---------------------------------------------------------------------------
+# run_skill SKILL_NAME [FILTER]
+#
+# Resolves the golden test config for SKILL_NAME, sources its prompt builder,
+# and dispatches to sg_run_manifest from skill-golden-lib.sh.
+#
+# Returns:
+#   0 — all fixtures passed (or skill skipped with a warning)
+#   1 — at least one fixture failed
+#   2 — configuration / setup error
+# ---------------------------------------------------------------------------
+run_skill() {
+	local skill_name="$1"
+	local filter="${2:-}"
+
+	local manifest_file="$SKILLS_DIR/$skill_name/golden.manifest.txt"
+	if [[ ! -f "$manifest_file" ]]; then
+		printf '%s: no golden.manifest.txt for skill: %s\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		return 2
+	fi
+
+	# ------------------------------------------------------------------
+	# Resolve config from SKILL.md frontmatter where present; fall back
+	# to conventions for any field that is not specified.
+	# ------------------------------------------------------------------
+	local model fixture_dir schema
+	model="haiku"
+	fixture_dir="$SCRIPT_DIR/implement-issue-test/fixtures/$skill_name"
+	schema=""
+
+	local skill_md="$SKILLS_DIR/$skill_name/SKILL.md"
+	if [[ -f "$skill_md" ]]; then
+		local fm_model fm_fixture_dir fm_schema
+		fm_model=$(read_golden_field "$skill_md" "model")       || fm_model=""
+		fm_fixture_dir=$(read_golden_field "$skill_md" "fixture_dir") \
+			|| fm_fixture_dir=""
+		fm_schema=$(read_golden_field "$skill_md" "schema")     || fm_schema=""
+
+		[[ -n "$fm_model" ]]       && model="$fm_model"
+		[[ -n "$fm_fixture_dir" ]] && fixture_dir="$(resolve_path "$fm_fixture_dir")"
+		[[ -n "$fm_schema" ]]      && schema="$(resolve_path "$fm_schema")"
+	fi
+
+	# Convention fallback: schemas/<skill-name>.json
+	if [[ -z "$schema" ]]; then
+		local candidate="$SCRIPT_DIR/schemas/$skill_name.json"
+		[[ -f "$candidate" ]] && schema="$candidate"
+	fi
+
+	if [[ -z "$schema" ]]; then
+		printf '%s: no schema found for skill: %s\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		printf '%s: add golden.schema to %s/SKILL.md or create %s\n' \
+			"$SCRIPT_NAME" "$skill_name" \
+			"$SCRIPT_DIR/schemas/$skill_name.json" >&2
+		return 2
+	fi
+
+	# ------------------------------------------------------------------
+	# Source the skill's prompt builder.  Without it we cannot invoke
+	# Claude.  Return 2 (setup error) so direct invocations get a
+	# non-zero exit and --all mode counts the skill as skipped (not
+	# failed), keeping partial-wired suites from blocking CI.
+	# ------------------------------------------------------------------
+	local prompt_builder_file="$SKILLS_DIR/$skill_name/prompt-builder.sh"
+	if [[ ! -f "$prompt_builder_file" ]]; then
+		printf '%s: [SKIP] %s — no prompt-builder.sh\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		return 2
+	fi
+
+	# Clear any previous build_prompt from a prior skill in --all mode.
+	unset -f build_prompt 2>/dev/null || true
+
+	# shellcheck source=/dev/null
+	source "$prompt_builder_file" || {
+		printf '%s: failed to source prompt-builder.sh for: %s\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		return 2
+	}
+
+	if ! declare -F build_prompt >/dev/null 2>&1; then
+		printf '%s: prompt-builder.sh for %s must define build_prompt()\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		return 2
+	fi
+
+	# ------------------------------------------------------------------
+	# Parse manifest entries.
+	# ------------------------------------------------------------------
+	local -a entries
+	while IFS= read -r entry; do
+		entries+=("$entry")
+	done < <(parse_manifest "$manifest_file")
+
+	if ((${#entries[@]} == 0)); then
+		printf '%s: manifest has no entries for skill: %s\n' \
+			"$SCRIPT_NAME" "$skill_name" >&2
+		return 2
+	fi
+
+	# ------------------------------------------------------------------
+	# Setup check (jq, claude CLI, schema path, fixture dir) then run.
+	# ------------------------------------------------------------------
+	sg_check_setup "$fixture_dir" "$schema" || return 2
+
+	sg_run_manifest \
+		"$fixture_dir" "$schema" "$model" \
+		build_prompt "$filter" \
+		"${entries[@]}"
+}
+
+# ---------------------------------------------------------------------------
+# run_all
+#
+# Discovers every skill that has a golden.manifest.txt file and runs each.
+# Skills that are not fully configured (missing prompt-builder.sh, missing
+# schema) are skipped with a warning and do not affect the overall exit code.
+# ---------------------------------------------------------------------------
+run_all() {
+	local -a skills
+	local manifest
+
+	for manifest in "$SKILLS_DIR"/*/golden.manifest.txt; do
+		[[ -f "$manifest" ]] || continue
+		skills+=("$(basename "$(dirname "$manifest")")")
+	done
+
+	if ((${#skills[@]} == 0)); then
+		printf '%s: no skills with golden.manifest.txt found in: %s\n' \
+			"$SCRIPT_NAME" "$SKILLS_DIR" >&2
+		return 2
+	fi
+
+	printf 'skill-golden: discovered %d skill(s): %s\n' \
+		"${#skills[@]}" "${skills[*]}"
+	printf '\n'
+
+	local overall=0 total=0 failed=0 skipped=0
+	local skill rc
+	for skill in "${skills[@]}"; do
+		printf '==> %s\n' "$skill"
+		total=$((total + 1))
+
+		run_skill "$skill"
+		rc=$?
+
+		if ((rc == 1)); then
+			failed=$((failed + 1))
+			overall=1
+		elif ((rc == 2)); then
+			skipped=$((skipped + 1))
+		fi
+
+		printf '\n'
+	done
+
+	printf 'skill-golden: %d skill(s) — %d failed, %d skipped\n' \
+		"$total" "$failed" "$skipped"
+
+	return "$overall"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	local mode=""
+	local skill_name=""
+	local filter=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--all)
+				mode="all"
+				shift
+				;;
+			-h|--help)
+				usage
+				exit 0
+				;;
+			--)
+				shift
+				break
+				;;
+			-*)
+				die "unknown option: $1"
+				;;
+			*)
+				if [[ -z "$skill_name" ]]; then
+					skill_name="$1"
+					mode="skill"
+				elif [[ -z "$filter" ]]; then
+					filter="$1"
+				else
+					die "unexpected argument: $1"
+				fi
+				shift
+				;;
+		esac
+	done
+
+	[[ -n "$mode" ]] || die "specify <skill-name> or --all"
+
+	case "$mode" in
+		skill) run_skill "$skill_name" "$filter" ;;
+		all)   run_all ;;
+	esac
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/skill-validate.sh
+++ b/plugins/pipeline-core/scripts/skill-validate.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+#
+# skill-validate.sh — validate SKILL.md YAML frontmatter against schema
+#
+# Usage:
+#   skill-validate.sh --skill <name>   validate one skill by directory name
+#   skill-validate.sh --all            validate every skill in SKILLS_DIR
+#
+# Environment (both are overridable for testing):
+#   SKILLS_DIR   — root of skill directories
+#                  (default: ../skills relative to this script)
+#   SKILL_SCHEMA — path to the JSON schema file
+#                  (default: schemas/skill-frontmatter.json relative to
+#                  this script)
+#
+# Exit codes:
+#   0 — all validated skills passed
+#   1 — one or more skills failed validation
+#
+
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+SKILLS_DIR="${SKILLS_DIR:-"$SCRIPT_DIR/../skills"}"
+SKILL_SCHEMA="${SKILL_SCHEMA:-"$SCRIPT_DIR/schemas/skill-frontmatter.json"}"
+
+# ---------------------------------------------------------------------------
+# die  — print error and exit 1
+# ---------------------------------------------------------------------------
+die() {
+	printf '%s: error: %s\n' "$SCRIPT_NAME" "$*" >&2
+	exit 1
+}
+
+# ---------------------------------------------------------------------------
+# usage
+# ---------------------------------------------------------------------------
+usage() {
+	cat <<EOF
+Usage: $SCRIPT_NAME --skill <name>
+       $SCRIPT_NAME --all
+       $SCRIPT_NAME <skill-file>
+
+Validate SKILL.md YAML frontmatter against the JSON schema.
+
+Options:
+    --skill <name>   Validate one skill directory in SKILLS_DIR
+    --all            Validate all skill directories in SKILLS_DIR
+    -h, --help       Show this message
+
+Arguments:
+    <skill-file>     Direct path to a SKILL.md file to validate
+
+Environment:
+    SKILLS_DIR       Root of skill directories
+                     (default: \$SCRIPT_DIR/../skills)
+    SKILL_SCHEMA     Path to the JSON schema
+                     (default: \$SCRIPT_DIR/schemas/skill-frontmatter.json)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# _validate_file <skill_file>
+#
+# Validates one SKILL.md file using Ruby (built-in YAML + JSON support).
+# Errors go to stderr.  Returns 0 on success, 1 on failure.
+# ---------------------------------------------------------------------------
+_validate_file() {
+	local skill_file="$1"
+
+	ruby - "$skill_file" "$SKILL_SCHEMA" 2>&1 <<'RUBYEOF'
+require 'yaml'
+require 'json'
+
+skill_path  = ARGV[0]
+schema_path = ARGV[1]
+
+# ---- read SKILL.md -------------------------------------------------------
+begin
+  content = File.read(skill_path)
+rescue SystemCallError => e
+  $stderr.puts "ERROR: #{skill_path}: cannot read file: #{e.message}"
+  exit 1
+end
+
+# ---- read schema ---------------------------------------------------------
+begin
+  schema = JSON.parse(File.read(schema_path))
+rescue SystemCallError => e
+  $stderr.puts "ERROR: cannot read schema #{schema_path}: #{e.message}"
+  exit 1
+rescue JSON::ParserError => e
+  $stderr.puts "ERROR: invalid schema JSON: #{e.message}"
+  exit 1
+end
+
+# ---- extract YAML frontmatter -------------------------------------------
+# Matches the first ---...--- block, with \A anchoring to the string start
+# and ^ matching line starts (Ruby's default multiline ^ / $).
+m = content.match(/\A---[ \t]*\r?\n(.*?)^---[ \t]*\r?$/m)
+unless m
+  $stderr.puts(
+    "ERROR: #{skill_path}: " \
+    "no YAML frontmatter delimiters (---) found"
+  )
+  exit 1
+end
+
+fm_text = m[1]
+if fm_text.strip.empty?
+  $stderr.puts "ERROR: #{skill_path}: empty frontmatter block"
+  exit 1
+end
+
+# ---- parse YAML ----------------------------------------------------------
+begin
+  data = Psych.safe_load(fm_text)
+rescue Psych::Exception => e
+  $stderr.puts(
+    "ERROR: #{skill_path}: invalid YAML: #{e.message.lines.first.chomp}"
+  )
+  exit 1
+end
+
+unless data.is_a?(Hash)
+  $stderr.puts(
+    "ERROR: #{skill_path}: " \
+    "frontmatter must be a YAML mapping (key: value pairs)"
+  )
+  exit 1
+end
+
+# ---- schema validation ---------------------------------------------------
+required = schema.fetch('required', [])
+allowed  = schema.fetch('properties', {}).keys
+
+errors = []
+required.each { |f| errors << "missing required field: '#{f}'" \
+  unless data.key?(f) }
+data.each_key { |k| errors << "unknown field: '#{k}'" \
+  unless allowed.include?(k) }
+
+if errors.any?
+  errors.each { |e| $stderr.puts "ERROR: #{skill_path}: #{e}" }
+  exit 1
+end
+
+exit 0
+RUBYEOF
+}
+
+# ---------------------------------------------------------------------------
+# validate_skill <name>
+#
+# Resolves SKILLS_DIR/<name>/SKILL.md and validates it.
+# ---------------------------------------------------------------------------
+validate_skill() {
+	local name="$1"
+	local skill_file="$SKILLS_DIR/$name/SKILL.md"
+
+	if [[ ! -f "$skill_file" ]]; then
+		printf 'ERROR: %s: SKILL.md not found\n' "$skill_file" >&2
+		return 1
+	fi
+
+	_validate_file "$skill_file"
+}
+
+# ---------------------------------------------------------------------------
+# validate_all
+#
+# Validates every SKILL.md found in SKILLS_DIR.
+# Continues past individual failures; returns 1 if any skill failed.
+# ---------------------------------------------------------------------------
+validate_all() {
+	local failed=0
+	local dir skill_file
+
+	for dir in "$SKILLS_DIR"/*/; do
+		[[ -d "$dir" ]] || continue
+		skill_file="${dir}SKILL.md"
+		[[ -f "$skill_file" ]] || continue
+
+		if ! _validate_file "$skill_file"; then
+			failed=1
+		fi
+	done
+
+	return "$failed"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	local mode=""
+	local skill_name=""
+	local skill_file_arg=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--skill)
+				[[ $# -ge 2 ]] || die "missing argument for --skill"
+				mode="skill"
+				skill_name="$2"
+				shift 2
+				;;
+			--all)
+				mode="all"
+				shift
+				;;
+			-h|--help)
+				usage
+				exit 0
+				;;
+			--)
+				shift
+				break
+				;;
+			-*)
+				die "unknown option: $1"
+				;;
+			*)
+				mode="file"
+				skill_file_arg="$1"
+				shift
+				;;
+		esac
+	done
+
+	[[ -n "$mode" ]] \
+		|| die "missing --skill <name>, --all, or <skill-file>"
+	[[ -f "$SKILL_SCHEMA" ]] || die "schema not found: $SKILL_SCHEMA"
+
+	case "$mode" in
+		skill)	validate_skill "$skill_name" ;;
+		all)	validate_all ;;
+		file)	_validate_file "$skill_file_arg" ;;
+	esac
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/surgical-fast-path.sh
+++ b/plugins/pipeline-core/scripts/surgical-fast-path.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+#
+# surgical-fast-path.sh
+#
+# Executes the surgical fast-path: dirty-tree check -> branch setup ->
+# implement -> commit -> push -> PR create -> mergeability check ->
+# squash-merge. Skips test loop, code review, deploy verify, docs.
+#
+# Invoked by implement-issue-orchestrator.sh after the triage stage routes
+# an issue to "fast-path". Inherits status file, log dir, and branch from
+# the parent orchestrator via env.
+#
+# Bail-out policy: each step that fails sets state="failed" and a specific
+# error reason in status.json. The script does NOT fall back to the full
+# pipeline — operators get a clear failure surface for tuning the triage
+# criteria. Pre-commit hook failures additionally capture stderr to
+# triage.json.hook_failure_output for postmortem.
+#
+# Kill switch: DISABLE_SURGICAL_FAST_PATH=1 forces an immediate exit. The
+# orchestrator already enforces this before invoking us, but we re-check so
+# that direct invocation honors the same control.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMA_DIR="${SCHEMA_DIR:-$SCRIPT_DIR/schemas}"
+
+if [[ -f "$SCRIPT_DIR/../config/platform.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/../config/platform.sh"
+fi
+if [[ -f "$SCRIPT_DIR/model-config.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/model-config.sh"
+fi
+
+# Required env from parent orchestrator (or from tests setting these directly).
+: "${STATUS_FILE:?STATUS_FILE required}"
+: "${LOG_BASE:?LOG_BASE required}"
+: "${ISSUE_NUMBER:?ISSUE_NUMBER required}"
+: "${BASE_BRANCH:?BASE_BRANCH required}"
+
+# BRANCH is normally exported by the orchestrator before exec'ing us. Fall
+# back to the value persisted in status.json so direct invocation works.
+BRANCH="${BRANCH:-$(jq -r '.branch // empty' "$STATUS_FILE" 2>/dev/null || true)}"
+if [[ -z "${BRANCH:-}" ]]; then
+    BRANCH="feature/issue-${ISSUE_NUMBER}"
+fi
+
+LOG_FILE="${LOG_FILE:-$LOG_BASE/surgical-fast-path.log}"
+mkdir -p "$LOG_BASE/stages"
+
+log() {
+    local ts
+    ts=$(date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S)
+    # "$*" joins all arguments into one string separated by the first
+    # character of IFS (a space by default), so multi-word calls like
+    # log "step" "$n" "done" produce a single readable log line.
+    printf '[%s] %s\n' "$ts" "$*" | tee -a "$LOG_FILE"
+}
+
+# --- status helpers (subset; the orchestrator owns the full set) -----------
+
+_jq_inplace() {
+    local file="$1"; shift
+    jq "$@" "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+}
+
+set_stage_in_progress() {
+    local stage="$1"
+    _jq_inplace "$STATUS_FILE" \
+        --arg s "$stage" \
+        '.stages[$s].status = "in_progress" |
+         .stages[$s].started_at = (now | todate) |
+         .current_stage = $s |
+         .state = "running" |
+         .last_update = (now | todate)'
+}
+
+set_stage_completed() {
+    local stage="$1"
+    _jq_inplace "$STATUS_FILE" \
+        --arg s "$stage" \
+        '.stages[$s].status = "completed" |
+         .stages[$s].completed_at = (now | todate) |
+         .last_update = (now | todate)'
+}
+
+# Each bail sets state=failed with a specific error reason. The orchestrator's
+# batch-level circuit breaker treats state=failed as a real failure, so a
+# false-positive triage surfaces as a counted incident, not a silent skip.
+bail() {
+    local reason="$1"
+    log "Fast-path bail: $reason"
+    _jq_inplace "$STATUS_FILE" \
+        --arg err "$reason" \
+        '.state = "failed" |
+         .error = $err |
+         .last_update = (now | todate)'
+    write_task_summary
+    exit 1
+}
+
+capture_hook_failure() {
+    local stderr_file="$1"
+    local triage_artifact="$LOG_BASE/triage.json"
+    [[ -f "$triage_artifact" ]] || echo '{}' > "$triage_artifact"
+    local hook_output
+    hook_output=$(head -c 4096 "$stderr_file" 2>/dev/null || true)
+    _jq_inplace "$triage_artifact" \
+        --arg out "$hook_output" \
+        '.hook_failure_output = $out'
+}
+
+# Resume support is at stage boundaries only. If status.json says a fast_path_*
+# stage is already "completed", we skip it. Crashes within a stage (between
+# commit and push, between push and pr-create, etc.) are NOT recovered — the
+# operator will see a specific bail reason and can intervene. The common
+# resume case (rate-limit between PR create and merge) IS handled.
+is_stage_completed() {
+    local stage="$1"
+    local status
+    status=$(jq -r --arg s "$stage" '.stages[$s].status // "pending"' "$STATUS_FILE" 2>/dev/null || echo "pending")
+    [[ "$status" == "completed" ]]
+}
+
+read_pr_number_from_status() {
+    jq -r '.stages.fast_path_pr.pr_number // empty' "$STATUS_FILE" 2>/dev/null
+}
+
+write_task_summary() {
+    [[ -f "$STATUS_FILE" ]] || return 0
+    local summary
+    summary=$(jq '
+        def size_points:
+            if . == "M" then 3
+            elif . == "L" then 5
+            else 1
+            end;
+        def extract_size:
+            if .description | test("\\*\\*\\(L\\)\\*\\*") then "L"
+            elif .description | test("\\*\\*\\(M\\)\\*\\*") then "M"
+            else "S"
+            end;
+        [.tasks[] | . + {size: extract_size}] as $tasks |
+        {
+            completed: {
+                S: [$tasks[] | select(.status == "completed" and .size == "S")] | length,
+                M: [$tasks[] | select(.status == "completed" and .size == "M")] | length,
+                L: [$tasks[] | select(.status == "completed" and .size == "L")] | length
+            },
+            failed: {
+                S: [$tasks[] | select(.status == "failed" and .size == "S")] | length,
+                M: [$tasks[] | select(.status == "failed" and .size == "M")] | length,
+                L: [$tasks[] | select(.status == "failed" and .size == "L")] | length
+            },
+            sp_completed: ([$tasks[] | select(.status == "completed") | .size | size_points] | add // 0),
+            sp_total: ([$tasks[] | .size | size_points] | add // 0)
+        }
+    ' "$STATUS_FILE" 2>/dev/null) || true
+    [[ -n "$summary" ]] || return 0
+    _jq_inplace "$STATUS_FILE" --argjson s "$summary" '.task_summary = $s' || true
+    cp "$STATUS_FILE" "$LOG_BASE/status.json" || true
+}
+
+# --- kill switch -----------------------------------------------------------
+
+if [[ "${DISABLE_SURGICAL_FAST_PATH:-0}" == "1" ]]; then
+    echo "DISABLE_SURGICAL_FAST_PATH=1 — refusing to run surgical fast-path"
+    exit 1
+fi
+
+log "Surgical fast-path starting for issue #$ISSUE_NUMBER on branch $BRANCH"
+
+pr_number=""
+
+# --- 1. Dirty tree check ---------------------------------------------------
+#
+# On fresh start (fast_path_implement not yet completed), stash any
+# uncommitted changes before branch checkout, then pop after checkout.
+# On resume (fast_path_implement already completed), a dirty tree means
+# leftover scratch from a prior crash — bail so the operator can
+# investigate.
+
+_stash_pushed=0
+if [[ -n "$(git status --porcelain 2>/dev/null || true)" ]]; then
+    if is_stage_completed fast_path_implement; then
+        bail "dirty_tree"
+    fi
+    log "Dirty working tree on fresh start — auto-stashing"
+    if ! git stash push --include-untracked \
+            -m "fast-path auto-stash #${ISSUE_NUMBER}" 2>>"$LOG_FILE"; then
+        bail "dirty_tree"
+    fi
+    _stash_pushed=1
+fi
+
+# --- 2. Branch setup -------------------------------------------------------
+
+git checkout "$BRANCH" 2>>"$LOG_FILE" || bail "branch_checkout_failed"
+
+if [[ "${_stash_pushed}" == "1" ]]; then
+    if ! git stash pop 2>>"$LOG_FILE"; then
+        bail "stash_pop_conflict"
+    fi
+fi
+
+# --- 3. Implement (skip if already completed) ------------------------------
+
+_pre_impl_porcelain=""
+_changed_paths=()
+_impl_resume=false
+
+if is_stage_completed fast_path_implement; then
+    _impl_resume=true
+    log "fast_path_implement already completed — skipping (resume)"
+else
+    set_stage_in_progress fast_path_implement
+
+    # Snapshot working-tree state before implement so we can compute
+    # the changed-path delta afterward and stage only those files.
+    _pre_impl_porcelain=$(git status --porcelain 2>/dev/null || true)
+
+    issue_body_file="$LOG_BASE/context/issue-body.md"
+    issue_body=""
+    [[ -f "$issue_body_file" ]] && issue_body=$(cat "$issue_body_file")
+
+    implement_prompt=$(cat <<PROMPT
+Implement the issue described below. The triage stage classified this as a
+surgical fast-path change — test-only scope, <30 lines diff, <=3 files,
+established pattern, precise specification. Apply ONLY the changes described
+in the Implementation Tasks section. Do not add tests, refactor, or expand
+scope beyond the listed tasks.
+
+Issue body:
+${issue_body}
+
+After making the edits, output JSON: {"status":"success","summary":"<one-line summary>"}.
+PROMPT
+)
+
+    implement_model="${FAST_PATH_IMPLEMENT_MODEL:-sonnet}"
+    implement_log="$LOG_BASE/stages/fast-path-implement.log"
+    implement_schema="$SCHEMA_DIR/implement-issue-implement.json"
+
+    if [[ -f "$implement_schema" ]]; then
+        schema_arg=(--json-schema "$(jq -c . "$implement_schema")")
+    else
+        schema_arg=()
+    fi
+
+    implement_output=$(env -u CLAUDECODE "${CLAUDE_CLI:-claude}" -p "$implement_prompt" \
+        --model "$implement_model" \
+        --dangerously-skip-permissions \
+        --output-format json \
+        "${schema_arg[@]}" \
+        2>&1) || bail "implement_failed"
+
+    printf '%s\n' "$implement_output" > "$implement_log"
+
+    # Process exit 0 is necessary but not sufficient — Claude CLI can return
+    # success with status="error" in the structured output. Without this
+    # check we'd commit a partial/empty change and the failure would surface
+    # as pre_commit_hook_failed downstream, hiding the real cause.
+    impl_status=$(printf '%s' "$implement_output" \
+        | jq -r '.structured_output.status // ((.result | fromjson?) | .status?) // "error"' \
+        2>/dev/null || echo "error")
+    if [[ "$impl_status" != "success" ]]; then
+        bail "implement_returned_${impl_status}"
+    fi
+
+    # Compute which paths the implement step added or modified.
+    # Stage only these files later — not the entire working tree.
+    _post_impl_porcelain=$(git status --porcelain 2>/dev/null || true)
+    while IFS= read -r _impl_line; do
+        if [[ -z "$_impl_line" ]]; then
+            continue
+        fi
+        _impl_path="${_impl_line:3}"
+        if [[ "$_impl_path" == *" -> "* ]]; then
+            _impl_path="${_impl_path##* -> }"
+        fi
+        _impl_path="${_impl_path#\"}"
+        _impl_path="${_impl_path%\"}"
+        _changed_paths+=("$_impl_path")
+    done < <(comm -13 \
+        <(printf '%s\n' "$_pre_impl_porcelain" | sort) \
+        <(printf '%s\n' "$_post_impl_porcelain" | sort))
+
+    # Scope guard: abort before commit if the implement delta contains paths
+    # that are never legitimate fast-path targets — pipeline internals
+    # (.claude/), documentation (docs/), or build-artifact directories.
+    # This prevents a misbehaving implement from silently modifying the
+    # pipeline itself and slipping through code review.
+    _out_of_scope_prefixes=(
+        ".claude/"
+        "docs/"
+        "dist/"
+        "build/"
+        ".next/"
+        ".nuxt/"
+        "coverage/"
+        "node_modules/"
+    )
+    if [[ ${#_changed_paths[@]} -gt 0 ]]; then
+        for _guard_path in "${_changed_paths[@]}"; do
+            for _prefix in "${_out_of_scope_prefixes[@]}"; do
+                if [[ "$_guard_path" == "${_prefix}"* ]]; then
+                    log "Scope guard: out-of-scope path in staged delta: $_guard_path"
+                    bail "out_of_scope_path_staged"
+                fi
+            done
+        done
+    fi
+
+    set_stage_completed fast_path_implement
+    log "Fast-path implement complete"
+fi
+
+# --- 4-6. Commit, push, PR create (skip if already completed) --------------
+#
+# These three steps are treated as one resumable unit. If fast_path_pr is
+# completed, the PR exists and we read its number from status.json. If it
+# is NOT completed, we run all three from scratch — meaning a mid-unit
+# crash (e.g. between commit and push) is not recovered automatically.
+
+if is_stage_completed fast_path_pr; then
+    pr_number=$(read_pr_number_from_status)
+    [[ -n "$pr_number" ]] || bail "pr_number_missing_on_resume"
+    log "fast_path_pr already completed — reusing PR #$pr_number (resume)"
+else
+    set_stage_in_progress fast_path_pr
+
+    if [[ ${#_changed_paths[@]} -gt 0 ]]; then
+        git add -- "${_changed_paths[@]}" 2>>"$LOG_FILE"
+    elif [[ "$_impl_resume" == "true" ]]; then
+        # Resume: implement ran in a prior invocation; stage current state.
+        git add -A 2>>"$LOG_FILE"
+    else
+        log "WARNING: no in-scope file changes detected — implement may be a no-op"
+        bail "empty_changed_paths"
+    fi
+
+    hook_stderr="$LOG_BASE/stages/fast-path-commit.stderr"
+    commit_msg="feat(issue-${ISSUE_NUMBER}): surgical fast-path change
+
+Closes #${ISSUE_NUMBER}"
+
+    if ! git commit -m "$commit_msg" 2>"$hook_stderr"; then
+        capture_hook_failure "$hook_stderr"
+        bail "pre_commit_hook_failed"
+    fi
+
+    if ! git push -u origin "$BRANCH" 2>>"$LOG_FILE"; then
+        bail "push_rejected"
+    fi
+
+    pr_url=$(gh pr create \
+        --base "$BASE_BRANCH" \
+        --head "$BRANCH" \
+        --title "feat(issue-${ISSUE_NUMBER}): surgical fast-path change" \
+        --body "Closes #${ISSUE_NUMBER}
+
+Created by the surgical fast-path. The triage classifier determined this
+change met all six fast-path criteria (test-only scope, surgical size,
+established pattern, precise specification, benign failure mode, no security
+concerns). See triage.json for the classification record." \
+        2>>"$LOG_FILE") || bail "pr_create_failed"
+
+    pr_number=$(printf '%s' "$pr_url" | grep -oE '[0-9]+$' | head -1)
+    [[ -n "$pr_number" ]] || bail "pr_number_unparseable"
+
+    _jq_inplace "$STATUS_FILE" \
+        --arg n "$pr_number" \
+        '.stages.fast_path_pr.pr_number = ($n | tonumber)'
+
+    set_stage_completed fast_path_pr
+    log "Fast-path PR created: #$pr_number"
+fi
+
+# --- 7-8. Mergeability check + squash-merge (skip if already completed) ---
+
+if is_stage_completed fast_path_merge; then
+    log "fast_path_merge already completed — pipeline already finished (resume)"
+else
+    set_stage_in_progress fast_path_merge
+
+    # GitHub computes mergeStateStatus asynchronously after PR creation.
+    # The first ~2-10s post-create reliably returns UNKNOWN. Without retry
+    # the fast-path would bail on virtually every real PR. Configurable so
+    # tests can short-circuit.
+    merge_check_attempts="${FAST_PATH_MERGE_CHECK_ATTEMPTS:-5}"
+    merge_check_delay="${FAST_PATH_MERGE_CHECK_DELAY:-3}"
+    merge_state="UNKNOWN"
+
+    for ((attempt=1; attempt<=merge_check_attempts; attempt++)); do
+        merge_state=$(gh pr view "$pr_number" --json mergeStateStatus 2>/dev/null \
+            | jq -r '.mergeStateStatus // "UNKNOWN"' 2>/dev/null || echo "UNKNOWN")
+        case "$merge_state" in
+            CLEAN|HAS_HOOKS) break ;;
+            UNKNOWN)
+                if (( attempt < merge_check_attempts )); then
+                    log "mergeStateStatus=UNKNOWN (attempt $attempt/$merge_check_attempts) — retrying in ${merge_check_delay}s"
+                    sleep "$merge_check_delay"
+                fi
+                ;;
+            *) break ;;  # DIRTY, BLOCKED, BEHIND, etc. — bail without retry
+        esac
+    done
+
+    case "$merge_state" in
+        CLEAN|HAS_HOOKS) ;;
+        *) bail "unsafe_merge_state_${merge_state}" ;;
+    esac
+
+    if ! gh pr merge "$pr_number" --squash --delete-branch 2>>"$LOG_FILE"; then
+        bail "merge_failed"
+    fi
+
+    set_stage_completed fast_path_merge
+fi
+
+# --- 9. Mark complete ------------------------------------------------------
+
+_jq_inplace "$STATUS_FILE" \
+    '.state = "completed" |
+     .current_stage = "complete" |
+     .last_update = (now | todate)'
+
+log "Surgical fast-path complete. PR #$pr_number merged and branch deleted."
+write_task_summary
+exit 0

--- a/plugins/pipeline-core/scripts/test-fix-loop.sh
+++ b/plugins/pipeline-core/scripts/test-fix-loop.sh
@@ -1,0 +1,681 @@
+#!/usr/bin/env bash
+#
+# test-fix-loop.sh
+# Runs Playwright E2E tests, detects failures, creates bug issues via Claude,
+# fixes them via implement-issue-orchestrator.sh, and loops until all pass.
+#
+# Usage:
+#   ./.claude/scripts/test-fix-loop.sh
+#   ./.claude/scripts/test-fix-loop.sh --test-file tests/e2e/molesworth-farmer-journey.spec.ts
+#   ./.claude/scripts/test-fix-loop.sh --max-iterations 5 --max-attempts-per-ac 2
+#   ./.claude/scripts/test-fix-loop.sh --branch feature/issue-679
+#
+# Outputs:
+#   - logs/test-fix-loop/<timestamp>/status.json: Real-time progress
+#   - logs/test-fix-loop/<timestamp>/stages/: Per-iteration logs
+#
+
+set -uo pipefail  # Note: not -e, we handle errors explicitly
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../config/platform.sh"
+source "$SCRIPT_DIR/model-config.sh"
+
+# Limits
+MAX_ITERATIONS="${MAX_ITERATIONS:-10}"
+MAX_ATTEMPTS_PER_AC="${MAX_ATTEMPTS_PER_AC:-3}"
+RATE_LIMIT_BUFFER=60
+RATE_LIMIT_DEFAULT_WAIT=3600
+
+# Defaults
+TEST_FILE="tests/e2e/molesworth-farmer-journey.spec.ts"
+BASE_BRANCH="main"
+PLAYWRIGHT_TIMEOUT=300  # 5 min for playwright run
+CLAUDE_STAGE_TIMEOUT=1800  # 30 min for claude explore/fix stages
+
+# =============================================================================
+# PORTABLE TIMEOUT (macOS does not ship GNU timeout)
+# =============================================================================
+
+if ! command -v timeout &>/dev/null; then
+    timeout() {
+        local duration="$1"; shift
+        perl -e '
+            use POSIX ":sys_wait_h";
+            alarm shift @ARGV;
+            $SIG{ALRM} = sub { kill 15, $pid; waitpid($pid, 0); exit 124 };
+            $pid = fork // die "fork: $!";
+            if ($pid == 0) { exec @ARGV; die "exec: $!" }
+            waitpid($pid, 0);
+            exit ($? >> 8);
+        ' "$duration" "$@"
+    }
+fi
+
+# =============================================================================
+# ARGUMENT PARSING
+# =============================================================================
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --test-file <path>         Playwright test file (default: $TEST_FILE)
+  --branch <name>            Base branch for fix PRs (default: $BASE_BRANCH)
+  --max-iterations <n>       Max total iterations (default: $MAX_ITERATIONS)
+  --max-attempts-per-ac <n>  Max fix attempts per AC (default: $MAX_ATTEMPTS_PER_AC)
+  --help                     Show this help
+
+Environment overrides:
+  MAX_ITERATIONS             Same as --max-iterations
+  MAX_ATTEMPTS_PER_AC        Same as --max-attempts-per-ac
+EOF
+    exit 3
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --test-file)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --test-file requires a value" >&2; exit 3; }
+            TEST_FILE="$2"
+            shift 2
+            ;;
+        --branch)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --branch requires a value" >&2; exit 3; }
+            BASE_BRANCH="$2"
+            shift 2
+            ;;
+        --max-iterations)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --max-iterations requires a value" >&2; exit 3; }
+            MAX_ITERATIONS="$2"
+            shift 2
+            ;;
+        --max-attempts-per-ac)
+            [[ -n "${2:-}" ]] || { echo "ERROR: --max-attempts-per-ac requires a value" >&2; exit 3; }
+            MAX_ATTEMPTS_PER_AC="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+# Validate test file exists
+if [[ ! -f "$TEST_FILE" ]]; then
+    echo "ERROR: Test file not found: $TEST_FILE" >&2
+    exit 1
+fi
+
+# =============================================================================
+# LOGGING
+# =============================================================================
+
+LOG_BASE="logs/test-fix-loop/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$LOG_BASE/stages"
+
+LOG_FILE="$LOG_BASE/orchestrator.log"
+STATUS_FILE="$LOG_BASE/status.json"
+STAGE_COUNTER=0
+
+log() {
+    local msg="[$(date -Iseconds)] $*"
+    printf '%s\n' "$msg" >> "$LOG_FILE"
+    printf '%s\n' "$msg" >&2
+}
+
+log_error() {
+    local msg="[$(date -Iseconds)] ERROR: $*"
+    printf '%s\n' "$msg" >> "$LOG_FILE"
+    printf '%s\n' "$msg" >&2
+}
+
+next_stage_log() {
+    local stage_name="$1"
+    STAGE_COUNTER=$((STAGE_COUNTER + 1))
+    printf "%02d-%s.log" "$STAGE_COUNTER" "$stage_name"
+}
+
+# =============================================================================
+# STATUS FILE MANAGEMENT
+# =============================================================================
+
+init_status() {
+    jq -n \
+        --argjson iteration 0 \
+        --argjson total_acs 0 \
+        --argjson passed_acs 0 \
+        --arg current_failure "" \
+        --argjson issues_created '[]' \
+        --argjson issues_fixed '[]' \
+        --arg state "initializing" \
+        --arg test_file "$TEST_FILE" \
+        --arg log_dir "$LOG_BASE" \
+        '{
+            iteration: $iteration,
+            total_acs: $total_acs,
+            passed_acs: $passed_acs,
+            current_failure: $current_failure,
+            issues_created: $issues_created,
+            issues_fixed: $issues_fixed,
+            state: $state,
+            test_file: $test_file,
+            log_dir: $log_dir,
+            ac_attempts: {},
+            last_update: (now | todate)
+        }' > "$STATUS_FILE"
+    log "Initialized status: $STATUS_FILE"
+}
+
+update_status() {
+    local field="$1"
+    local value="$2"
+    local value_type="${3:-string}"  # string, number, array, raw
+
+    case "$value_type" in
+        string)
+            jq --arg f "$field" --arg v "$value" \
+                '.[$f] = $v | .last_update = (now | todate)' \
+                "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+            ;;
+        number)
+            jq --arg f "$field" --argjson v "$value" \
+                '.[$f] = $v | .last_update = (now | todate)' \
+                "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+            ;;
+        raw)
+            jq --arg f "$field" --argjson v "$value" \
+                '.[$f] = $v | .last_update = (now | todate)' \
+                "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+            ;;
+    esac
+}
+
+increment_ac_attempts() {
+    local ac_key="$1"
+    jq --arg k "$ac_key" \
+        '.ac_attempts[$k] = ((.ac_attempts[$k] // 0) + 1) | .last_update = (now | todate)' \
+        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+}
+
+get_ac_attempts() {
+    local ac_key="$1"
+    jq -r --arg k "$ac_key" '.ac_attempts[$k] // 0' "$STATUS_FILE"
+}
+
+add_issue_created() {
+    local issue_number="$1"
+    jq --arg i "$issue_number" \
+        '.issues_created += [$i] | .last_update = (now | todate)' \
+        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+}
+
+add_issue_fixed() {
+    local issue_number="$1"
+    jq --arg i "$issue_number" \
+        '.issues_fixed += [$i] | .last_update = (now | todate)' \
+        "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+}
+
+# =============================================================================
+# RATE LIMIT DETECTION (reused from implement-issue-orchestrator.sh)
+# =============================================================================
+
+detect_rate_limit() {
+    local output="$1"
+
+    local status
+    status=$(printf '%s' "$output" | jq -r '.structured_output.status // empty' 2>/dev/null)
+
+    if [[ "$status" == "success" ]]; then
+        return 1
+    fi
+
+    if [[ "$status" == "rate_limit" ]]; then
+        return 0
+    fi
+
+    local is_error
+    is_error=$(printf '%s' "$output" | jq -r '.is_error // false' 2>/dev/null)
+
+    if [[ "$is_error" != "true" ]]; then
+        return 1
+    fi
+
+    local result
+    result=$(printf '%s' "$output" | jq -r '.result // empty' 2>/dev/null)
+    if printf '%s' "$result" | grep -qiE 'rate.limit|429|too many requests|quota.exceeded'; then
+        return 0
+    fi
+
+    return 1
+}
+
+extract_wait_time() {
+    local output="$1"
+    local result
+    result=$(printf '%s' "$output" | jq -r '.result // empty' 2>/dev/null)
+    local search_text="$result $output"
+
+    local retry_after
+    retry_after=$(printf '%s' "$search_text" | grep -oiE 'retry.after[^0-9]*([0-9]+)' | grep -oE '[0-9]+' | head -1)
+    if [[ -n "$retry_after" ]] && (( retry_after > 0 )); then
+        printf '%s\n' "$retry_after"
+        return
+    fi
+
+    local wait_mins
+    wait_mins=$(printf '%s' "$search_text" | grep -oiE 'wait[^0-9]*([0-9]+)[^0-9]*min' | grep -oE '[0-9]+' | head -1)
+    if [[ -n "$wait_mins" ]] && (( wait_mins > 0 )); then
+        printf '%s\n' "$((wait_mins * 60))"
+        return
+    fi
+
+    printf '%s\n' "$RATE_LIMIT_DEFAULT_WAIT"
+}
+
+handle_rate_limit() {
+    local output="$1"
+    local wait_time
+    wait_time=$(extract_wait_time "$output")
+    wait_time=$((wait_time + RATE_LIMIT_BUFFER))
+
+    local resume_at
+    resume_at=$(date -Iseconds -d "+${wait_time} seconds" 2>/dev/null \
+        || date -v+${wait_time}S -Iseconds 2>/dev/null \
+        || echo "unknown")
+
+    log "Rate limit hit. Waiting ${wait_time}s until $resume_at"
+    update_status "state" "rate_limited"
+    sleep "$wait_time"
+    update_status "state" "running"
+}
+
+# =============================================================================
+# PLAYWRIGHT TEST RUNNER
+# =============================================================================
+
+run_playwright_tests() {
+    local iteration="$1"
+    local stage_log="$LOG_BASE/stages/$(next_stage_log "playwright-iter-$iteration")"
+    local json_output_file="$LOG_BASE/stages/playwright-iter-${iteration}-results.json"
+
+    log "Running Playwright tests (iteration $iteration): $TEST_FILE"
+
+    local exit_code=0
+    local raw_output_file="${json_output_file}.raw"
+    timeout "$PLAYWRIGHT_TIMEOUT" npx playwright test "$TEST_FILE" \
+        --reporter=json \
+        > "$raw_output_file" 2>"$stage_log" || exit_code=$?
+
+    # Playwright JSON reporter mixes global setup/teardown stdout with JSON.
+    # Extract only the JSON portion (starts with first '{' on a line).
+    if [[ -f "$raw_output_file" ]]; then
+        sed -n '/^{/,$p' "$raw_output_file" > "$json_output_file"
+        # If sed produced empty output, the JSON may start after cleanup output
+        if [[ ! -s "$json_output_file" ]]; then
+            # Try extracting from first line containing opening brace
+            grep -n '{' "$raw_output_file" | head -1 | cut -d: -f1 | while read -r line_num; do
+                tail -n +"$line_num" "$raw_output_file" > "$json_output_file"
+            done
+        fi
+    fi
+
+    if (( exit_code == 124 )); then
+        log_error "Playwright timed out after ${PLAYWRIGHT_TIMEOUT}s"
+        return 124
+    fi
+
+    log "Playwright exit code: $exit_code"
+    printf '%s' "$json_output_file"
+    return "$exit_code"
+}
+
+# =============================================================================
+# PARSE PLAYWRIGHT JSON RESULTS
+# =============================================================================
+
+parse_test_results() {
+    local json_file="$1"
+
+    if [[ ! -f "$json_file" ]]; then
+        log_error "Playwright JSON output not found: $json_file"
+        echo '{"total":0,"passed":0,"failed":0,"failures":[]}'
+        return 1
+    fi
+
+    # Extract test counts and first failure details from JSON reporter output
+    # Playwright JSON reporter structure: { suites: [ { specs: [ { tests: [ { results: [...] } ] } ] } ] }
+    jq -c '
+        # Flatten all test results
+        [.suites[]?.specs[]? | {
+            title: .title,
+            test_id: .id,
+            file: .file,
+            results: [.tests[]?.results[]?],
+            ok: .ok
+        }] as $all_tests |
+
+        # Count totals
+        ($all_tests | length) as $total |
+        [$all_tests[] | select(.ok == true)] | length as $passed |
+        [$all_tests[] | select(.ok != true)] as $failed_tests |
+        ($failed_tests | length) as $failed |
+
+        # Extract first failure details
+        (if ($failed > 0) then
+            $failed_tests[0] | {
+                test_name: .title,
+                file: .file,
+                error_message: ([.results[]? | .error?.message // empty] | first // "unknown error"),
+                error_snippet: ([.results[]? | .error?.snippet // empty] | first // ""),
+                screenshot: ([.results[]? | .attachments[]? | select(.name == "screenshot") | .path // empty] | first // "")
+            }
+        else
+            null
+        end) as $first_failure |
+
+        {
+            total: $total,
+            passed: $passed,
+            failed: $failed,
+            first_failure: $first_failure,
+            failed_tests: [$failed_tests[] | .title]
+        }
+    ' "$json_file" 2>/dev/null || {
+        log_error "Failed to parse Playwright JSON output"
+        echo '{"total":0,"passed":0,"failed":0,"failures":[]}'
+        return 1
+    }
+}
+
+# =============================================================================
+# CREATE BUG ISSUE VIA CLAUDE
+# =============================================================================
+
+create_bug_issue() {
+    local test_name="$1"
+    local error_message="$2"
+    local screenshot_path="$3"
+    local test_file="$4"
+    local iteration="$5"
+
+    local stage_log="$LOG_BASE/stages/$(next_stage_log "create-issue-iter-$iteration")"
+
+    # Build the explore prompt with failure context
+    local screenshot_context=""
+    if [[ -n "$screenshot_path" && -f "$screenshot_path" ]]; then
+        screenshot_context="Screenshot of failure: $screenshot_path"
+    fi
+
+    local prompt
+    prompt=$(cat <<PROMPT_EOF
+/explore
+
+## Bug Report: E2E Test Failure
+
+**Failing test:** \`$test_name\`
+**Test file:** \`$test_file\`
+**Error message:**
+\`\`\`
+$error_message
+\`\`\`
+$screenshot_context
+
+## Context
+This test failure was detected during automated E2E testing of the Molesworth farmer journey.
+The test is part of the acceptance criteria validation for the farmer workflow.
+
+## Instructions
+1. Investigate the root cause of this test failure
+2. Identify the affected files and components
+3. Create a GitHub issue with:
+   - Clear description of the bug
+   - Steps to reproduce (the failing test)
+   - Affected files
+   - Suggested fix approach
+   - Label: bug
+4. Output the created issue number at the end in the format: ISSUE_NUMBER=<number>
+PROMPT_EOF
+)
+
+    log "Creating bug issue for failing test: $test_name"
+
+    local output
+    local exit_code=0
+
+    output=$(timeout "$CLAUDE_STAGE_TIMEOUT" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
+        --model "$(resolve_model "implement" "")" \
+        --dangerously-skip-permissions \
+        --output-format json \
+        2>&1) || exit_code=$?
+
+    printf '%s\n' "=== create-issue output ===" >> "$stage_log"
+    printf '%s\n' "$output" >> "$stage_log"
+    printf '%s\n' "=== exit code: $exit_code ===" >> "$stage_log"
+
+    if (( exit_code == 124 )); then
+        log_error "Claude timed out creating issue"
+        return 1
+    fi
+
+    # Check rate limit
+    if detect_rate_limit "$output"; then
+        handle_rate_limit "$output"
+        # Retry once
+        output=$(timeout "$CLAUDE_STAGE_TIMEOUT" env -u CLAUDECODE "$CLAUDE_CLI" -p "$prompt" \
+            --model "$(resolve_model "implement" "")" \
+            --dangerously-skip-permissions \
+            --output-format json \
+            2>&1) || exit_code=$?
+
+        printf '%s\n' "=== create-issue retry output ===" >> "$stage_log"
+        printf '%s\n' "$output" >> "$stage_log"
+    fi
+
+    # Extract issue number from Claude output
+    # Look for ISSUE_NUMBER=<digits> pattern in the result text
+    local result_text
+    result_text=$(printf '%s' "$output" | jq -r '.result // empty' 2>/dev/null)
+
+    local issue_number
+    issue_number=$(printf '%s' "$result_text" | grep -oE 'ISSUE_NUMBER=[0-9]+' | grep -oE '[0-9]+' | head -1)
+
+    # Fallback: look for "gh issue create" output patterns like "#123" or "issue/123"
+    if [[ -z "$issue_number" ]]; then
+        issue_number=$(printf '%s' "$result_text" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | tail -1)
+    fi
+
+    # Fallback: look for github issue URL
+    if [[ -z "$issue_number" ]]; then
+        issue_number=$(printf '%s' "$result_text" | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | tail -1)
+    fi
+
+    if [[ -z "$issue_number" ]]; then
+        log_error "Could not extract issue number from Claude output"
+        return 1
+    fi
+
+    log "Created issue #$issue_number for: $test_name"
+    printf '%s' "$issue_number"
+}
+
+# =============================================================================
+# FIX BUG VIA IMPLEMENT-ISSUE-ORCHESTRATOR
+# =============================================================================
+
+fix_bug_issue() {
+    local issue_number="$1"
+    local iteration="$2"
+
+    local stage_log="$LOG_BASE/stages/$(next_stage_log "fix-issue-$issue_number-iter-$iteration")"
+
+    log "Fixing issue #$issue_number via implement-issue-orchestrator.sh"
+
+    local exit_code=0
+    timeout 3600 bash "$SCRIPT_DIR/implement-issue-orchestrator.sh" \
+        --issue "$issue_number" \
+        --branch "$BASE_BRANCH" \
+        --quiet \
+        > "$stage_log" 2>&1 || exit_code=$?
+
+    log "implement-issue-orchestrator exit code: $exit_code (issue #$issue_number)"
+    return "$exit_code"
+}
+
+# =============================================================================
+# MAIN LOOP
+# =============================================================================
+
+main() {
+    log "=== test-fix-loop started ==="
+    log "Test file: $TEST_FILE"
+    log "Base branch: $BASE_BRANCH"
+    log "Max iterations: $MAX_ITERATIONS"
+    log "Max attempts per AC: $MAX_ATTEMPTS_PER_AC"
+    log "Log directory: $LOG_BASE"
+
+    init_status
+    update_status "state" "running"
+
+    local iteration=0
+
+    while (( iteration < MAX_ITERATIONS )); do
+        iteration=$((iteration + 1))
+        update_status "iteration" "$iteration" "number"
+
+        log "--- Iteration $iteration/$MAX_ITERATIONS ---"
+
+        # Step 1: Run Playwright tests
+        local json_file
+        local test_exit_code=0
+        json_file=$(run_playwright_tests "$iteration") || test_exit_code=$?
+
+        # Handle timeout separately — stdout is empty, no JSON to parse
+        if (( test_exit_code == 124 )); then
+            log_error "Playwright timed out — skipping fix attempt this iteration"
+            update_status "state" "playwright_timeout"
+            continue
+        fi
+
+        # If tests passed (exit code 0), we're done
+        if (( test_exit_code == 0 )); then
+            log "All tests passed on iteration $iteration!"
+
+            # Parse final results for accurate counts
+            local final_results
+            final_results=$(parse_test_results "$json_file")
+            local total passed
+            total=$(printf '%s' "$final_results" | jq -r '.total')
+            passed=$(printf '%s' "$final_results" | jq -r '.passed')
+
+            update_status "total_acs" "$total" "number"
+            update_status "passed_acs" "$passed" "number"
+            update_status "current_failure" ""
+            update_status "state" "completed"
+
+            log "=== test-fix-loop completed: ALL TESTS PASS ==="
+            log "Total: $total, Passed: $passed, Iterations: $iteration"
+            return 0
+        fi
+
+        # Step 2: Parse failures
+        local results
+        results=$(parse_test_results "$json_file")
+
+        local total passed failed
+        total=$(printf '%s' "$results" | jq -r '.total')
+        passed=$(printf '%s' "$results" | jq -r '.passed')
+        failed=$(printf '%s' "$results" | jq -r '.failed')
+
+        update_status "total_acs" "$total" "number"
+        update_status "passed_acs" "$passed" "number"
+
+        log "Results: $passed/$total passed, $failed failed"
+
+        # Step 3: Get first failure details
+        local test_name error_message screenshot_path
+        test_name=$(printf '%s' "$results" | jq -r '.first_failure.test_name // "unknown"')
+        error_message=$(printf '%s' "$results" | jq -r '.first_failure.error_message // "unknown error"')
+        screenshot_path=$(printf '%s' "$results" | jq -r '.first_failure.screenshot // ""')
+
+        update_status "current_failure" "$test_name"
+
+        log "First failure: $test_name"
+
+        # Step 4: Check per-AC attempt limit
+        # Use test name as the AC key (sanitized)
+        local ac_key
+        ac_key=$(printf '%s' "$test_name" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '-' | sed 's/-$//')
+        increment_ac_attempts "$ac_key"
+
+        local attempts
+        attempts=$(get_ac_attempts "$ac_key")
+
+        if (( attempts > MAX_ATTEMPTS_PER_AC )); then
+            log_error "Max attempts ($MAX_ATTEMPTS_PER_AC) exceeded for AC: $test_name (attempts: $attempts)"
+            update_status "state" "failed_max_attempts_per_ac"
+            log "=== test-fix-loop stopped: MAX_ATTEMPTS_PER_AC exceeded for '$test_name' ==="
+            return 1
+        fi
+
+        log "Attempt $attempts/$MAX_ATTEMPTS_PER_AC for: $test_name"
+
+        # Step 5: Create bug issue via Claude
+        local issue_number
+        issue_number=$(create_bug_issue "$test_name" "$error_message" "$screenshot_path" "$TEST_FILE" "$iteration")
+
+        if [[ -z "$issue_number" ]]; then
+            log_error "Failed to create issue — skipping fix attempt"
+            continue
+        fi
+
+        add_issue_created "$issue_number"
+
+        # Step 6: Fix the bug via implement-issue-orchestrator
+        local fix_exit_code=0
+        fix_bug_issue "$issue_number" "$iteration" || fix_exit_code=$?
+
+        if (( fix_exit_code == 0 )); then
+            add_issue_fixed "$issue_number"
+            log "Issue #$issue_number fixed successfully"
+        else
+            log_error "Failed to fix issue #$issue_number (exit code: $fix_exit_code)"
+            # Continue to next iteration — re-running tests will show if progress was made
+        fi
+
+        # Step 7: Loop continues — next iteration will re-run tests
+        log "Completed iteration $iteration, looping to re-test..."
+    done
+
+    # Exhausted max iterations
+    log_error "Max iterations ($MAX_ITERATIONS) reached without all tests passing"
+    update_status "state" "failed_max_iterations"
+
+    # Final test run results
+    local final_json final_results
+    final_json=$(run_playwright_tests "final") || true
+    if [[ -f "$final_json" ]]; then
+        final_results=$(parse_test_results "$final_json")
+        local final_passed final_total
+        final_passed=$(printf '%s' "$final_results" | jq -r '.passed')
+        final_total=$(printf '%s' "$final_results" | jq -r '.total')
+        update_status "passed_acs" "$final_passed" "number"
+        update_status "total_acs" "$final_total" "number"
+        log "Final state: $final_passed/$final_total passed after $MAX_ITERATIONS iterations"
+    fi
+
+    log "=== test-fix-loop stopped: MAX_ITERATIONS reached ==="
+    return 1
+}
+
+main "$@"

--- a/plugins/pipeline-core/scripts/triage-validate.sh
+++ b/plugins/pipeline-core/scripts/triage-validate.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# triage-validate.sh — golden tests for the triage classifier prompt
+#
+# Usage:
+#   triage-validate.sh [<fixture-basename>]
+#   TRIAGE_MODEL=sonnet triage-validate.sh
+#
+# Exit codes: 0 all passed, 1 one or more flipped, 2 setup error.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$SCRIPT_DIR/implement-issue-test/fixtures/triage"
+SCHEMA_FILE="$SCRIPT_DIR/schemas/implement-issue-triage.json"
+TRIAGE_MODEL="${TRIAGE_MODEL:-haiku}"
+
+# Propagate legacy CLAUDE_CLI to the library variable (lib default: "claude").
+: "${SG_CLAUDE_CLI:=${CLAUDE_CLI:-claude}}"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/skill-golden-lib.sh"
+
+# =============================================================================
+# Manifest: fixture -> expected_route|expected_disqualifying_criterion
+# Use "*" to accept any criterion; name a specific criterion to pin it.
+# =============================================================================
+
+MANIFEST=(
+	"issue-2836|fast-path|*"
+	"issue-2837|fast-path|*"
+	"issue-2838|fast-path|*"
+	"issue-2839|fast-path|*"
+	"issue-2752|full|test_only_scope"
+	"issue-2754|full|test_only_scope"
+	"issue-2776|full|test_only_scope"
+	"issue-auth-test|full|no_security_concerns"
+	"issue-vague|full|precise_specification"
+	"issue-novel-pattern|full|established_pattern"
+)
+
+# =============================================================================
+# Prompt builder
+# =============================================================================
+
+# shellcheck source=prompts/triage-prompt.sh
+source "$SCRIPT_DIR/prompts/triage-prompt.sh"
+
+# =============================================================================
+# Argument parsing
+# =============================================================================
+
+filter=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--)
+			shift
+			break
+			;;
+		-*)
+			printf '%s: unknown option: %s\n' "${0##*/}" "$1" >&2
+			exit 2
+			;;
+		*)
+			filter="$1"
+			shift
+			;;
+	esac
+done
+
+# =============================================================================
+# Dispatch
+# =============================================================================
+
+sg_check_setup "$FIXTURE_DIR" "$SCHEMA_FILE" || exit 2
+sg_run_manifest "$FIXTURE_DIR" "$SCHEMA_FILE" "$TRIAGE_MODEL" \
+	build_prompt "$filter" "${MANIFEST[@]}"
+exit $?


### PR DESCRIPTION
Part of #599 (Task 3 — does not close it). **Strictly additive**, so the running pipeline is unaffected.

**What:** copies the runtime layout into `plugins/pipeline-core/scripts/` — 30 `*.sh` (both orchestrators, resolver, model-config, issue-body-lib, decide-*), 25 schemas, `platform/`, `prompts/`. **Byte-identical copies** (verified via `cmp` on all 70), structure preserved so `BASH_SOURCE` self-location resolves siblings identically to `.claude/scripts/`.

**Excluded:** dev bats dirs (`implement-issue-test/`, `platform-test/`) — developer/eval tests, not consumer runtime; verified no core script depends on them.

**Not repointed:** no reference points at the bundle yet (tasks 4/5). `plugin.json` version + hooks repoint are task 6.

**Verified:** resolver resolves `schemas/*.json` + `*.sh` from the bundle (self-location, `CLAUDE_PLUGIN_ROOT` unset, cwd=/); existing suites 98/98 (skill-load 5, issue-body-lib 85, resolver 8).