### PR TITLE
harden(validator): fail fast when issue-body-lib.sh sourced under non-bash (#601)

### DIFF
--- a/.claude/scripts/implement-issue-test/test-issue-body-lib.bats
+++ b/.claude/scripts/implement-issue-test/test-issue-body-lib.bats
@@ -1231,3 +1231,34 @@ Task 2: test the thing
 	[[ "$output" == *"format"*"Task 1: prose form"* ]]
 	[[ "$output" != *$'\r'* ]]
 }
+
+# =============================================================================
+# bash-host guard (issue #601)
+# =============================================================================
+
+# (a) Structural: the POSIX-portable BASH_VERSION guard block is present.
+@test "bash-host guard: BASH_VERSION check is present in the library" {
+	run grep -F 'if [ -z "${BASH_VERSION:-}" ]; then' "$LIB_PATH"
+	[ "$status" -eq 0 ]
+	run grep -F 'requires bash' "$LIB_PATH"
+	[ "$status" -eq 0 ]
+}
+
+# (b) Functional: sourcing under a non-bash shell (zsh) fails fast with a clear
+# message. NOTE macOS /bin/sh is bash-in-posix-mode and SETS BASH_VERSION, so
+# it is unsuitable for this check — use zsh. Skip when zsh is unavailable.
+@test "bash-host guard: sourcing under zsh errors non-zero with a clear message" {
+	if ! command -v zsh >/dev/null 2>&1; then
+		skip "zsh not available"
+	fi
+	run zsh -c "source '$LIB_PATH'"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"requires bash"* ]]
+}
+
+# (c) Regression: under bash the lib still sources cleanly and validates a
+# known-good body.
+@test "bash-host guard: under bash the lib sources and assert_issue_valid still passes" {
+	run assert_issue_valid "$(valid_body)"
+	[ "$status" -eq 0 ]
+}

--- a/.claude/scripts/issue-body-lib.sh
+++ b/.claude/scripts/issue-body-lib.sh
@@ -43,6 +43,16 @@
 #   _extract_task_files_from_desc  (path token extraction)
 #
 
+# Bash-host guard (issue #601) — this library uses bash-only builtins (shopt,
+# [[ =~ ]], BASH_SOURCE).  When sourced under a non-bash shell (e.g. zsh, the
+# macOS default) it would otherwise emit spurious validation verdicts instead
+# of erroring.  Fail fast with a clear message.  Kept POSIX-portable ([ ], not
+# [[ ]]) so a non-bash shell parses it.
+if [ -z "${BASH_VERSION:-}" ]; then
+    printf '%s\n' "issue-body-lib.sh: requires bash (sourced under a non-bash shell)." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 # Idempotent source guard — re-sourcing is a no-op so readonly constants and
 # repeated `source` calls never error.
 [[ -n "${_ISSUE_BODY_LIB_SOURCED:-}" ]] && return 0


### PR DESCRIPTION
Closes #601. Adds a POSIX-portable `BASH_VERSION` guard at the top of `issue-body-lib.sh` — sourcing under a non-bash shell (zsh) now errors clearly + non-zero instead of emitting spurious `assert_issue_valid` verdicts. Bats 93/93 (structural + zsh-functional + bash regression); shellcheck clean.