### PR TITLE
fix(plugin): port turn-budget promotion to the bundled orchestrator

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -5772,6 +5772,9 @@ Commit your changes with a descriptive message."
 					"timeout ${current_timeout}s"
 			fi
 
+			# Oversized-(S) turn-budget hint; cleared after because
+			# run_stage runs in a subshell and cannot unset it for us.
+			_RUN_STAGE_DESC_LEN=${#tdesc}
 			if [[ -n "$current_model" ]]; then
 				impl_result=$(run_stage \
 					"implement-task-$tid" \
@@ -5787,6 +5790,7 @@ Commit your changes with a descriptive message."
 					"implement-issue-implement.json" \
 					"$tagent" "$tsize")
 			fi
+			unset _RUN_STAGE_DESC_LEN
 			_halt_if_budget_exceeded
 
 			local impl_status

--- a/plugins/pipeline-core/scripts/implement-issue-orchestrator.sh
+++ b/plugins/pipeline-core/scripts/implement-issue-orchestrator.sh
@@ -2324,6 +2324,14 @@ run_stage() {
     # fix/fix-review-* gets a dedicated sonnet cap (env: MAX_TURNS_FIX_REVIEW,
     # default 20) — targeted corrections, less scope than implement/review.
     # pr/pr-review/research turn limits are unchanged.
+    # One-shot task-description length hint, set by the task-launch site
+    # immediately before calling run_stage.  Consumed and cleared here so a
+    # stale value can never raise the budget of an unrelated later stage.
+    local _stage_desc_len="${_RUN_STAGE_DESC_LEN:-0}"
+    local _promote_chars="${TASK_DESC_PROMOTE_CHARS:-200}"
+    unset _RUN_STAGE_DESC_LEN
+    [[ "$_stage_desc_len" =~ ^[0-9]+$ ]] || _stage_desc_len=0
+
     local -a turns_args=()
     local _matched_prefix _inherent_tier
     _matched_prefix=$(_match_stage_prefix "$stage_name") || true
@@ -2353,6 +2361,16 @@ run_stage() {
         if [[ "$complexity" == "M" || "$complexity" == "L" ]]; then
             turns_args=(--max-turns 40)
             log "  Max turns: 40 (sonnet with M/L complexity)"
+        elif (( _stage_desc_len > _promote_chars )); then
+            # Oversized (S) task — almost certainly mis-sized.  18 of 30
+            # recorded max-turns failures died at exactly this 25-turn cap.
+            # Raise ONLY the turn budget to the M/L value; task_size itself is
+            # deliberately left at S because size also drives review attempts,
+            # the quality loop, model routing and docs skipping — promoting it
+            # would re-introduce the Opus/quality cost that issue #579 removed.
+            turns_args=(--max-turns 40)
+            log "  Max turns: 40 (sonnet S-complexity, oversized description:" \
+                "${_stage_desc_len} chars > ${_promote_chars}, env: TASK_DESC_PROMOTE_CHARS)"
         else
             turns_args=(--max-turns 25)
             log "  Max turns: 25 (sonnet with S/empty complexity)"
@@ -4918,6 +4936,11 @@ Commit your changes with a descriptive message."
 				"timeout ${current_timeout}s"
 		fi
 
+		# Hand run_stage the task-description length so an oversized (S)
+		# task gets the M/L turn budget instead of dying at 25 turns.
+		# run_stage runs in a command substitution (subshell), so its own
+		# unset cannot reach us — clear it here too.
+		_RUN_STAGE_DESC_LEN=${#task_desc}
 		if [[ -n "$current_model" ]]; then
 			impl_result=$(run_stage \
 				"implement-task-$task_id" \
@@ -4932,6 +4955,7 @@ Commit your changes with a descriptive message."
 				"implement-issue-implement.json" \
 				"$task_agent" "$task_size")
 		fi
+		unset _RUN_STAGE_DESC_LEN
 		_halt_if_budget_exceeded
 
 		local impl_status
@@ -5763,6 +5787,9 @@ Commit your changes with a descriptive message."
 					"timeout ${current_timeout}s"
 			fi
 
+			# Oversized-(S) turn-budget hint; cleared after because
+			# run_stage runs in a subshell and cannot unset it for us.
+			_RUN_STAGE_DESC_LEN=${#tdesc}
 			if [[ -n "$current_model" ]]; then
 				impl_result=$(run_stage \
 					"implement-task-$tid" \
@@ -5778,6 +5805,7 @@ Commit your changes with a descriptive message."
 					"implement-issue-implement.json" \
 					"$tagent" "$tsize")
 			fi
+			unset _RUN_STAGE_DESC_LEN
 			_halt_if_budget_exceeded
 
 			local impl_status


### PR DESCRIPTION
`v0.3.0` shipped the **plugin** copy of `implement-issue-orchestrator.sh`, which lacked the oversized-(S) turn-budget promotion from #619 — that change landed only in `.claude/scripts/`. Consumers installing `pipeline-core` did not get the fix.

Also closes a gap in the original #619 change: only `run_task_in_worktree` set the description-length hint, so tasks executed via `execute_batch_serial` never got the raised budget. **Both call sites are now wired in both copies.**

Verified: both files pass `bash -n`, both declare `TASK_DESC_PROMOTE_CHARS`, both have 2 hint sites. Suite 111/111.

Follow-up filed separately for the underlying divergence — two hand-maintained copies with no sync rule and no tests over the bundled one.

Refs #619, #614