### PR TITLE
fix(orchestrator): raise turn budget for oversized S tasks

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -2305,6 +2305,14 @@ run_stage() {
     # fix/fix-review-* gets a dedicated sonnet cap (env: MAX_TURNS_FIX_REVIEW,
     # default 20) — targeted corrections, less scope than implement/review.
     # pr/pr-review/research turn limits are unchanged.
+    # One-shot task-description length hint, set by the task-launch site
+    # immediately before calling run_stage.  Consumed and cleared here so a
+    # stale value can never raise the budget of an unrelated later stage.
+    local _stage_desc_len="${_RUN_STAGE_DESC_LEN:-0}"
+    local _promote_chars="${TASK_DESC_PROMOTE_CHARS:-200}"
+    unset _RUN_STAGE_DESC_LEN
+    [[ "$_stage_desc_len" =~ ^[0-9]+$ ]] || _stage_desc_len=0
+
     local -a turns_args=()
     local _matched_prefix _inherent_tier
     _matched_prefix=$(_match_stage_prefix "$stage_name") || true
@@ -2334,6 +2342,16 @@ run_stage() {
         if [[ "$complexity" == "M" || "$complexity" == "L" ]]; then
             turns_args=(--max-turns 40)
             log "  Max turns: 40 (sonnet with M/L complexity)"
+        elif (( _stage_desc_len > _promote_chars )); then
+            # Oversized (S) task — almost certainly mis-sized.  18 of 30
+            # recorded max-turns failures died at exactly this 25-turn cap.
+            # Raise ONLY the turn budget to the M/L value; task_size itself is
+            # deliberately left at S because size also drives review attempts,
+            # the quality loop, model routing and docs skipping — promoting it
+            # would re-introduce the Opus/quality cost that issue #579 removed.
+            turns_args=(--max-turns 40)
+            log "  Max turns: 40 (sonnet S-complexity, oversized description:" \
+                "${_stage_desc_len} chars > ${_promote_chars}, env: TASK_DESC_PROMOTE_CHARS)"
         else
             turns_args=(--max-turns 25)
             log "  Max turns: 25 (sonnet with S/empty complexity)"
@@ -4903,6 +4921,11 @@ Commit your changes with a descriptive message."
 				"timeout ${current_timeout}s"
 		fi
 
+		# Hand run_stage the task-description length so an oversized (S)
+		# task gets the M/L turn budget instead of dying at 25 turns.
+		# run_stage runs in a command substitution (subshell), so its own
+		# unset cannot reach us — clear it here too.
+		_RUN_STAGE_DESC_LEN=${#task_desc}
 		if [[ -n "$current_model" ]]; then
 			impl_result=$(run_stage \
 				"implement-task-$task_id" \
@@ -4917,6 +4940,7 @@ Commit your changes with a descriptive message."
 				"implement-issue-implement.json" \
 				"$task_agent" "$task_size")
 		fi
+		unset _RUN_STAGE_DESC_LEN
 		_halt_if_budget_exceeded
 
 		local impl_status

--- a/.claude/scripts/implement-issue-test/test-stage-runner.bats
+++ b/.claude/scripts/implement-issue-test/test-stage-runner.bats
@@ -1306,6 +1306,67 @@ EOF
 }
 
 # -----------------------------------------------------------------------------
+# Oversized S-task turn-budget promotion.
+#
+# An (S)-marked task whose description exceeds TASK_DESC_PROMOTE_CHARS is
+# very likely mis-sized: 18 of 30 recorded max-turns failures died at exactly
+# the 25-turn S cap.  Raise ONLY the turn budget to the M/L value — task_size
+# itself is deliberately NOT promoted, because size also drives review
+# attempts, the quality loop, model routing and docs skipping (issue #579
+# cost policy).
+# -----------------------------------------------------------------------------
+
+@test "run_stage raises S-complexity turn budget when task description is oversized" {
+    source "$MODEL_CONFIG_ARRAYS_FILE"
+    timeout() {
+        shift; shift; shift; shift
+        echo '{"result":"ok","structured_output":{"status":"success"}}'
+    }
+    export -f timeout
+
+    _RUN_STAGE_DESC_LEN=250
+    run_stage "implement-task-1" "prompt" "test-schema.json" "" "S" "" "sonnet"
+
+    grep -q "Max turns: 40 (sonnet S-complexity, oversized description" "$LOG_FILE" || \
+        fail "Expected raised turn budget for oversized S task. Log: $(cat "$LOG_FILE")"
+}
+
+@test "run_stage keeps the 25-turn S budget for a normally-sized description" {
+    source "$MODEL_CONFIG_ARRAYS_FILE"
+    timeout() {
+        shift; shift; shift; shift
+        echo '{"result":"ok","structured_output":{"status":"success"}}'
+    }
+    export -f timeout
+
+    _RUN_STAGE_DESC_LEN=120
+    run_stage "implement-task-1" "prompt" "test-schema.json" "" "S" "" "sonnet"
+
+    grep -q "Max turns: 25 (sonnet with S/empty complexity)" "$LOG_FILE" || \
+        fail "Expected unchanged 25-turn budget. Log: $(cat "$LOG_FILE")"
+}
+
+@test "run_stage clears the description-length hint so it cannot leak to later stages" {
+    source "$MODEL_CONFIG_ARRAYS_FILE"
+    timeout() {
+        shift; shift; shift; shift
+        echo '{"result":"ok","structured_output":{"status":"success"}}'
+    }
+    export -f timeout
+
+    _RUN_STAGE_DESC_LEN=250
+    run_stage "implement-task-1" "prompt" "test-schema.json" "" "S" "" "sonnet"
+
+    [[ -z "${_RUN_STAGE_DESC_LEN:-}" ]] || \
+        fail "_RUN_STAGE_DESC_LEN leaked after run_stage: '${_RUN_STAGE_DESC_LEN}'"
+
+    : > "$LOG_FILE"
+    run_stage "implement-task-2" "prompt" "test-schema.json" "" "S" "" "sonnet"
+    grep -q "Max turns: 25 (sonnet with S/empty complexity)" "$LOG_FILE" || \
+        fail "Second stage inherited the raised budget. Log: $(cat "$LOG_FILE")"
+}
+
+# -----------------------------------------------------------------------------
 # pr / pr-review budgets are intentionally unchanged by the stage-type-aware
 # override — verify they still get their original caps (10 / 10) and that the
 # new MAX_TURNS_SIMPLIFY / MAX_TURNS_FIX_REVIEW env vars do not affect them.


### PR DESCRIPTION
Raises the turn budget to the M/L value (40) for an `(S)` task whose description exceeds `TASK_DESC_PROMOTE_CHARS` (default 200), instead of letting it die at the 25-turn S cap.

**Why:** 18 of 30 recorded `error_max_turns` failures died at exactly 26 turns (the 25 cap + 1), including #614 tasks 2-3 and #615 tasks 1-2. The orchestrator already computed a `Task N description is X chars` warning and discarded it; this acts on that signal.

**Scope — deliberately narrow.** Only the turn budget is raised; `task_size` stays `S`. Size also drives review attempts, the quality loop, model routing and docs skipping, so promoting it would re-introduce the Opus/quality spend that #579 removed.

`run_stage` is invoked in a command substitution (subshell), so its own `unset` cannot reach the caller — the hint is cleared at the call site too, preventing a raised budget leaking into later stages.

**Limits:** addresses the 18 failures at the 25-turn cap. The 11 that died at 41 turns already had the 40-turn budget and are untouched — those need real decomposition (#581).

**Tests:** 3 new (raise / no-raise / no-leak). Full suite 111/111.

Refs #579, #581