### PR TITLE
fix(plugin): drop redundant manifest hooks field (duplicate-hooks load failure)

### DIFF
--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
-  "skills": "./skills",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills"
 }


### PR DESCRIPTION
Discovered during the #610 rollout: `claude plugin list` failed to load pipeline-core with *"Duplicate hooks file detected: ./hooks/hooks.json"*. `plugin.json` declared `"hooks": "./hooks/hooks.json"`, but Claude Code auto-loads `hooks/hooks.json` by convention — the manifest field should only reference *additional* hook files. Removed it (hooks still auto-load); version 0.2.0 → 0.2.1. `claude plugin list` now loads the plugin cleanly. Note: static `claude plugin validate` passed — only runtime load caught this.