### PR TITLE
fix(plugin): route platform.sh through the consumer resolver everywhere

### DIFF
--- a/.claude/scripts/batch-orchestrator.sh
+++ b/.claude/scripts/batch-orchestrator.sh
@@ -66,7 +66,16 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCHEMA_DIR="$SCRIPT_DIR/schemas"
-source "$SCRIPT_DIR/../config/platform.sh"
+# shellcheck source=resolve-pipeline-root.sh
+source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 source "$SCRIPT_DIR/issue-body-lib.sh"
 # claude-usage.sh provides is_model_exhausted / model_reset_at for the
 # pre-flight log line. Sourcing is no-op when CLAUDE_USAGE_SESSION_KEY is

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -53,7 +53,16 @@ source "$SCRIPT_DIR/model-config.sh"
 source "$SCRIPT_DIR/claude-usage.sh"
 # shellcheck source=prompts/triage-prompt.sh
 source "$SCRIPT_DIR/prompts/triage-prompt.sh"
-source "$SCRIPT_DIR/../config/platform.sh"
+# shellcheck source=resolve-pipeline-root.sh
+source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 PLATFORM_DIR="$SCRIPT_DIR/platform"
 
 # Resolve PLATFORM_CONTEXT_FILE to an absolute path so file checks work regardless of CWD

--- a/.claude/scripts/implement-issue-test/test-integration.bats
+++ b/.claude/scripts/implement-issue-test/test-integration.bats
@@ -1053,11 +1053,33 @@ teardown() {
 # PLATFORM CONFIG SOURCING
 # =============================================================================
 
-@test "orchestrator sources platform config" {
+@test "orchestrator sources platform config via the consumer resolver" {
     local script_content
     script_content=$(cat "$ORCHESTRATOR_SCRIPT")
 
-    [[ "$script_content" == *'source "$SCRIPT_DIR/../config/platform.sh"'* ]]
+    # Must resolve platform.sh through resolve_consumer_file, NOT by hardcoding
+    # "$SCRIPT_DIR/../config/platform.sh" — that path does not exist inside the
+    # plugin bundle, which ships no config/ dir, so consumers silently got an
+    # unset TRACKER / DEPLOY_VERIFY_CMD / MAX_* set.
+    [[ "$script_content" == *'resolve_consumer_file platform.sh'* ]]
+    [[ "$script_content" != *'source "$SCRIPT_DIR/../config/platform.sh"'* ]]
+}
+
+@test "no pipeline script hardcodes ../config/platform.sh" {
+    local offenders=""
+    local d
+    for d in "$SCRIPT_DIR" "$SCRIPT_DIR/platform"; do
+        [[ -d "$d" ]] || continue
+        local f
+        for f in "$d"/*.sh; do
+            [[ -f "$f" ]] || continue
+            [[ "$(basename "$f")" == "resolve-pipeline-root.sh" ]] && continue
+            if grep -q 'SCRIPT_DIR/\.\./config/platform\.sh\|SCRIPT_DIR/\.\./\.\./config/platform\.sh' "$f"; then
+                offenders+=" $(basename "$f")"
+            fi
+        done
+    done
+    [[ -z "$offenders" ]] || fail "hardcoded platform.sh source in:$offenders"
 }
 
 @test "orchestrator sets PLATFORM_DIR" {

--- a/.claude/scripts/platform-test/helpers/test-helper.bash
+++ b/.claude/scripts/platform-test/helpers/test-helper.bash
@@ -29,20 +29,31 @@ setup_test_env() {
 
     # -----------------------------------------------------------------
     # Create a mock platform.sh config in the location the platform
-    # scripts expect: ../../config/platform.sh relative to SCRIPT_DIR.
-    # Instead of modifying the real config we override the sourcing by
-    # placing a shim config alongside the real platform scripts.
-    # The platform scripts do:
+    # scripts resolve to. The platform scripts do:
     #   SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-    #   source "$SCRIPT_DIR/../../config/platform.sh"
-    # So we create $TEST_TMP/config/platform.sh and symlink the scripts
-    # into $TEST_TMP/scripts/platform/ so the relative path resolves.
+    #   source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+    #   PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)"
+    # resolve_consumer_file's lookups are:
+    #   1. $PIPELINE_CONFIG_DIR/<rel>
+    #   2. <git-toplevel-or-PWD>/.claude/config/<rel>
+    #   3. <lib-dir>/../config/<rel>
+    # Lookup 3 would land on $TEST_TMP/config/platform.sh, but the suite
+    # runs with CWD inside this repo, so lookup 2 wins first and resolves
+    # the REAL .claude/config/platform.sh — silently shadowing the mock
+    # and leaving JIRA_* unset. Pin lookup 1 at the fixture so resolution
+    # is deterministic regardless of where bats is invoked from.
     # -----------------------------------------------------------------
     mkdir -p "$TEST_TMP/scripts/platform"
     mkdir -p "$TEST_TMP/config"
 
     # Copy all platform scripts to the temp location
     cp "$SCRIPT_DIR"/*.sh "$TEST_TMP/scripts/platform/"
+
+    # The resolver library the platform scripts source (one level up)
+    cp "$SCRIPT_DIR/../resolve-pipeline-root.sh" "$TEST_TMP/scripts/"
+
+    # Pin config resolution at the fixture (lookup 1 beats lookups 2 and 3)
+    export PIPELINE_CONFIG_DIR="$TEST_TMP/config"
 
     # Set default platform config values
     export TRACKER="github"

--- a/.claude/scripts/platform/comment-issue.sh
+++ b/.claude/scripts/platform/comment-issue.sh
@@ -2,8 +2,16 @@
 # Usage: comment-issue.sh <issue-number-or-key> "Comment body" [repo]
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLATFORM_CONFIG="$SCRIPT_DIR/../../config/platform.sh"
-if [[ -f "$PLATFORM_CONFIG" ]]; then source "$PLATFORM_CONFIG"; fi
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 ISSUE="$1" COMMENT="$2" REPO_ARG="${3:-}"
 

--- a/.claude/scripts/platform/comment-mr.sh
+++ b/.claude/scripts/platform/comment-mr.sh
@@ -3,8 +3,16 @@
 # Adds a comment to a PR (GitHub) or MR (GitLab)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLATFORM_CONFIG="$SCRIPT_DIR/../../config/platform.sh"
-if [[ -f "$PLATFORM_CONFIG" ]]; then source "$PLATFORM_CONFIG"; fi
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 MR="$1" COMMENT="$2" REPO_ARG="${3:-}"
 

--- a/.claude/scripts/platform/create-issue.sh
+++ b/.claude/scripts/platform/create-issue.sh
@@ -3,7 +3,16 @@
 # Returns: issue number or key on stdout (e.g., "42" or "KIN-123")
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 TITLE="" BODY="" LABELS="" PARENT=""
 while [[ $# -gt 0 ]]; do

--- a/.claude/scripts/platform/create-mr.sh
+++ b/.claude/scripts/platform/create-mr.sh
@@ -3,7 +3,16 @@
 # Returns: MR/PR number on stdout
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 SOURCE="" TARGET="" TITLE="" BODY=""
 while [[ $# -gt 0 ]]; do

--- a/.claude/scripts/platform/find-mr.sh
+++ b/.claude/scripts/platform/find-mr.sh
@@ -3,7 +3,16 @@
 # Returns: MR/PR number if found, empty string if not
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 BRANCH="" STATE="open"
 while [[ $# -gt 0 ]]; do

--- a/.claude/scripts/platform/list-issues.sh
+++ b/.claude/scripts/platform/list-issues.sh
@@ -5,7 +5,16 @@
 # For Jira: uses JQL (auto-built from flags or explicit --jql)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 JQL="" STATE="open" ASSIGNEE="" LABELS=""
 while [[ $# -gt 0 ]]; do

--- a/.claude/scripts/platform/merge-mr.sh
+++ b/.claude/scripts/platform/merge-mr.sh
@@ -2,7 +2,16 @@
 # Usage: merge-mr.sh <mr-number>
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 MR="$1"
 

--- a/.claude/scripts/platform/read-issue.sh
+++ b/.claude/scripts/platform/read-issue.sh
@@ -4,7 +4,16 @@
 # Body is always returned as plain markdown text.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 ISSUE="$1"
 

--- a/.claude/scripts/platform/read-mr-comments.sh
+++ b/.claude/scripts/platform/read-mr-comments.sh
@@ -3,7 +3,16 @@
 # Returns: JSON array of comment bodies
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 MR="$1"
 

--- a/.claude/scripts/platform/transition-issue.sh
+++ b/.claude/scripts/platform/transition-issue.sh
@@ -4,7 +4,16 @@
 # Jira: transitions to the named state (defaults to JIRA_DONE_TRANSITION)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 ISSUE="$1"
 TRANSITION="${2:-${JIRA_DONE_TRANSITION:-}}"

--- a/.claude/scripts/post-batch-validate.sh
+++ b/.claude/scripts/post-batch-validate.sh
@@ -21,7 +21,16 @@ set -uo pipefail
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../config/platform.sh"
+# shellcheck source=resolve-pipeline-root.sh
+source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 HEALTH_URL="http://localhost:30004/health"
 HEALTH_TIMEOUT=120      # seconds to poll /health after Docker rebuild

--- a/.claude/scripts/resolve-pipeline-root.sh
+++ b/.claude/scripts/resolve-pipeline-root.sh
@@ -22,10 +22,17 @@
 # identically in the plugin bundle and in the repo-local .claude/scripts/ layout.
 # That makes the repo-local fallback inherent: no big-bang cutover needed.
 #
+# A companion resolver, resolve_consumer_file(), handles the opposite case:
+# per-repo config (platform.sh, context.md) that lives OUTSIDE the bundle, in
+# whichever repo installed the plugin. See its docstring below for details.
+#
 # Usage:
 #   source "$SCRIPT_DIR/resolve-pipeline-root.sh"
 #   schema="$(resolve_pipeline_file schemas/stage-result.json)" || {
 #       echo "schema not found" >&2; exit 1;
+#   }
+#   platform="$(resolve_consumer_file platform.sh)" || {
+#       echo "platform.sh not found" >&2; exit 1;
 #   }
 #
 # resolve_pipeline_file <relative/path>
@@ -34,6 +41,15 @@
 #        non-empty AND the file exists there.
 #     2. <dir-of-this-library>/<rel>        — self-location via BASH_SOURCE; the
 #        canonical path for both layouts.
+#   On a hit: prints the absolute path and returns 0.
+#   On a miss (or empty argument): prints nothing and returns non-zero.
+#
+# resolve_consumer_file <relative/path>
+#   Prints the first existing absolute path for <relative/path> under the
+#   CONSUMER repo's .claude/config/, searching:
+#     1. $PIPELINE_CONFIG_DIR/<rel>              — explicit override.
+#     2. <git-toplevel-or-PWD>/.claude/config/<rel> — the consumer repo root.
+#     3. <dir-of-this-library>/../config/<rel>   — legacy repo-local fallback.
 #   On a hit: prints the absolute path and returns 0.
 #   On a miss (or empty argument): prints nothing and returns non-zero.
 
@@ -63,6 +79,55 @@ if [[ -z "${_RESOLVE_PIPELINE_ROOT_SOURCED:-}" ]]; then
         #    bundle and the repo-local .claude/scripts/ layout alike.
         if [[ -e "${_PIPELINE_SCRIPTS_DIR}/${rel}" ]]; then
             printf '%s\n' "${_PIPELINE_SCRIPTS_DIR}/${rel}"
+            return 0
+        fi
+
+        return 1
+    }
+
+    # resolve_consumer_file <relative/path>
+    #   Prints the first existing absolute path for <relative/path> within a
+    #   CONSUMER repo's .claude/config/ directory — distinct from
+    #   resolve_pipeline_file() above, which resolves assets that ship
+    #   INSIDE the bundle (schemas, prompts). Consumer config (platform.sh,
+    #   context.md) by definition lives OUTSIDE the bundle, in the repo that
+    #   installed the plugin, so it needs its own root anchor. Searches:
+    #     1. $PIPELINE_CONFIG_DIR/<rel>   — explicit override; useful in
+    #        CI/tests. Honored only when set AND the file exists there.
+    #     2. <git-toplevel-or-PWD>/.claude/config/<rel> — the consumer repo
+    #        root, resolved via `git rev-parse --show-toplevel`, falling
+    #        back to $PWD when not inside a git repo.
+    #     3. <dir-of-this-library>/../config/<rel> — legacy repo-local
+    #        fallback. Identical file to (2) in the repo-local layout, so
+    #        existing consumers see no behavior change.
+    #   On a hit: prints the absolute path and returns 0.
+    #   On a miss (or empty argument): prints nothing and returns non-zero.
+    resolve_consumer_file() {
+        local rel="$1"
+        [[ -n "$rel" ]] || return 1
+
+        # 1. Explicit override via PIPELINE_CONFIG_DIR (e.g. CI/tests).
+        if [[ -n "${PIPELINE_CONFIG_DIR:-}" && \
+            -e "${PIPELINE_CONFIG_DIR}/${rel}" ]]; then
+            printf '%s\n' "${PIPELINE_CONFIG_DIR}/${rel}"
+            return 0
+        fi
+
+        # 2. Consumer repo root: git toplevel, falling back to $PWD when
+        #    not inside a git repo (e.g. a stripped-down CI checkout).
+        local consumer_root
+        consumer_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+        consumer_root="${consumer_root:-$PWD}"
+        if [[ -e "${consumer_root}/.claude/config/${rel}" ]]; then
+            printf '%s\n' "${consumer_root}/.claude/config/${rel}"
+            return 0
+        fi
+
+        # 3. Legacy fallback: config/ sibling of this library's scripts/
+        #    dir. Normalize away the ".." so callers get a clean path.
+        local legacy_config_dir="${_PIPELINE_SCRIPTS_DIR}/../config"
+        if [[ -e "${legacy_config_dir}/${rel}" ]]; then
+            printf '%s\n' "$(cd "$legacy_config_dir" && pwd)/${rel}"
             return 0
         fi
 

--- a/.claude/scripts/surgical-fast-path.sh
+++ b/.claude/scripts/surgical-fast-path.sh
@@ -26,10 +26,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCHEMA_DIR="${SCHEMA_DIR:-$SCRIPT_DIR/schemas}"
 
-if [[ -f "$SCRIPT_DIR/../config/platform.sh" ]]; then
-    # shellcheck disable=SC1091
-    source "$SCRIPT_DIR/../config/platform.sh"
-fi
+# shellcheck source=resolve-pipeline-root.sh
+source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 if [[ -f "$SCRIPT_DIR/model-config.sh" ]]; then
     # shellcheck disable=SC1091
     source "$SCRIPT_DIR/model-config.sh"

--- a/.claude/scripts/test-fix-loop.sh
+++ b/.claude/scripts/test-fix-loop.sh
@@ -22,7 +22,16 @@ set -uo pipefail  # Note: not -e, we handle errors explicitly
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../config/platform.sh"
+# shellcheck source=resolve-pipeline-root.sh
+source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 source "$SCRIPT_DIR/model-config.sh"
 
 # Limits

--- a/plugins/pipeline-core/scripts/batch-orchestrator.sh
+++ b/plugins/pipeline-core/scripts/batch-orchestrator.sh
@@ -66,7 +66,16 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCHEMA_DIR="$SCRIPT_DIR/schemas"
-source "$SCRIPT_DIR/../config/platform.sh"
+# shellcheck source=resolve-pipeline-root.sh
+source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 source "$SCRIPT_DIR/issue-body-lib.sh"
 # claude-usage.sh provides is_model_exhausted / model_reset_at for the
 # pre-flight log line. Sourcing is no-op when CLAUDE_USAGE_SESSION_KEY is

--- a/plugins/pipeline-core/scripts/platform/comment-issue.sh
+++ b/plugins/pipeline-core/scripts/platform/comment-issue.sh
@@ -2,8 +2,16 @@
 # Usage: comment-issue.sh <issue-number-or-key> "Comment body" [repo]
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLATFORM_CONFIG="$SCRIPT_DIR/../../config/platform.sh"
-if [[ -f "$PLATFORM_CONFIG" ]]; then source "$PLATFORM_CONFIG"; fi
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 ISSUE="$1" COMMENT="$2" REPO_ARG="${3:-}"
 

--- a/plugins/pipeline-core/scripts/platform/comment-mr.sh
+++ b/plugins/pipeline-core/scripts/platform/comment-mr.sh
@@ -3,8 +3,16 @@
 # Adds a comment to a PR (GitHub) or MR (GitLab)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLATFORM_CONFIG="$SCRIPT_DIR/../../config/platform.sh"
-if [[ -f "$PLATFORM_CONFIG" ]]; then source "$PLATFORM_CONFIG"; fi
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 MR="$1" COMMENT="$2" REPO_ARG="${3:-}"
 

--- a/plugins/pipeline-core/scripts/platform/create-issue.sh
+++ b/plugins/pipeline-core/scripts/platform/create-issue.sh
@@ -3,7 +3,16 @@
 # Returns: issue number or key on stdout (e.g., "42" or "KIN-123")
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 TITLE="" BODY="" LABELS="" PARENT=""
 while [[ $# -gt 0 ]]; do

--- a/plugins/pipeline-core/scripts/platform/create-mr.sh
+++ b/plugins/pipeline-core/scripts/platform/create-mr.sh
@@ -3,7 +3,16 @@
 # Returns: MR/PR number on stdout
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 SOURCE="" TARGET="" TITLE="" BODY=""
 while [[ $# -gt 0 ]]; do

--- a/plugins/pipeline-core/scripts/platform/find-mr.sh
+++ b/plugins/pipeline-core/scripts/platform/find-mr.sh
@@ -3,7 +3,16 @@
 # Returns: MR/PR number if found, empty string if not
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 BRANCH="" STATE="open"
 while [[ $# -gt 0 ]]; do

--- a/plugins/pipeline-core/scripts/platform/list-issues.sh
+++ b/plugins/pipeline-core/scripts/platform/list-issues.sh
@@ -5,7 +5,16 @@
 # For Jira: uses JQL (auto-built from flags or explicit --jql)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 JQL="" STATE="open" ASSIGNEE="" LABELS=""
 while [[ $# -gt 0 ]]; do

--- a/plugins/pipeline-core/scripts/platform/merge-mr.sh
+++ b/plugins/pipeline-core/scripts/platform/merge-mr.sh
@@ -2,7 +2,16 @@
 # Usage: merge-mr.sh <mr-number>
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 MR="$1"
 

--- a/plugins/pipeline-core/scripts/platform/read-issue.sh
+++ b/plugins/pipeline-core/scripts/platform/read-issue.sh
@@ -4,7 +4,16 @@
 # Body is always returned as plain markdown text.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 ISSUE="$1"
 

--- a/plugins/pipeline-core/scripts/platform/read-mr-comments.sh
+++ b/plugins/pipeline-core/scripts/platform/read-mr-comments.sh
@@ -3,7 +3,16 @@
 # Returns: JSON array of comment bodies
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 MR="$1"
 

--- a/plugins/pipeline-core/scripts/platform/transition-issue.sh
+++ b/plugins/pipeline-core/scripts/platform/transition-issue.sh
@@ -4,10 +4,19 @@
 # Jira: transitions to the named state (defaults to JIRA_DONE_TRANSITION)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/../../config/platform.sh"
+# shellcheck source=../resolve-pipeline-root.sh
+source "$SCRIPT_DIR/../resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 ISSUE="$1"
-TRANSITION="${2:-$JIRA_DONE_TRANSITION}"
+TRANSITION="${2:-${JIRA_DONE_TRANSITION:-}}"
 
 case "$TRACKER" in
   github) gh issue close "$ISSUE" ;;

--- a/plugins/pipeline-core/scripts/post-batch-validate.sh
+++ b/plugins/pipeline-core/scripts/post-batch-validate.sh
@@ -21,7 +21,16 @@ set -uo pipefail
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../config/platform.sh"
+# shellcheck source=resolve-pipeline-root.sh
+source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 
 HEALTH_URL="http://localhost:30004/health"
 HEALTH_TIMEOUT=120      # seconds to poll /health after Docker rebuild

--- a/plugins/pipeline-core/scripts/surgical-fast-path.sh
+++ b/plugins/pipeline-core/scripts/surgical-fast-path.sh
@@ -26,10 +26,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCHEMA_DIR="${SCHEMA_DIR:-$SCRIPT_DIR/schemas}"
 
-if [[ -f "$SCRIPT_DIR/../config/platform.sh" ]]; then
-    # shellcheck disable=SC1091
-    source "$SCRIPT_DIR/../config/platform.sh"
-fi
+# shellcheck source=resolve-pipeline-root.sh
+source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 if [[ -f "$SCRIPT_DIR/model-config.sh" ]]; then
     # shellcheck disable=SC1091
     source "$SCRIPT_DIR/model-config.sh"

--- a/plugins/pipeline-core/scripts/test-fix-loop.sh
+++ b/plugins/pipeline-core/scripts/test-fix-loop.sh
@@ -22,7 +22,16 @@ set -uo pipefail  # Note: not -e, we handle errors explicitly
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../config/platform.sh"
+# shellcheck source=resolve-pipeline-root.sh
+source "$SCRIPT_DIR/resolve-pipeline-root.sh"
+PLATFORM_SH_FILE="$(resolve_consumer_file platform.sh)" || {
+    echo "FATAL: platform.sh not found (checked \$PIPELINE_CONFIG_DIR," \
+        "<repo-root>/.claude/config/, and the legacy fallback)." \
+        "Cannot continue without consumer platform config." >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$PLATFORM_SH_FILE"
 source "$SCRIPT_DIR/model-config.sh"
 
 # Limits

--- a/tests/marketplace-smoke.bats
+++ b/tests/marketplace-smoke.bats
@@ -556,3 +556,38 @@ MAP
 	[ "$status" -ne 0 ] \
 		|| { echo "CLAUDE_PLUGIN_ROOT used in a skill (use a pipeline-core-* bin instead):" >&2; echo "$output" >&2; return 1; }
 }
+
+@test "bundle: no bundled script hardcodes ../config/platform.sh" {
+	local scripts_dir="$REPO_ROOT/plugins/pipeline-core/scripts"
+	[ -d "$scripts_dir" ] || skip "bundle scripts not present"
+
+	# The bundle ships no config/ dir, so "$SCRIPT_DIR/../config/platform.sh"
+	# resolves inside the plugin cache and misses. The unguarded form errors;
+	# the [[ -f ]]-guarded form fails open, leaving TRACKER, GIT_CLI,
+	# DEPLOY_VERIFY_CMD and the MAX_* caps unset instead of defaulted — a
+	# silent deploy-verify skip. Everything must route through
+	# resolve_consumer_file() instead.
+	run grep -rnE 'SCRIPT_DIR/(\.\./)+config/platform\.sh' \
+		--include='*.sh' "$scripts_dir"
+	[ "$status" -ne 0 ] \
+		|| { echo "hardcoded platform.sh source in bundled script(s):" >&2; echo "$output" >&2; return 1; }
+}
+
+@test "bundle: platform scripts resolve config and abort loudly when it is missing" {
+	local rd="$REPO_ROOT/plugins/pipeline-core/scripts/platform/read-issue.sh"
+	[ -f "$rd" ] || skip "read-issue.sh not present"
+
+	grep -q 'resolve_consumer_file platform.sh' "$rd" \
+		|| { echo "read-issue.sh does not use resolve_consumer_file" >&2; return 1; }
+
+	# In an isolated non-git dir with no override and no reachable
+	# .claude/config/platform.sh, all three lookup paths must miss and the
+	# script must exit non-zero naming platform.sh — never continue unset.
+	run env -u PIPELINE_CONFIG_DIR -u CLAUDE_PLUGIN_ROOT \
+		bash -c 'cd "$1" && exec "$2" 123' _ "$TEST_TMP" "$rd"
+
+	[ "$status" -ne 0 ] \
+		|| { echo "expected non-zero exit when platform.sh unresolvable, got 0: $output" >&2; return 1; }
+	[[ "$output" == *"platform.sh"* ]] \
+		|| { echo "expected FATAL platform.sh message, got: $output" >&2; return 1; }
+}


### PR DESCRIPTION
The bundle ships no `config/` dir, but **14 bundled scripts still hardcoded** `source "\$SCRIPT_DIR/../config/platform.sh"`. That path resolves inside the plugin cache, so it always missed:

```
$ read-issue.sh 5351
.../0.3.1/scripts/platform/../../config/platform.sh: No such file or directory
```

#614 converted only `implement-issue-orchestrator.sh`. Everything else — the whole `platform/` critical path (issue read/comment/create, MR create/find/merge), `batch-orchestrator`, `post-batch-validate`, `test-fix-loop` — was left behind.

Two failure shapes, **the guarded one nastier**:

```bash
source "$SCRIPT_DIR/../../config/platform.sh"           # errors
if [[ -f "$PLATFORM_CONFIG" ]]; then source ...; fi     # fails open
```

The fail-open form left `TRACKER`, `GIT_CLI`, `MERGE_STYLE`, `TEST_*_CMD`, `DEPLOY_VERIFY_CMD` and the `MAX_*` caps **unset rather than defaulted** — `platform.sh` supplies the `${VAR:-default}` values. A silent deploy-verify skip reads as "works" until it quietly stops running.

All **29 call sites across both trees** now resolve via `resolve_consumer_file()` and abort loudly on a miss.

### Also fixed, found while converting

- `.claude/scripts/resolve-pipeline-root.sh` was **71 lines and defined only `resolve_pipeline_file`** — `resolve_consumer_file` existed solely in the plugin copy. Reconciled from the superset (#623 task 3); that pair is now identical.
- `platform-test` pinned its fixture to the old relative path. Lookup 2 (`<git-toplevel>/.claude/config/`) resolved this repo's **real** config and silently shadowed the mock — harness now pins `PIPELINE_CONFIG_DIR`.
- `transition-issue.sh` (plugin copy) used `$JIRA_DONE_TRANSITION` unguarded — a `set -u` failure when unset.
- `test-integration.bats` asserted the hardcoded pattern it should have forbidden.

### Verified

End-to-end from a consumer repo — `read-issue.sh` returns issue JSON and resolves that repo's own `.claude/config/platform.sh`.

| Check | Result |
|---|---|
| `marketplace-smoke` | 23/23 (2 new guards) |
| `test-integration` | 133/0 |
| `bash -n` × 82 scripts | clean |
| `platform-test` | failure set **byte-identical to origin/main** (10 pre-existing acli-CLI-drift failures) |

Refs #614, #623