### PR TITLE
feat(issue-617): add cost reconciliation and bail-stage cost regression tests

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -1031,12 +1031,47 @@ set_stage_completed() {
 set_stage_failed() {
     local stage="$1"
     local error_kind="$2"
-    jq --arg stage "$stage" \
-       '.stages[$stage].completed_at = (now | todate) |
-        .stages[$stage].status = "error" |
-        .state = "failed" |
-        .last_update = (now | todate)' \
-       "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+
+    # issue #617: a bailed stage's spend must reach cost_summary just like a
+    # completed one. Default tokens/cost from the per-stage accumulator that
+    # _apply_stage_action's "bail" branch populated via _stage_acc_add —
+    # mirrors set_stage_completed's bridge above. A stage with no accumulator
+    # file (never started, or started but no run_stage attempt spent
+    # anything) yields nothing here and is persisted as zero/absent.
+    local tokens_json estimated_cost
+    local _acc_sum
+    _acc_sum=$(_stage_acc_sum "$stage")
+    if [[ -n "$_acc_sum" ]]; then
+        tokens_json=$(printf '%s' "$_acc_sum" | jq -c '.tokens' 2>/dev/null)
+        estimated_cost=$(printf '%s' "$_acc_sum" | jq -r '.cost' 2>/dev/null)
+    fi
+
+    if [[ -n "$tokens_json" ]]; then
+        jq --arg stage "$stage" \
+           --argjson tokens "$tokens_json" \
+           --argjson estimated_cost "${estimated_cost:-0}" \
+           '.stages[$stage].completed_at = (now | todate) |
+            .stages[$stage].status = "error" |
+            .stages[$stage].tokens = $tokens |
+            .stages[$stage].estimated_cost = $estimated_cost |
+            .state = "failed" |
+            .cost_summary = {
+                total_input_tokens:          ([.stages[]?.tokens.input_tokens // 0] | add // 0),
+                total_output_tokens:         ([.stages[]?.tokens.output_tokens // 0] | add // 0),
+                total_cache_read_tokens:     ([.stages[]?.tokens.cache_read_input_tokens // 0] | add // 0),
+                total_cache_creation_tokens: ([.stages[]?.tokens.cache_creation_input_tokens // 0] | add // 0),
+                total_cost_usd:              ([.stages[]?.estimated_cost // 0] | add // 0)
+            } |
+            .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    else
+        jq --arg stage "$stage" \
+           '.stages[$stage].completed_at = (now | todate) |
+            .stages[$stage].status = "error" |
+            .state = "failed" |
+            .last_update = (now | todate)' \
+           "$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+    fi
     sync_status_to_log
     emit_event "stage_end" "stage=$stage" "status=error" "error_kind=$error_kind"
 }
@@ -2162,6 +2197,11 @@ _apply_stage_action() {
 			;;
 		bail)
 			log_error "Stage bailed: ${reason:-action=bail}"
+			# issue #617: a bailed run_stage's own spend must still reach
+			# cost_summary — mirror the "accept" branch above and append this
+			# stage_result's tokens/cost to the logical stage's accumulator
+			# before recording the failure, so set_stage_failed picks it up.
+			_stage_acc_add "$stage_result"
 			set_stage_failed \
 				"${_RUN_STAGE_NAME:-unknown}" \
 				"$(jq -r '.error_kind // "bail"' <<< "$stage_result")"

--- a/.claude/scripts/implement-issue-test/cost-accounting.bats
+++ b/.claude/scripts/implement-issue-test/cost-accounting.bats
@@ -300,20 +300,9 @@ _setup_orchestrator_env() {
 # fail loudly — naming both figures and the percent drift — if that sum
 # diverges from cost_summary.total_cost_usd by more than the tolerance.
 
-# Sums .stages[*].estimated_cost in $1 (a metrics.json/status.json-shaped
-# file) and fails loudly if that sum diverges from .cost_summary.total_cost_usd
-# by more than $2 percent (default 5).
-assert_cost_reconciles() {
-	local metrics_file="$1" tolerance_pct="${2:-5}"
-	local stage_sum summary_total pct
-	stage_sum=$(jq -r '[.stages[]?.estimated_cost // 0] | add // 0' "$metrics_file")
-	summary_total=$(jq -r '.cost_summary.total_cost_usd // 0' "$metrics_file")
-	pct=$(awk -v a="$stage_sum" -v b="$summary_total" \
-		'BEGIN { d = a - b; if (d < 0) d = -d; base = (a == 0) ? 1 : a; printf "%.4f", (d / base) * 100 }')
-
-	awk -v pct="$pct" -v tol="$tolerance_pct" 'BEGIN { exit !(pct <= tol) }' \
-		|| fail "cost_summary.total_cost_usd ($summary_total) drifts ${pct}% from the summed per-stage estimated_cost ($stage_sum) — exceeds the ±${tolerance_pct}% reconciliation tolerance"
-}
+# assert_cost_reconciles() lives in helpers/test-helper.bash alongside the
+# other shared assertion helpers (it is also useful for batch-level metrics
+# reconciliation, not just this file).
 
 @test "cost_summary reconciles with summed per-stage cost within 5%, including a failed stage and triage" {
 	_setup_orchestrator_env
@@ -347,8 +336,11 @@ assert_cost_reconciles() {
 
 	# Reproduce the #617 defect directly on metrics.json: cost_summary only
 	# counted the non-failed stages (0.4479 + 0.9562 + 0.4144 = 1.8185),
-	# ~51% below the full per-stage sum (5.2994) computed above — the same
-	# under-report ratio the issue measured on the real run.
+	# ~65.7% below the full per-stage sum (5.2994) computed above. This
+	# test's stage costs are synthetic, not the issue's real-run figures, so
+	# the drift percentage differs from the ~51% measured there — what's
+	# reproduced is the same defect shape: failed and triage stages silently
+	# excluded from the rollup.
 	jq '.cost_summary.total_cost_usd = 1.8185' \
 		"$LOG_BASE/metrics.json" > "$LOG_BASE/metrics.json.tmp" && mv "$LOG_BASE/metrics.json.tmp" "$LOG_BASE/metrics.json"
 
@@ -364,7 +356,7 @@ assert_cost_reconciles() {
 #
 # Issue #617: the reconciliation tests above hand-craft a status.json with
 # estimated_cost already present on the "error" stages, which only proves
-# export_metrics'"'"'s rollup is status-agnostic (it always was). It does not
+# export_metrics's rollup is status-agnostic (it always was). It does not
 # prove a real failing run ever gets that estimated_cost onto the stage entry
 # in the first place. In production a failing run_stage attempt is routed
 # through _apply_stage_action's "bail" branch, which calls set_stage_failed
@@ -378,6 +370,13 @@ assert_cost_reconciles() {
 @test "a stage that bails still persists its cost so cost_summary includes it" {
 	_setup_orchestrator_env
 	init_status
+	# Pin check_run_budget's ceilings to their documented disabled state (0 —
+	# see orchestrator.sh's check_run_budget) so this test exercises the bail
+	# path regardless of what that default happens to be elsewhere. If it
+	# ever flips, an unpinned test would silently start exercising the
+	# budget_exceeded path instead.
+	export MAX_RUN_TOKENS=0
+	export MAX_RUN_COST_USD=0
 	set_stage_started "implement_task_2"
 
 	local stage_result

--- a/.claude/scripts/implement-issue-test/cost-accounting.bats
+++ b/.claude/scripts/implement-issue-test/cost-accounting.bats
@@ -289,6 +289,76 @@ _setup_orchestrator_env() {
 }
 
 # =============================================================================
+# RECONCILIATION — summed per-stage cost vs cost_summary.total_cost_usd (±5%)
+# =============================================================================
+#
+# Issue #617: cost_summary under-reported run cost by ~51% because failed and
+# triage stages never had estimated_cost recorded on them, so the rollup
+# silently excluded exactly the spend #580 existed to make visible. This is
+# the regression guard called for by #617's acceptance criteria: sum whatever
+# estimated_cost every .stages[] entry carries (regardless of status) and
+# fail loudly — naming both figures and the percent drift — if that sum
+# diverges from cost_summary.total_cost_usd by more than the tolerance.
+
+# Sums .stages[*].estimated_cost in $1 (a metrics.json/status.json-shaped
+# file) and fails loudly if that sum diverges from .cost_summary.total_cost_usd
+# by more than $2 percent (default 5).
+assert_cost_reconciles() {
+	local metrics_file="$1" tolerance_pct="${2:-5}"
+	local stage_sum summary_total pct
+	stage_sum=$(jq -r '[.stages[]?.estimated_cost // 0] | add // 0' "$metrics_file")
+	summary_total=$(jq -r '.cost_summary.total_cost_usd // 0' "$metrics_file")
+	pct=$(awk -v a="$stage_sum" -v b="$summary_total" \
+		'BEGIN { d = a - b; if (d < 0) d = -d; base = (a == 0) ? 1 : a; printf "%.4f", (d / base) * 100 }')
+
+	awk -v pct="$pct" -v tol="$tolerance_pct" 'BEGIN { exit !(pct <= tol) }' \
+		|| fail "cost_summary.total_cost_usd ($summary_total) drifts ${pct}% from the summed per-stage estimated_cost ($stage_sum) — exceeds the ±${tolerance_pct}% reconciliation tolerance"
+}
+
+@test "cost_summary reconciles with summed per-stage cost within 5%, including a failed stage and triage" {
+	_setup_orchestrator_env
+	init_status
+	# Mirrors the issue #617 ground-truth shape: a failed task stage and the
+	# triage stage each carry their own estimated_cost, not just the
+	# successfully completed stages.
+	jq '.stages.triage = {status: "completed", estimated_cost: 0.4479} |
+	    .stages.implement_task_1 = {status: "completed", estimated_cost: 0.9562} |
+	    .stages.implement_task_2 = {status: "error", estimated_cost: 1.3836} |
+	    .stages.implement_task_3 = {status: "error", estimated_cost: 2.0973} |
+	    .stages.pr = {status: "completed", estimated_cost: 0.4144}' \
+		"$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+
+	export_metrics
+
+	assert_cost_reconciles "$LOG_BASE/metrics.json"
+}
+
+@test "reconciliation check fails loudly when cost_summary drifts more than 5% from summed per-stage cost" {
+	_setup_orchestrator_env
+	init_status
+	jq '.stages.triage = {status: "completed", estimated_cost: 0.4479} |
+	    .stages.implement_task_1 = {status: "completed", estimated_cost: 0.9562} |
+	    .stages.implement_task_2 = {status: "error", estimated_cost: 1.3836} |
+	    .stages.implement_task_3 = {status: "error", estimated_cost: 2.0973} |
+	    .stages.pr = {status: "completed", estimated_cost: 0.4144}' \
+		"$STATUS_FILE" > "${STATUS_FILE}.tmp" && mv "${STATUS_FILE}.tmp" "$STATUS_FILE"
+
+	export_metrics
+
+	# Reproduce the #617 defect directly on metrics.json: cost_summary only
+	# counted the non-failed stages (0.4479 + 0.9562 + 0.4144 = 1.8185),
+	# ~51% below the full per-stage sum (5.2994) computed above — the same
+	# under-report ratio the issue measured on the real run.
+	jq '.cost_summary.total_cost_usd = 1.8185' \
+		"$LOG_BASE/metrics.json" > "$LOG_BASE/metrics.json.tmp" && mv "$LOG_BASE/metrics.json.tmp" "$LOG_BASE/metrics.json"
+
+	run assert_cost_reconciles "$LOG_BASE/metrics.json"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"drifts"* ]]
+	[[ "$output" == *"reconciliation tolerance"* ]]
+}
+
+# =============================================================================
 # BATCH-LEVEL cost_summary ROLLUP (batch-orchestrator.sh)
 # =============================================================================
 #

--- a/.claude/scripts/implement-issue-test/cost-accounting.bats
+++ b/.claude/scripts/implement-issue-test/cost-accounting.bats
@@ -359,6 +359,51 @@ assert_cost_reconciles() {
 }
 
 # =============================================================================
+# FAILED-STAGE COST — bail path must still persist cost onto the stage
+# =============================================================================
+#
+# Issue #617: the reconciliation tests above hand-craft a status.json with
+# estimated_cost already present on the "error" stages, which only proves
+# export_metrics'"'"'s rollup is status-agnostic (it always was). It does not
+# prove a real failing run ever gets that estimated_cost onto the stage entry
+# in the first place. In production a failing run_stage attempt is routed
+# through _apply_stage_action's "bail" branch, which calls set_stage_failed
+# with only the stage name + error_kind — never the stage_result's
+# tokens/cost, unlike the "accept" branch which threads tokens/cost onto the
+# stage via _stage_acc_add. This is the actual source of #617's ~51%
+# under-report: a bailed stage's own spend never reaches cost_summary. This
+# test drives the real bail path end-to-end and must fail until that gap is
+# closed.
+
+@test "a stage that bails still persists its cost so cost_summary includes it" {
+	_setup_orchestrator_env
+	init_status
+	set_stage_started "implement_task_2"
+
+	local stage_result
+	stage_result=$(jq -n '{
+		status: "error",
+		error_kind: "error_max_turns",
+		tokens: {input_tokens: 500000, output_tokens: 200000,
+		         cache_creation_input_tokens: 0, cache_read_input_tokens: 0},
+		cost: {reported_usd: 1.3836, computed_usd: 1.3836, estimated_usd: 1.3836}
+	}')
+
+	_RUN_STAGE_NAME="implement_task_2"
+	run _apply_stage_action "$stage_result" "bail" "max turns exceeded"
+	[ "$status" -eq 1 ]
+
+	export_metrics
+
+	local stage_status total_cost
+	stage_status=$(jq -r '.stages.implement_task_2.status' "$LOG_BASE/metrics.json")
+	total_cost=$(jq -r '.cost_summary.total_cost_usd' "$LOG_BASE/metrics.json")
+	[ "$stage_status" = "error" ]
+	assert_cost_equals "$total_cost" "1.3836" \
+		"a bailed stage's cost must still reach cost_summary.total_cost_usd"
+}
+
+# =============================================================================
 # BATCH-LEVEL cost_summary ROLLUP (batch-orchestrator.sh)
 # =============================================================================
 #

--- a/.claude/scripts/implement-issue-test/helpers/test-helper.bash
+++ b/.claude/scripts/implement-issue-test/helpers/test-helper.bash
@@ -364,6 +364,53 @@ assert_not_empty() {
     return 0
 }
 
+# Sums .stages[*].estimated_cost in $1 (a metrics.json/status.json-shaped
+# file) and fails loudly if that sum diverges from .cost_summary.total_cost_usd
+# by more than $2 percent (default 5). Shared by cost-accounting.bats and any
+# batch-level metrics reconciliation checks.
+assert_cost_reconciles() {
+    local metrics_file="$1" tolerance_pct="${2:-5}"
+    local stage_sum summary_total pct
+
+    # A jq failure (malformed metrics.json, a non-object .stages[] entry)
+    # must surface as a parse error, not as an empty string awk silently
+    # coerces to 0 and reports as a bogus "drifts 100%". `fail` only
+    # returns 1, so each check must return explicitly.
+    stage_sum=$(jq -r '[.stages[]?.estimated_cost // 0] | add // 0' \
+        "$metrics_file") || {
+        fail "assert_cost_reconciles: cannot parse .stages[] estimated_cost from $metrics_file"
+        return 1
+    }
+    summary_total=$(jq -r '.cost_summary.total_cost_usd // 0' \
+        "$metrics_file") || {
+        fail "assert_cost_reconciles: cannot parse .cost_summary.total_cost_usd from $metrics_file"
+        return 1
+    }
+    if [[ -z "$stage_sum" || -z "$summary_total" ]]; then
+        fail "assert_cost_reconciles: empty cost figures from $metrics_file (stage_sum='$stage_sum' summary_total='$summary_total')"
+        return 1
+    fi
+
+    # Scale drift by the LARGER of the two figures. Using the stage sum
+    # alone lets a total rollup failure (stage_sum 0) pass whenever
+    # summary_total is small, because the old `base = 1` fallback made any
+    # value under 0.05 look like sub-5% drift.
+    pct=$(awk -v a="$stage_sum" -v b="$summary_total" \
+        'BEGIN {
+            d = a - b; if (d < 0) d = -d
+            base = (a > b) ? a : b
+            if (base == 0) { print "0.0000"; exit }
+            printf "%.4f", (d / base) * 100
+        }')
+
+    if ! awk -v pct="$pct" -v tol="$tolerance_pct" \
+        'BEGIN { exit !(pct <= tol) }'; then
+        fail "cost_summary.total_cost_usd ($summary_total) drifts ${pct}% from the summed per-stage estimated_cost ($stage_sum) — exceeds the ±${tolerance_pct}% reconciliation tolerance"
+        return 1
+    fi
+    return 0
+}
+
 # =============================================================================
 # SOURCE SCRIPT FUNCTIONS
 # =============================================================================


### PR DESCRIPTION
Part of #617.

Implements two of the issue's five implementation tasks:
- Task 4: ±5% cost reconciliation check (`assert_cost_reconciles`, now
  shared via `helpers/test-helper.bash`)
- Task 5: BATS regression proving a bailed stage's spend reaches
  `cost_summary` — `_apply_stage_action`'s `bail` branch now threads cost
  onto the stage via `_stage_acc_add` before calling `set_stage_failed`,
  which itself now folds any accumulated tokens/cost into the stage entry
  and recomputed `cost_summary` on the failure path.

Not implemented yet (remaining #617 tasks/ACs — tracked on the issue):
- Task 2: collapse the underscore/hyphen stage-key conventions onto one
  canonical `.stages[]` key
- Task 3: persist `tokens`/`estimated_cost` for task-level stages under
  both key conventions
- AC: `metrics.json` supports a model↔outcome join
- AC: reconciliation verified against the real run's ground-truth figures
  (`issue-614-20260726-153711`, $7.63 vs `cost_summary`)

Note: `run_triage_stage` always calls `set_stage_completed`, never
`set_stage_failed`, so a failing triage stage does not yet exercise the
bail-path cost fix landed here — that gap is part of Task 2/3 above.

Using "Part of" rather than "Closes" since these core ACs are still open.
