### PR TITLE
chore(plugin): bump pipeline-core to 0.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
First version whose bundled `platform/` scripts resolve consumer config. `0.3.1` shipped 14 scripts hardcoding `\$SCRIPT_DIR/../config/platform.sh`, which misses inside the plugin cache — breaking every issue read, comment and PR operation, and silently unsetting `DEPLOY_VERIFY_CMD`.

Both manifests bumped together; version-agreement assertion passes.