### PR TITLE
feat(pipeline): plugin bin/ entrypoints + dual-mode skill invocation (part of #599)

### DIFF
--- a/plugins/pipeline-core/bin/pipeline-core-batch
+++ b/plugins/pipeline-core/bin/pipeline-core-batch
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# pipeline-core-batch — plugin bin entrypoint (on PATH when pipeline-core is enabled).
+#
+# Self-locates the bundled batch orchestrator via ${BASH_SOURCE[0]} so it resolves whether
+# it runs from the plugin cache dir or a repo-local checkout. CLAUDE_PLUGIN_ROOT is NOT
+# relied on: it is unset in the model's Bash-tool shell (issue #599 Task 1 finding).
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$PLUGIN_ROOT/scripts/batch-orchestrator.sh" "$@"

--- a/plugins/pipeline-core/bin/pipeline-core-capture-usage-fixture
+++ b/plugins/pipeline-core/bin/pipeline-core-capture-usage-fixture
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# pipeline-core-capture-usage-fixture — plugin bin entrypoint (on PATH when pipeline-core is enabled).
+#
+# Self-locates the bundled script via ${BASH_SOURCE[0]} so it resolves whether it runs
+# from the plugin cache dir or a repo-local checkout. CLAUDE_PLUGIN_ROOT is NOT relied on:
+# it is unset in the model's Bash-tool shell (issue #599 Task 1 finding).
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$PLUGIN_ROOT/scripts/capture-usage-fixture.sh" "$@"

--- a/plugins/pipeline-core/bin/pipeline-core-create-followup-issue
+++ b/plugins/pipeline-core/bin/pipeline-core-create-followup-issue
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# pipeline-core-create-followup-issue — plugin bin entrypoint (on PATH when pipeline-core is enabled).
+#
+# Self-locates the bundled script via ${BASH_SOURCE[0]} so it resolves whether it runs
+# from the plugin cache dir or a repo-local checkout. CLAUDE_PLUGIN_ROOT is NOT relied on:
+# it is unset in the model's Bash-tool shell (issue #599 Task 1 finding).
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$PLUGIN_ROOT/scripts/create-followup-issue.sh" "$@"

--- a/plugins/pipeline-core/bin/pipeline-core-feedback-record
+++ b/plugins/pipeline-core/bin/pipeline-core-feedback-record
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# pipeline-core-feedback-record — plugin bin entrypoint (on PATH when pipeline-core is enabled).
+#
+# Self-locates the bundled script via ${BASH_SOURCE[0]} so it resolves whether it runs
+# from the plugin cache dir or a repo-local checkout. CLAUDE_PLUGIN_ROOT is NOT relied on:
+# it is unset in the model's Bash-tool shell (issue #599 Task 1 finding).
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$PLUGIN_ROOT/scripts/feedback-record.sh" "$@"

--- a/plugins/pipeline-core/bin/pipeline-core-implement
+++ b/plugins/pipeline-core/bin/pipeline-core-implement
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# pipeline-core-implement — plugin bin entrypoint (on PATH when pipeline-core is enabled).
+#
+# Self-locates the bundled orchestrator via ${BASH_SOURCE[0]} so it resolves whether
+# it runs from the plugin cache dir or a repo-local checkout. CLAUDE_PLUGIN_ROOT is NOT
+# relied on: it is unset in the model's Bash-tool shell (issue #599 Task 1 finding).
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$PLUGIN_ROOT/scripts/implement-issue-orchestrator.sh" "$@"

--- a/plugins/pipeline-core/bin/pipeline-core-platform-dir
+++ b/plugins/pipeline-core/bin/pipeline-core-platform-dir
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# pipeline-core-platform-dir — plugin bin entrypoint (on PATH when pipeline-core is enabled).
+#
+# Prints the absolute path to the bundled platform-abstraction scripts dir, self-located
+# via ${BASH_SOURCE[0]} so it resolves whether it runs from the plugin cache dir or a
+# repo-local checkout. Skills use it to resolve PLATFORM_DIR in dual mode:
+#   PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
+# CLAUDE_PLUGIN_ROOT is NOT relied on: it is unset in the model's Bash-tool shell (#599 Task 1).
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+printf '%s\n' "$PLUGIN_ROOT/scripts/platform"

--- a/plugins/pipeline-core/bin/pipeline-core-skill-golden
+++ b/plugins/pipeline-core/bin/pipeline-core-skill-golden
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# pipeline-core-skill-golden — plugin bin entrypoint (on PATH when pipeline-core is enabled).
+#
+# Self-locates the bundled script via ${BASH_SOURCE[0]} so it resolves whether it runs
+# from the plugin cache dir or a repo-local checkout. CLAUDE_PLUGIN_ROOT is NOT relied on:
+# it is unset in the model's Bash-tool shell (issue #599 Task 1 finding).
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$PLUGIN_ROOT/scripts/skill-golden.sh" "$@"

--- a/plugins/pipeline-core/skills/enrich-issue/SKILL.md
+++ b/plugins/pipeline-core/skills/enrich-issue/SKILL.md
@@ -52,7 +52,7 @@ On success, removes the `needs-explore` label from the issue.
 Read the issue body and title:
 
 ```bash
-PLATFORM_DIR=".claude/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 [[ -f .claude/config/platform.sh ]] && source .claude/config/platform.sh
 ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --json body,title,labels \
   --jq '{title: .title, body: .body, labels: [.labels[].name]}')

--- a/plugins/pipeline-core/skills/explore/SKILL.md
+++ b/plugins/pipeline-core/skills/explore/SKILL.md
@@ -129,7 +129,7 @@ The `## Deploy Verification` section body **must** include a `**Verification com
 Create the issue using the platform wrapper with `--parent` set to the chosen epic:
 
 ```bash
-PLATFORM_DIR=".claude/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 "$PLATFORM_DIR/create-issue.sh" --title "$TITLE" --parent "$EPIC_KEY" --body "$(cat <<'EOF'
 ## Context
 [What was discovered and why it matters — 2-3 sentences]

--- a/plugins/pipeline-core/skills/handle-issues/SKILL.md
+++ b/plugins/pipeline-core/skills/handle-issues/SKILL.md
@@ -313,7 +313,8 @@ escalates sonnet → opus on the fly.
 If the response shape changes:
 
 ```bash
-.claude/scripts/capture-usage-fixture.sh
+CAPTURE_USAGE="$(command -v pipeline-core-capture-usage-fixture || echo .claude/scripts/capture-usage-fixture.sh)"
+"$CAPTURE_USAGE"
 ```
 
 (prompts for sessionKey + org UUID, writes to
@@ -391,7 +392,7 @@ Extract from the user's context query:
 Build and execute `gh` command based on parsed criteria:
 
 ```bash
-PLATFORM_DIR="${CLAUDE_PLUGIN_ROOT}/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 
 # Example: issues assigned to user
 "$PLATFORM_DIR/list-issues.sh" --assignee "@me" --state open
@@ -470,12 +471,16 @@ echo "Manifest written to: $MANIFEST"
 Launch the batch orchestrator as a background process:
 
 ```bash
+# Resolve the batch orchestrator dual-mode: prefer the plugin bin (on PATH when
+# pipeline-core is enabled), else fall back to the repo-local script.
+BATCH="$(command -v pipeline-core-batch || echo .claude/scripts/batch-orchestrator.sh)"
+
 # Launch orchestrator (agent is read from manifest, or can be overridden via --agent)
-nohup "${CLAUDE_PLUGIN_ROOT}/scripts/batch-orchestrator.sh" --manifest "$MANIFEST" \
+nohup "$BATCH" --manifest "$MANIFEST" \
   > "logs/handle-issues/orchestrator-$(date +%Y%m%d-%H%M%S).log" 2>&1 &
 
 # Or with explicit agent override:
-# nohup "${CLAUDE_PLUGIN_ROOT}/scripts/batch-orchestrator.sh" --manifest "$MANIFEST" --agent bulletproof-frontend-developer \
+# nohup "$BATCH" --manifest "$MANIFEST" --agent bulletproof-frontend-developer \
 #   > "logs/handle-issues/orchestrator-$(date +%Y%m%d-%H%M%S).log" 2>&1 &
 
 ORCHESTRATOR_PID=$!
@@ -703,7 +708,8 @@ Running `/handle-issues` with `--enrich-followups` (or `batch-orchestrator.sh --
 
 ```bash
 # Launch orchestrator with enrichment sweep enabled
-nohup "${CLAUDE_PLUGIN_ROOT}/scripts/batch-orchestrator.sh" --manifest "$MANIFEST" --enrich-followups \
+BATCH="$(command -v pipeline-core-batch || echo .claude/scripts/batch-orchestrator.sh)"
+nohup "$BATCH" --manifest "$MANIFEST" --enrich-followups \
   > "logs/handle-issues/orchestrator-$(date +%Y%m%d-%H%M%S).log" 2>&1 &
 ```
 
@@ -711,7 +717,8 @@ Running `/handle-issues` with `--implement-followups` implies `--enrich-followup
 
 ```bash
 # Launch orchestrator with enrichment + implementation sweep enabled
-nohup "${CLAUDE_PLUGIN_ROOT}/scripts/batch-orchestrator.sh" --manifest "$MANIFEST" --implement-followups \
+BATCH="$(command -v pipeline-core-batch || echo .claude/scripts/batch-orchestrator.sh)"
+nohup "$BATCH" --manifest "$MANIFEST" --implement-followups \
   > "logs/handle-issues/orchestrator-$(date +%Y%m%d-%H%M%S).log" 2>&1 &
 ```
 

--- a/plugins/pipeline-core/skills/implement-issue/SKILL.md
+++ b/plugins/pipeline-core/skills/implement-issue/SKILL.md
@@ -44,10 +44,13 @@ End-to-end issue implementation — reads plan from issue tracker, implements wi
 
 ## Invocation
 
-Immediately launch the orchestrator:
+Immediately launch the orchestrator. Resolve it dual-mode — prefer the plugin bin
+(`pipeline-core-implement`, on PATH when `pipeline-core` is enabled), else fall back to
+the repo-local script:
 
 ```bash
-.claude/scripts/implement-issue-orchestrator.sh \
+IMPL="$(command -v pipeline-core-implement || echo .claude/scripts/implement-issue-orchestrator.sh)"
+"$IMPL" \
   --issue $ISSUE_NUMBER \
   --branch $BASE_BRANCH
 ```
@@ -55,7 +58,8 @@ Immediately launch the orchestrator:
 Or with explicit agent override:
 
 ```bash
-.claude/scripts/implement-issue-orchestrator.sh \
+IMPL="$(command -v pipeline-core-implement || echo .claude/scripts/implement-issue-orchestrator.sh)"
+"$IMPL" \
   --issue $ISSUE_NUMBER \
   --branch $BASE_BRANCH \
   --agent bulletproof-frontend-developer

--- a/plugins/pipeline-core/skills/improvement-loop/SKILL.md
+++ b/plugins/pipeline-core/skills/improvement-loop/SKILL.md
@@ -230,7 +230,8 @@ misroute cannot recur silently across model updates or prompt edits.
 4. **Verify the new fixture passes**
 
    ```bash
-   .claude/scripts/skill-golden.sh triage-classify <issue-id>
+   SKILL_GOLDEN="$(command -v pipeline-core-skill-golden || echo .claude/scripts/skill-golden.sh)"
+   "$SKILL_GOLDEN" triage-classify <issue-id>
    ```
 
    The fixture must pass before committing. If it fails, the prompt or the expected

--- a/plugins/pipeline-core/skills/investigating-codebase-for-user-stories/SKILL.md
+++ b/plugins/pipeline-core/skills/investigating-codebase-for-user-stories/SKILL.md
@@ -269,7 +269,7 @@ Generate stories as issues for sprint planning:
 ### Single Issue Creation
 
 ```bash
-PLATFORM_DIR="${CLAUDE_PLUGIN_ROOT}/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 "$PLATFORM_DIR/create-issue.sh" \
   --title "As a guest, I want to sign up" \
   --body "$(cat docs/user-stories/authentication/guest-signup.md)" \
@@ -283,7 +283,7 @@ Generate `create-issues.sh` alongside stories:
 ```bash
 #!/bin/bash
 # Auto-generated from user stories
-PLATFORM_DIR="${CLAUDE_PLUGIN_ROOT}/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 
 "$PLATFORM_DIR/create-issue.sh" --title "Guest Signup" \
   --body "$(cat docs/user-stories/authentication/guest-signup.md)" \

--- a/plugins/pipeline-core/skills/pipeline-feedback/SKILL.md
+++ b/plugins/pipeline-core/skills/pipeline-feedback/SKILL.md
@@ -70,7 +70,8 @@ After kind is determined, gather the remaining fields. Ask each in one `AskUserQ
 Once fields are collected, invoke:
 
 ```bash
-.claude/scripts/feedback-record.sh \
+FEEDBACK_RECORD="$(command -v pipeline-core-feedback-record || echo .claude/scripts/feedback-record.sh)"
+"$FEEDBACK_RECORD" \
   --kind   "$KIND" \
   --issue  "$ISSUE" \
   --observed "$OBSERVED" \

--- a/plugins/pipeline-core/skills/process-pr/SKILL.md
+++ b/plugins/pipeline-core/skills/process-pr/SKILL.md
@@ -105,7 +105,7 @@ digraph process_pr {
 
 ```bash
 # Verify PR/MR exists and is open
-PLATFORM_DIR=".claude/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 "$PLATFORM_DIR/read-mr-comments.sh" "$PR_NUMBER"
 
 # Verify issue exists and is open
@@ -118,7 +118,7 @@ PLATFORM_DIR=".claude/scripts/platform"
 
 ```bash
 # Get PR/MR comments
-PLATFORM_DIR=".claude/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 "$PLATFORM_DIR/read-mr-comments.sh" "$PR_NUMBER"
 ```
 
@@ -134,7 +134,7 @@ PLATFORM_DIR=".claude/scripts/platform"
 
 ```bash
 # Get comments as JSON array
-PLATFORM_DIR=".claude/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 COMMENTS=$("$PLATFORM_DIR/read-mr-comments.sh" "$PR_NUMBER" | jq -r '.[]')
 ```
 
@@ -225,7 +225,7 @@ fi
 if [[ -n "$MERGE_BLOCKED_REASON" ]]; then
     echo "MERGE BLOCKED: $MERGE_BLOCKED_REASON"
     # Post a comment on the PR explaining why it was not merged
-    PLATFORM_DIR=".claude/scripts/platform"
+    PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
     "$PLATFORM_DIR/comment-mr.sh" "$PR_NUMBER" "$(cat <<EOF
 ## Merge Blocked — Unresolved Quality Feedback
 
@@ -257,7 +257,7 @@ fi
 ### Step 4b: Merge PR/MR
 
 ```bash
-PLATFORM_DIR=".claude/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 "$PLATFORM_DIR/merge-mr.sh" "$PR_NUMBER"
 ```
 
@@ -271,7 +271,7 @@ PLATFORM_DIR=".claude/scripts/platform"
 ### Step 4c: Comment on Issue
 
 ```bash
-PLATFORM_DIR=".claude/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 "$PLATFORM_DIR/comment-issue.sh" "$ISSUE_NUMBER" "$(cat <<'EOF'
 ## Completed
 
@@ -289,7 +289,7 @@ EOF
 ### Step 4d: Close Issue
 
 ```bash
-PLATFORM_DIR=".claude/scripts/platform"
+PLATFORM_DIR="$(pipeline-core-platform-dir 2>/dev/null || echo .claude/scripts/platform)"
 "$PLATFORM_DIR/transition-issue.sh" "$ISSUE_NUMBER"
 ```
 
@@ -354,10 +354,12 @@ Examples:
 
 > **CRITICAL — NEVER use `gh issue create` or `create-issue.sh` directly.** Every follow-up issue MUST go through `create-followup-issue.sh`. It runs `assert_issue_valid` fail-closed before creation, ensuring the body has parseable task lines, a known agent, a resolvable file path, and an `## Acceptance Criteria` section. Writing bodies by hand and bypassing this script produces malformed issues that stall the pipeline and require manual remediation. If `create-followup-issue.sh` exits non-zero for any reason (missing argument, validation failure), log the error and skip that item — do NOT fall back to `gh issue create`.
 
-For each extracted issue, invoke `create-followup-issue.sh`:
+For each extracted issue, invoke `create-followup-issue.sh` (dual-mode: prefer the plugin
+bin `pipeline-core-create-followup-issue`, else the repo-local script):
 
 ```bash
-".claude/scripts/create-followup-issue.sh" \
+CREATE_FOLLOWUP="$(command -v pipeline-core-create-followup-issue || echo .claude/scripts/create-followup-issue.sh)"
+"$CREATE_FOLLOWUP" \
   --title "$ISSUE_TITLE" \
   --description "$EXTRACTED_DESCRIPTION" \
   --task-description "$INFERRED_TASK_DESCRIPTION" \

--- a/tests/marketplace-smoke.bats
+++ b/tests/marketplace-smoke.bats
@@ -306,3 +306,99 @@ JSON
 	run _validate_hooks "$core"
 	[ "$status" -eq 0 ] || { echo "$output" >&2; return 1; }
 }
+
+# ===========================================================================
+# bin entrypoints — self-locating wrappers on the Bash-tool PATH (issue #599 Task 5)
+#
+# When pipeline-core is enabled its bin/ dir is added to PATH by convention, so
+# skills invoke bundled scripts by prefixed name (pipeline-core-*). Each wrapper
+# self-locates its sibling scripts/ dir via ${BASH_SOURCE[0]} — CLAUDE_PLUGIN_ROOT
+# is NOT set in the model's Bash-tool shell (Task 1 finding), so it cannot be used.
+# Skills use a dual-mode guard so they also work repo-local (no plugin):
+#   X="$(command -v pipeline-core-<name> || echo .claude/scripts/<orch>.sh)"; "$X" ...
+# ===========================================================================
+
+# The distinct bin entrypoints and the sibling script each must exec.
+_bin_entrypoints() {
+	cat <<'MAP'
+pipeline-core-implement|implement-issue-orchestrator.sh
+pipeline-core-batch|batch-orchestrator.sh
+pipeline-core-create-followup-issue|create-followup-issue.sh
+pipeline-core-feedback-record|feedback-record.sh
+pipeline-core-skill-golden|skill-golden.sh
+pipeline-core-capture-usage-fixture|capture-usage-fixture.sh
+MAP
+}
+
+@test "bin: every pipeline-core-* wrapper exists and is executable" {
+	local bin_dir="$REPO_ROOT/plugins/pipeline-core/bin"
+	[ -d "$bin_dir" ] || { echo "bin dir missing: $bin_dir" >&2; return 1; }
+
+	local name script
+	while IFS='|' read -r name script; do
+		[ -n "$name" ] || continue
+		[ -f "$bin_dir/$name" ] || { echo "missing wrapper: $name" >&2; return 1; }
+		[ -x "$bin_dir/$name" ] || { echo "not executable: $name" >&2; return 1; }
+	done < <(_bin_entrypoints)
+
+	# The platform-dir resolver is also required.
+	[ -x "$bin_dir/pipeline-core-platform-dir" ] \
+		|| { echo "missing/not executable: pipeline-core-platform-dir" >&2; return 1; }
+}
+
+@test "bin: exec wrappers self-locate scripts/<orch>.sh via BASH_SOURCE and pass args" {
+	local bin_dir="$REPO_ROOT/plugins/pipeline-core/bin"
+	local name script
+	while IFS='|' read -r name script; do
+		[ -n "$name" ] || continue
+
+		# Build a stub plugin layout: bin/<wrapper> + scripts/<orch>.sh (stub).
+		local stub="$TEST_TMP/$name"
+		mkdir -p "$stub/bin" "$stub/scripts"
+		cp "$bin_dir/$name" "$stub/bin/$name"
+		printf '#!/usr/bin/env bash\necho "RAN:%s args=$*"\n' "$script" \
+			> "$stub/scripts/$script"
+		chmod +x "$stub/scripts/$script"
+
+		# Run from an unrelated cwd so resolution can only come from BASH_SOURCE.
+		run bash -c 'cd / && "$1" --issue 7 --branch main' _ "$stub/bin/$name"
+		[ "$status" -eq 0 ] || { echo "$name failed: $output" >&2; return 1; }
+		[[ "$output" == "RAN:$script args=--issue 7 --branch main" ]] \
+			|| { echo "$name resolved wrong: $output" >&2; return 1; }
+	done < <(_bin_entrypoints)
+}
+
+@test "bin: pipeline-core-platform-dir prints the self-located scripts/platform dir" {
+	local bin_dir="$REPO_ROOT/plugins/pipeline-core/bin"
+	local stub="$TEST_TMP/platform"
+	mkdir -p "$stub/bin" "$stub/scripts/platform"
+	cp "$bin_dir/pipeline-core-platform-dir" "$stub/bin/"
+
+	run bash -c 'cd / && "$1"' _ "$stub/bin/pipeline-core-platform-dir"
+	[ "$status" -eq 0 ] || { echo "$output" >&2; return 1; }
+	[ "$output" = "$stub/scripts/platform" ] \
+		|| { echo "got: $output want: $stub/scripts/platform" >&2; return 1; }
+}
+
+@test "skills: no bundle skill has a bare .claude/scripts/*.sh invocation without a guard" {
+	local skills_dir="$REPO_ROOT/plugins/pipeline-core/skills"
+	[ -d "$skills_dir" ] || skip "bundle skills not present"
+
+	# Command-position invocation: line starts (after optional ws / nohup / quote /
+	# leading $) with .claude/scripts/....sh. Prose, tables, and dual-mode guards
+	# (which reference the path only after `echo`) are not command-position, so they
+	# do not match. Any match is an un-guarded hardcoded invocation and must fail.
+	run grep -rnE '^[[:space:]]*(nohup[[:space:]]+)?"?\$?\.claude/scripts/[^ ]*\.sh' \
+		"$skills_dir"
+	[ "$status" -ne 0 ] \
+		|| { echo "bare .claude/scripts invocation(s) found:" >&2; echo "$output" >&2; return 1; }
+}
+
+@test "skills: no bundle skill runs a bundled script via \${CLAUDE_PLUGIN_ROOT} (unset in Bash-tool shell)" {
+	local skills_dir="$REPO_ROOT/plugins/pipeline-core/skills"
+	[ -d "$skills_dir" ] || skip "bundle skills not present"
+
+	run grep -rnE 'CLAUDE_PLUGIN_ROOT' "$skills_dir"
+	[ "$status" -ne 0 ] \
+		|| { echo "CLAUDE_PLUGIN_ROOT used in a skill (use a pipeline-core-* bin instead):" >&2; echo "$output" >&2; return 1; }
+}


### PR DESCRIPTION
Part of #599 (Task 5). Does not close it (hooks/version, consumer settings, sync.sh deprecation remain).

**bin/ entrypoints** (`plugins/pipeline-core/bin/pipeline-core-*`, chmod +x): thin self-locating wrappers (`PLUGIN_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd); exec "$PLUGIN_ROOT/scripts/<orch>.sh" "$@"`). On the Bash-tool PATH by convention when the plugin is enabled (empirically confirmed + docs). Prefixed names avoid the flat-PATH collision risk. No `pipeline-core-explore` — no skill invokes it.

**Skill repoint (dual-mode, AC5):** every bundle-skill invocation now resolves `command -v pipeline-core-<x> || .claude/scripts/<orch>.sh` — works as an enabled plugin AND repo-local/mid-transition. Also fixes the `handle-issues`/`investigating-codebase` `${CLAUDE_PLUGIN_ROOT}/scripts/...` invocations, which were non-functional (var unset in the Bash-tool shell, per Task 1).

**Not touched:** `.claude/skills/` (synced repo-local copies), `hooks.json` (Task 6), prose/doc/example `.claude/scripts` mentions (not invocations).

**Tests:** `marketplace-smoke.bats` 14/14 (+5 new, incl. a verified-non-noop guard test); shellcheck clean on all 7 wrappers.