### PR TITLE
feat(pipeline): consumer settings + sync.sh deprecation + bundle smoke (#599 Tasks 7-9)

### DIFF
--- a/plugins/pipeline-core/consumer-settings.example.json
+++ b/plugins/pipeline-core/consumer-settings.example.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "claude-pipeline": {
+      "source": {
+        "source": "github",
+        "repo": "stevegrocott/claude-pipeline"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "pipeline-core@claude-pipeline": true
+  }
+}

--- a/sync.sh
+++ b/sync.sh
@@ -337,6 +337,25 @@ list_core() {
     echo "  .claude/skills/ (non-universal skills)"
 }
 
+# Deprecation notice for the script/skill copy path. Marketplace consumers
+# should enable the pipeline-core plugin instead of copying files. Non-fatal:
+# the legacy copy still runs below for mid-transition consumers that have not
+# adopted the plugin marketplace yet.
+print_marketplace_deprecation() {
+    cat <<'NOTICE'
+  ---------------------------------------------------------------------------
+  DEPRECATED: copying .claude/scripts + skills into a consumer is being phased
+  out in favour of the pipeline-core marketplace plugin (no file copying).
+
+  Prefer: merge plugins/pipeline-core/consumer-settings.example.json into the
+  consumer's .claude/settings.json and commit it — Claude Code then resolves
+  scripts, schemas, skills, and hooks from the installed plugin.
+
+  The legacy copy below still runs for mid-transition consumers.
+  ---------------------------------------------------------------------------
+NOTICE
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -349,6 +368,8 @@ case "$COMMAND" in
     to)
         [[ $# -lt 2 ]] && usage
         PROJECT_DIR=$(resolve_project_dir "$2")
+        print_marketplace_deprecation
+        echo ""
         echo "Syncing core files: pipeline → $2"
         echo ""
 

--- a/tests/marketplace-smoke.bats
+++ b/tests/marketplace-smoke.bats
@@ -308,6 +308,61 @@ JSON
 }
 
 # ===========================================================================
+# Bundled runtime — scripts + schemas ship in the plugin and self-resolve
+# (issue #599 Task 9). A marketplace consumer with NO copied .claude/scripts
+# must still get the orchestration engine + JSON schemas from the plugin, and
+# resolve-pipeline-root.sh must locate a bundled schema via BASH_SOURCE alone
+# (CLAUDE_PLUGIN_ROOT is unset in the model's Bash-tool shell — Task 1 finding).
+# ===========================================================================
+
+@test "bundle: pipeline-core ships the orchestrator scripts and schemas" {
+	local scripts_dir="$REPO_ROOT/plugins/pipeline-core/scripts"
+	[ -d "$scripts_dir" ] \
+		|| { echo "scripts dir missing: $scripts_dir" >&2; return 1; }
+
+	local orch
+	for orch in \
+		implement-issue-orchestrator.sh \
+		explore-orchestrator.sh \
+		batch-orchestrator.sh; do
+		[ -f "$scripts_dir/$orch" ] \
+			|| { echo "missing bundled orchestrator: $orch" >&2; return 1; }
+	done
+
+	# JSON schemas ship alongside the scripts under scripts/schemas/.
+	[ -d "$scripts_dir/schemas" ] \
+		|| { echo "schemas dir missing: $scripts_dir/schemas" >&2; return 1; }
+	local schema_count
+	schema_count=$(find "$scripts_dir/schemas" -maxdepth 1 -name '*.json' | wc -l)
+	[ "$schema_count" -gt 0 ] \
+		|| { echo "no *.json schemas under $scripts_dir/schemas" >&2; return 1; }
+}
+
+@test "bundle: resolve-pipeline-root.sh self-resolves a bundled schema (CLAUDE_PLUGIN_ROOT unset)" {
+	local scripts_dir="$REPO_ROOT/plugins/pipeline-core/scripts"
+	local resolver="$scripts_dir/resolve-pipeline-root.sh"
+	[ -f "$resolver" ] \
+		|| { echo "resolver missing: $resolver" >&2; return 1; }
+
+	# Pick a real bundled schema and resolve it by its relative path.
+	local schema
+	schema="$(find "$scripts_dir/schemas" -maxdepth 1 -name '*.json' | head -1)"
+	[ -n "$schema" ] || skip "no bundled schema to resolve"
+	local rel="schemas/$(basename "$schema")"
+
+	# Source the resolver FROM the bundle with CLAUDE_PLUGIN_ROOT unset, so the
+	# only way it can find the schema is BASH_SOURCE self-location.
+	run env -u CLAUDE_PLUGIN_ROOT bash -c '
+		source "$1"
+		resolve_pipeline_file "$2"
+	' _ "$resolver" "$rel"
+
+	[ "$status" -eq 0 ] || { echo "resolver failed: $output" >&2; return 1; }
+	[ "$output" = "$scripts_dir/$rel" ] \
+		|| { echo "resolved wrong: got '$output' want '$scripts_dir/$rel'" >&2; return 1; }
+}
+
+# ===========================================================================
 # bin entrypoints — self-locating wrappers on the Bash-tool PATH (issue #599 Task 5)
 #
 # When pipeline-core is enabled its bin/ dir is added to PATH by convention, so


### PR DESCRIPTION
Part of #599 — the final implementable tasks (7, 8, 9). Completes #599's in-scope work; AC6 (per-consumer rollout, incl. reinstalling the stale pipeline-core@0.1.0 → 0.2.0) remains an explicit follow-up.

**Task 7** — `plugins/pipeline-core/consumer-settings.example.json`: enable pipeline-core via the marketplace, no file copying. Schema verified against live settings + docs (`extraKnownMarketplaces` object-keyed → github repo + `autoUpdate`; `enabledPlugins: {"pipeline-core@claude-pipeline": true}`). Added via **git repo**, not raw-JSON URL.

**Task 8** — `sync.sh` prints a non-fatal deprecation notice on `to <project>` steering to the plugin flow; **legacy copy still runs** for mid-transition consumers.

**Task 9** — `marketplace-smoke.bats`: asserts scripts+schemas are bundled and `resolve-pipeline-root.sh` self-resolves a bundled schema (CLAUDE_PLUGIN_ROOT unset).

Verified: JSON valid; smoke 16/16; shellcheck clean.