### PR TITLE
chore(plugin): bump pipeline-core to 0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/.claude/scripts/implement-issue-test/test-surgical-fast-path.bats
+++ b/.claude/scripts/implement-issue-test/test-surgical-fast-path.bats
@@ -56,12 +56,14 @@ setup() {
     unset MOCK_GIT_DIRTY MOCK_GIT_HOOK_FAILURE MOCK_GIT_PUSH_EXIT_CODE \
           MOCK_GIT_GREP_FILE_COUNT MOCK_GH_MERGE_STATE \
           MOCK_GH_MERGE_STATE_SEQ MOCK_GH_MERGE_STATE_CTR \
+          MOCK_GH_CHECK_ROLLUP \
           MOCK_GH_PR_CREATE_EXIT_CODE MOCK_GH_PR_MERGE_EXIT_CODE \
           MOCK_GIT_STASH_PUSH_EXIT_CODE MOCK_GIT_STASH_POP_EXIT_CODE \
           MOCK_GIT_POST_IMPL_FILES || true
     # Clear stash marker files left over from prior tests (per-test $TEST_TMP
     # is fresh, but be explicit for resume-style tests that re-enter setup).
-    rm -f "$TEST_TMP/git-stash-pushed" "$TEST_TMP/git-stash-popped" || true
+    rm -f "$TEST_TMP/git-stash-pushed" "$TEST_TMP/git-stash-popped" \
+          "$TEST_TMP/gh-pr-merge-called" || true
     unset FAST_PATH_MERGE_CHECK_ATTEMPTS FAST_PATH_MERGE_CHECK_DELAY || true
 
     # Default: zero retry delay so tests don't sleep.
@@ -282,7 +284,11 @@ if [[ "${1:-}" == "pr" ]]; then
                 state="${MOCK_GH_MERGE_STATE:-CLEAN}"
             fi
             if [[ "$json_field" == *mergeStateStatus* ]]; then
-                printf '{"mergeStateStatus":"%s"}\n' "$state"
+                # merge-mr.sh (the full path) requests mergeStateStatus and
+                # statusCheckRollup together; include the rollup so tests can
+                # distinguish a concluded check failure from a pending one.
+                printf '{"mergeStateStatus":"%s","statusCheckRollup":%s}\n' \
+                    "$state" "${MOCK_GH_CHECK_ROLLUP:-[]}"
             elif [[ "$json_field" == *number* ]]; then
                 printf '{"number":%s}\n' "$num"
             else
@@ -291,6 +297,9 @@ if [[ "${1:-}" == "pr" ]]; then
             exit 0
             ;;
         merge)
+            # Record that a merge was actually attempted so tests can assert
+            # a refused/waiting PR never reaches this call.
+            : > "$TEST_TMP/gh-pr-merge-called"
             exit "${MOCK_GH_PR_MERGE_EXIT_CODE:-0}"
             ;;
     esac

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
Version bump for the seven fixes merged in #643 (c1e46bf1).

Consumers pinning 0.3.2 have none of: #617, #632, #634, #636, #637, #638, #640.

Cutting this tag is the prerequisite for retiring the directory-source marketplace registration (#615) and rolling the plugin out to consumers (#610) — tagging before it would pin a version that predates the fixes.