### PR TITLE
chore(pipeline): pin pipeline-core plugin version 0.2.0 (#599 Task 6)

### DIFF
--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pipeline-core",
-  "version": "0.1.0",
-  "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline.",
+  "version": "0.2.0",
+  "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
Part of #599 (Task 6). **hooks.json needed no change** — it already references its bundled hook via `${CLAUDE_PLUGIN_ROOT}/hooks/scripts/scaffold-placeholder.sh` (the placeholder substitution is valid inside hook command strings), and that script is present in the bundle. So Task 6 reduces to pinning the version.

**Change:** `plugin.json` version 0.1.0 → 0.2.0 + description noting the self-contained bundle (scripts/ + bin/ + hooks) and BASH_SOURCE self-location.

**Follow-up flagged (out of scope):** the plugin `hooks.json` registers only `scaffold-placeholder`; whether `post-pr-simplify` / `detect-core-edit` should also ship in the plugin is a separate hook-completeness decision.

Smoke test green; JSON validated.