### PR TITLE
fix(parsing): isolate the CLI envelope so leading notices don't fail a stage (#646)

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -2191,6 +2191,57 @@ _epoch_ms() {
     fi
 }
 
+# _extract_cli_envelope <raw-stage-output>
+#
+# Isolate the CLI's JSON result envelope from a stage's stdout (issue #646).
+#
+# The CLI can print a notice BEFORE the envelope on the same stream. The case
+# that broke the first plugin-based consumer run was the untrusted-workspace
+# warning:
+#
+#   Ignoring 9 permissions.allow entries from .claude/settings.json: this
+#   workspace has not been trusted. ...
+#   {"is_error":false,...,"structured_output":{...}}
+#
+# Feeding that to jq fails, so a stage that succeeded is recorded
+# no_structured_output. On the claude-spend #64 run this failed the test and
+# docs stages and then discarded a PR the pr stage had actually created.
+#
+# Takes the LAST complete top-level object, not the first: the notice text can
+# itself contain JSON-looking fragments, and the envelope is always last.
+#
+# Arguments:
+#   $1 - raw stage output
+# Outputs:
+#   The envelope JSON on stdout, or nothing when the stream holds no object
+# Returns:
+#   0 always — an empty result is the caller's "no envelope" signal, matching
+#   the existing `// empty` extraction style
+_extract_cli_envelope() {
+    local raw="$1"
+    [[ -n "$raw" ]] || return 0
+
+    # Fast path: the whole stream is the envelope. This is the common case and
+    # avoids a per-line jq spawn on large outputs.
+    if printf '%s' "$raw" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        printf '%s' "$raw"
+        return 0
+    fi
+
+    local line found=""
+    while IFS= read -r line; do
+        # Only consider lines that begin an object, so prose mentioning JSON
+        # is skipped without paying for a jq call.
+        [[ "$line" == '{'* ]] || continue
+        if printf '%s' "$line" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            found="$line"
+        fi
+    done <<< "$raw"
+
+    [[ -n "$found" ]] || return 0
+    printf '%s' "$found"
+}
+
 # Extract permission_denials tool_name array from raw CLI output as a JSON
 # array. Returns "[]" when absent, malformed, or jq fails.
 _extract_denials() {
@@ -2679,6 +2730,18 @@ run_stage() {
 
     printf '%s\n' "=== $stage_name output ===" >> "$stage_log"
     printf '%s\n' "$output" >> "$stage_log"
+
+    # Every jq below parses _envelope, not output (issue #646). The CLI can
+    # print a notice ahead of its JSON envelope — the untrusted-workspace
+    # permissions warning is the known case — and jq over the raw stream then
+    # fails, recording a successful stage as no_structured_output.
+    #
+    # $output deliberately stays raw: the stage log above and the diagnostic
+    # dumps below are where that notice is visible, and it is the thing that
+    # explains the failure to whoever reads them.
+    local _envelope
+    _envelope=$(_extract_cli_envelope "$output")
+    [[ -n "$_envelope" ]] || _envelope="$output"
     printf '%s\n' "=== exit code: $exit_code ===" >> "$stage_log"
 
     # Parse token usage and reported cost from the CLI's JSON envelope
@@ -2693,7 +2756,7 @@ run_stage() {
     # The agent may have produced valid output before the timeout killed the CLI.
     if (( exit_code == 124 )); then
         local timeout_structured
-        timeout_structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
+        timeout_structured=$(printf '%s' "$_envelope" | jq -c '.structured_output // empty' 2>/dev/null)
         if [[ -n "$timeout_structured" ]]; then
             log "WARN: Stage $stage_name timed out after ${stage_timeout}s but produced structured output — using it"
             local _sr
@@ -2710,7 +2773,7 @@ run_stage() {
         # Fallback: if no structured output, try .result text wrapping
         # (same pattern as lines 936-944)
         local timeout_fallback_result
-        timeout_fallback_result=$(printf '%s' "$output" | jq -c '
+        timeout_fallback_result=$(printf '%s' "$_envelope" | jq -c '
             select(.is_error == false and .result != null) |
             {status: "success", summary: .result}
         ' 2>/dev/null)
@@ -2799,6 +2862,14 @@ run_stage() {
         output=$(< "$_retry_out_tmp")
         rm -f "$_retry_out_tmp"
 
+        # Re-normalise: the retry is a fresh CLI invocation and can carry the
+        # same leading notice as the first attempt (#646). Without this the
+        # retry's valid envelope is unparseable and a stage that succeeded on
+        # retry is still recorded failed — which is how claude-spend #64
+        # created PR #80 and then reported "PR creation failed" with pr=none.
+        _envelope=$(_extract_cli_envelope "$output")
+        [[ -n "$_envelope" ]] || _envelope="$output"
+
         # Re-extract usage — output now reflects the retry attempt, not the
         # original (likely-zeroed) timed-out attempt captured above.
         _stage_usage=$(_extract_usage "$output")
@@ -2831,24 +2902,24 @@ run_stage() {
 
     # Detect max-turns exhaustion
     local output_subtype
-    output_subtype=$(printf '%s' "$output" | jq -r '.subtype // empty' 2>/dev/null)
+    output_subtype=$(printf '%s' "$_envelope" | jq -r '.subtype // empty' 2>/dev/null)
 
     # Detect permission denials early (needed for structured-error classification)
     # Produces a comma-joined string for human-readable log_warn messages below.
     local _permission_denials
-    _permission_denials=$(_extract_denials "$output" \
+    _permission_denials=$(_extract_denials "$_envelope" \
         | jq -r 'select(length > 0) | join(", ")' 2>/dev/null || true)
 
     # Extract structured output from the run
     local structured
-    structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
+    structured=$(printf '%s' "$_envelope" | jq -c '.structured_output // empty' 2>/dev/null)
 
     # .result fallback — build (with field extraction) when .structured_output
     # is absent but the CLI returned a text result.
     local _fallback_result=""
     if [[ -z "$structured" ]]; then
         local _basic_fallback
-        _basic_fallback=$(printf '%s' "$output" | jq -c '
+        _basic_fallback=$(printf '%s' "$_envelope" | jq -c '
             select(.is_error == false and .result != null) |
             {status: "success", summary: .result}
         ' 2>/dev/null)
@@ -2856,7 +2927,7 @@ run_stage() {
         if [[ -n "$_basic_fallback" ]]; then
             log "WARNING: No .structured_output from $stage_name — using .result fallback"
             local result_text
-            result_text=$(printf '%s' "$output" \
+            result_text=$(printf '%s' "$_envelope" \
                 | jq -r '.result // empty' 2>/dev/null)
 
             _fallback_result="$_basic_fallback"
@@ -3122,15 +3193,22 @@ for m in re.finditer(r'\[\s*\{', t):
             printf '%s\n' "$output" >> "$stage_log"
             printf '%s\n' \
                 "=== escalation exit code: $_esc_exit_code ===" >> "$stage_log"
+
+            # Third capture point, same reasoning as the first two (#646): the
+            # escalated call is a fresh CLI invocation and can carry its own
+            # leading notice. _envelope must track the attempt being parsed, or
+            # the fallback below reads the previous attempt's JSON.
+            _envelope=$(_extract_cli_envelope "$output")
+            [[ -n "$_envelope" ]] || _envelope="$output"
             (( _esc_exit_code != 0 )) && \
                 log_warn "escalation CLI exited $_esc_exit_code"
 
             # Extract output from the escalated run
             local _esc_structured
-            _esc_structured=$(printf '%s' "$output" \
+            _esc_structured=$(printf '%s' "$_envelope" \
                 | jq -c '.structured_output // empty' 2>/dev/null)
             if [[ -z "$_esc_structured" ]]; then
-                _esc_structured=$(printf '%s' "$output" | jq -c '
+                _esc_structured=$(printf '%s' "$_envelope" | jq -c '
                     select(.is_error == false and .result != null) |
                     {status: "success", summary: .result}
                 ' 2>/dev/null)
@@ -3270,7 +3348,7 @@ for m in re.finditer(r'\[\s*\{', t):
             _retry_structured=$(printf '%s' "$output" \
                 | jq -c '.structured_output // empty' 2>/dev/null)
             if [[ -z "$_retry_structured" ]]; then
-                _retry_structured=$(printf '%s' "$output" | jq -c '
+                _retry_structured=$(printf '%s' "$_envelope" | jq -c '
                     select(.is_error == false and .result != null) |
                     {status: "success", summary: .result}
                 ' 2>/dev/null)

--- a/.claude/scripts/implement-issue-test/test-json-parsing.bats
+++ b/.claude/scripts/implement-issue-test/test-json-parsing.bats
@@ -1257,3 +1257,81 @@ FIXTURE_EOF
 	[ "$(printf '%s' "$output" | jq -r '.output_tokens')" = "9" ]
 	[ "$(printf '%s' "$output" | jq -r '.total_cost_usd')" = "0" ]
 }
+
+# =============================================================================
+# ENVELOPE EXTRACTION WITH LEADING NON-JSON (issue #646)
+#
+# The CLI can emit notices on stdout BEFORE its JSON envelope — the
+# untrusted-workspace permissions warning being the case that broke the first
+# plugin-based consumer run. jq over the raw stream then fails and a
+# successful stage is recorded no_structured_output.
+# =============================================================================
+
+# The exact pollution observed on claude-spend run issue-64-20260728-234318.
+_polluted_output() {
+	printf '%s\n' 'Ignoring 9 permissions.allow entries from .claude/settings.json: this workspace has not been trusted. Run Claude Code interactively here once and accept the trust dialog, or set projects["/Users/x/projects/y"].hasTrustDialogAccepted: true in /Users/x/.claude.json.'
+	printf '%s\n' '{"is_error":false,"result":"done","structured_output":{"status":"success","pr_number":80,"pr_url":"https://github.com/o/r/pull/80","error":null}}'
+}
+
+@test "(#646) envelope preceded by a warning line still parses" {
+	local out
+	out=$(_polluted_output)
+
+	local env
+	env=$(_extract_cli_envelope "$out")
+
+	local status_val
+	status_val=$(printf '%s' "$env" | jq -r '.structured_output.status // empty' 2>/dev/null)
+	[ "$status_val" = "success" ] || {
+		printf 'FAIL: expected structured_output.status=success, got: %s\n' "$status_val" >&2
+		return 1
+	}
+}
+
+@test "(#646) pr_number survives extraction from a polluted stream" {
+	local out
+	out=$(_polluted_output)
+
+	local pr
+	pr=$(_extract_cli_envelope "$out" | jq -r '.structured_output.pr_number // empty' 2>/dev/null)
+	[ "$pr" = "80" ] || {
+		printf 'FAIL: expected pr_number 80, got: %s\n' "$pr" >&2
+		return 1
+	}
+}
+
+@test "(#646) a clean envelope is unaffected" {
+	local out='{"is_error":false,"structured_output":{"status":"success"}}'
+	local got
+	got=$(_extract_cli_envelope "$out" | jq -r '.structured_output.status // empty' 2>/dev/null)
+	[ "$got" = "success" ] || {
+		printf 'FAIL: clean envelope regressed, got: %s\n' "$got" >&2
+		return 1
+	}
+}
+
+@test "(#646) output with no JSON at all yields nothing" {
+	local out
+	out=$(printf 'just a warning\nand another line\n')
+	local got
+	got=$(_extract_cli_envelope "$out" 2>/dev/null || true)
+	[ -z "$got" ] || {
+		printf 'FAIL: expected empty extraction, got: %s\n' "$got" >&2
+		return 1
+	}
+}
+
+@test "(#646) JSON embedded inside the warning text is not mistaken for the envelope" {
+	# The trust warning itself contains a JSON-looking fragment. The envelope
+	# is the last complete top-level object, not the first thing resembling one.
+	local out
+	out=$(printf '%s\n%s\n' \
+		'Note: set projects["/x"].hasTrustDialogAccepted: true — see {"example":"fragment"}' \
+		'{"is_error":false,"structured_output":{"status":"success","pr_number":99}}')
+	local pr
+	pr=$(_extract_cli_envelope "$out" | jq -r '.structured_output.pr_number // empty' 2>/dev/null)
+	[ "$pr" = "99" ] || {
+		printf 'FAIL: expected pr_number 99 from the real envelope, got: %s\n' "$pr" >&2
+		return 1
+	}
+}

--- a/.claude/scripts/implement-issue-test/test-stage-runner.bats
+++ b/.claude/scripts/implement-issue-test/test-stage-runner.bats
@@ -2526,3 +2526,40 @@ EOF
 	ql_tokens=$(jq -r '.stages.quality_loop.tokens // "absent"' "$STATUS_FILE")
 	[ "$ql_tokens" = "absent" ] || fail "quality_loop must not inherit spend, got '$ql_tokens'"
 }
+
+# =============================================================================
+# ENVELOPE EXTRACTION THROUGH run_stage (issue #646)
+#
+# The helper being correct does not prove run_stage uses it. These drive the
+# real stage path with a stream that carries a notice before the envelope —
+# the untrusted-workspace warning that broke the claude-spend #64 run.
+# =============================================================================
+
+@test "(#646) run_stage parses an envelope preceded by the untrusted-workspace warning" {
+    export MOCK_CLAUDE_RESPONSE="$TEST_TMP/mock-response.json"
+    {
+        printf '%s\n' 'Ignoring 9 permissions.allow entries from .claude/settings.json: this workspace has not been trusted. Run Claude Code interactively here once and accept the trust dialog.'
+        printf '%s\n' '{"is_error":false,"result":"ok","structured_output":{"status":"success","summary":"did the thing"}}'
+    } > "$MOCK_CLAUDE_RESPONSE"
+
+    run run_stage "test" "prompt" "test-schema.json"
+    [ "$status" -eq 0 ] || {
+        printf 'FAIL: polluted stream should still succeed. output:\n%s\n' "$output" >&2
+        return 1
+    }
+    [[ "$output" != *"no_structured_output"* ]] || {
+        printf 'FAIL: recorded no_structured_output despite a valid envelope\n' >&2
+        return 1
+    }
+}
+
+@test "(#646) run_stage still fails when the stream carries no envelope at all" {
+    export MOCK_CLAUDE_RESPONSE="$TEST_TMP/mock-response.json"
+    printf '%s\n' 'just a warning, no JSON anywhere' > "$MOCK_CLAUDE_RESPONSE"
+
+    run run_stage "test" "prompt" "test-schema.json"
+    [ "$status" -eq 1 ] || {
+        printf 'FAIL: a stream with no envelope must still fail\n' >&2
+        return 1
+    }
+}

--- a/plugins/pipeline-core/scripts/implement-issue-orchestrator.sh
+++ b/plugins/pipeline-core/scripts/implement-issue-orchestrator.sh
@@ -2191,6 +2191,57 @@ _epoch_ms() {
     fi
 }
 
+# _extract_cli_envelope <raw-stage-output>
+#
+# Isolate the CLI's JSON result envelope from a stage's stdout (issue #646).
+#
+# The CLI can print a notice BEFORE the envelope on the same stream. The case
+# that broke the first plugin-based consumer run was the untrusted-workspace
+# warning:
+#
+#   Ignoring 9 permissions.allow entries from .claude/settings.json: this
+#   workspace has not been trusted. ...
+#   {"is_error":false,...,"structured_output":{...}}
+#
+# Feeding that to jq fails, so a stage that succeeded is recorded
+# no_structured_output. On the claude-spend #64 run this failed the test and
+# docs stages and then discarded a PR the pr stage had actually created.
+#
+# Takes the LAST complete top-level object, not the first: the notice text can
+# itself contain JSON-looking fragments, and the envelope is always last.
+#
+# Arguments:
+#   $1 - raw stage output
+# Outputs:
+#   The envelope JSON on stdout, or nothing when the stream holds no object
+# Returns:
+#   0 always — an empty result is the caller's "no envelope" signal, matching
+#   the existing `// empty` extraction style
+_extract_cli_envelope() {
+    local raw="$1"
+    [[ -n "$raw" ]] || return 0
+
+    # Fast path: the whole stream is the envelope. This is the common case and
+    # avoids a per-line jq spawn on large outputs.
+    if printf '%s' "$raw" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        printf '%s' "$raw"
+        return 0
+    fi
+
+    local line found=""
+    while IFS= read -r line; do
+        # Only consider lines that begin an object, so prose mentioning JSON
+        # is skipped without paying for a jq call.
+        [[ "$line" == '{'* ]] || continue
+        if printf '%s' "$line" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            found="$line"
+        fi
+    done <<< "$raw"
+
+    [[ -n "$found" ]] || return 0
+    printf '%s' "$found"
+}
+
 # Extract permission_denials tool_name array from raw CLI output as a JSON
 # array. Returns "[]" when absent, malformed, or jq fails.
 _extract_denials() {
@@ -2679,6 +2730,18 @@ run_stage() {
 
     printf '%s\n' "=== $stage_name output ===" >> "$stage_log"
     printf '%s\n' "$output" >> "$stage_log"
+
+    # Every jq below parses _envelope, not output (issue #646). The CLI can
+    # print a notice ahead of its JSON envelope — the untrusted-workspace
+    # permissions warning is the known case — and jq over the raw stream then
+    # fails, recording a successful stage as no_structured_output.
+    #
+    # $output deliberately stays raw: the stage log above and the diagnostic
+    # dumps below are where that notice is visible, and it is the thing that
+    # explains the failure to whoever reads them.
+    local _envelope
+    _envelope=$(_extract_cli_envelope "$output")
+    [[ -n "$_envelope" ]] || _envelope="$output"
     printf '%s\n' "=== exit code: $exit_code ===" >> "$stage_log"
 
     # Parse token usage and reported cost from the CLI's JSON envelope
@@ -2693,7 +2756,7 @@ run_stage() {
     # The agent may have produced valid output before the timeout killed the CLI.
     if (( exit_code == 124 )); then
         local timeout_structured
-        timeout_structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
+        timeout_structured=$(printf '%s' "$_envelope" | jq -c '.structured_output // empty' 2>/dev/null)
         if [[ -n "$timeout_structured" ]]; then
             log "WARN: Stage $stage_name timed out after ${stage_timeout}s but produced structured output — using it"
             local _sr
@@ -2710,7 +2773,7 @@ run_stage() {
         # Fallback: if no structured output, try .result text wrapping
         # (same pattern as lines 936-944)
         local timeout_fallback_result
-        timeout_fallback_result=$(printf '%s' "$output" | jq -c '
+        timeout_fallback_result=$(printf '%s' "$_envelope" | jq -c '
             select(.is_error == false and .result != null) |
             {status: "success", summary: .result}
         ' 2>/dev/null)
@@ -2799,6 +2862,14 @@ run_stage() {
         output=$(< "$_retry_out_tmp")
         rm -f "$_retry_out_tmp"
 
+        # Re-normalise: the retry is a fresh CLI invocation and can carry the
+        # same leading notice as the first attempt (#646). Without this the
+        # retry's valid envelope is unparseable and a stage that succeeded on
+        # retry is still recorded failed — which is how claude-spend #64
+        # created PR #80 and then reported "PR creation failed" with pr=none.
+        _envelope=$(_extract_cli_envelope "$output")
+        [[ -n "$_envelope" ]] || _envelope="$output"
+
         # Re-extract usage — output now reflects the retry attempt, not the
         # original (likely-zeroed) timed-out attempt captured above.
         _stage_usage=$(_extract_usage "$output")
@@ -2831,24 +2902,24 @@ run_stage() {
 
     # Detect max-turns exhaustion
     local output_subtype
-    output_subtype=$(printf '%s' "$output" | jq -r '.subtype // empty' 2>/dev/null)
+    output_subtype=$(printf '%s' "$_envelope" | jq -r '.subtype // empty' 2>/dev/null)
 
     # Detect permission denials early (needed for structured-error classification)
     # Produces a comma-joined string for human-readable log_warn messages below.
     local _permission_denials
-    _permission_denials=$(_extract_denials "$output" \
+    _permission_denials=$(_extract_denials "$_envelope" \
         | jq -r 'select(length > 0) | join(", ")' 2>/dev/null || true)
 
     # Extract structured output from the run
     local structured
-    structured=$(printf '%s' "$output" | jq -c '.structured_output // empty' 2>/dev/null)
+    structured=$(printf '%s' "$_envelope" | jq -c '.structured_output // empty' 2>/dev/null)
 
     # .result fallback — build (with field extraction) when .structured_output
     # is absent but the CLI returned a text result.
     local _fallback_result=""
     if [[ -z "$structured" ]]; then
         local _basic_fallback
-        _basic_fallback=$(printf '%s' "$output" | jq -c '
+        _basic_fallback=$(printf '%s' "$_envelope" | jq -c '
             select(.is_error == false and .result != null) |
             {status: "success", summary: .result}
         ' 2>/dev/null)
@@ -2856,7 +2927,7 @@ run_stage() {
         if [[ -n "$_basic_fallback" ]]; then
             log "WARNING: No .structured_output from $stage_name — using .result fallback"
             local result_text
-            result_text=$(printf '%s' "$output" \
+            result_text=$(printf '%s' "$_envelope" \
                 | jq -r '.result // empty' 2>/dev/null)
 
             _fallback_result="$_basic_fallback"
@@ -3122,15 +3193,22 @@ for m in re.finditer(r'\[\s*\{', t):
             printf '%s\n' "$output" >> "$stage_log"
             printf '%s\n' \
                 "=== escalation exit code: $_esc_exit_code ===" >> "$stage_log"
+
+            # Third capture point, same reasoning as the first two (#646): the
+            # escalated call is a fresh CLI invocation and can carry its own
+            # leading notice. _envelope must track the attempt being parsed, or
+            # the fallback below reads the previous attempt's JSON.
+            _envelope=$(_extract_cli_envelope "$output")
+            [[ -n "$_envelope" ]] || _envelope="$output"
             (( _esc_exit_code != 0 )) && \
                 log_warn "escalation CLI exited $_esc_exit_code"
 
             # Extract output from the escalated run
             local _esc_structured
-            _esc_structured=$(printf '%s' "$output" \
+            _esc_structured=$(printf '%s' "$_envelope" \
                 | jq -c '.structured_output // empty' 2>/dev/null)
             if [[ -z "$_esc_structured" ]]; then
-                _esc_structured=$(printf '%s' "$output" | jq -c '
+                _esc_structured=$(printf '%s' "$_envelope" | jq -c '
                     select(.is_error == false and .result != null) |
                     {status: "success", summary: .result}
                 ' 2>/dev/null)
@@ -3270,7 +3348,7 @@ for m in re.finditer(r'\[\s*\{', t):
             _retry_structured=$(printf '%s' "$output" \
                 | jq -c '.structured_output // empty' 2>/dev/null)
             if [[ -z "$_retry_structured" ]]; then
-                _retry_structured=$(printf '%s' "$output" | jq -c '
+                _retry_structured=$(printf '%s' "$_envelope" | jq -c '
                     select(.is_error == false and .result != null) |
                     {status: "success", summary: .result}
                 ' 2>/dev/null)


### PR DESCRIPTION
Closes #646.

The CLI can print a notice on stdout ahead of its JSON envelope; `jq` over the raw stream then fails and a successful stage is recorded `no_structured_output`. Surfaced on the first plugin-based consumer run — `claude-spend` #64 created **PR #80** and reported `PR creation failed` with `pr=none`.

`_extract_cli_envelope()` takes the **last** complete top-level object, since the notice text can contain JSON-looking fragments. Fast path leaves an already-parsing stream untouched.

Wired in at all three capture points in `run_stage` — initial, `retry_same`, escalation. Each is a separate invocation that can carry its own notice. The escalation case was caught by `test-timeout-escalation.bats` going red when only two of the three were refreshed.

`$output` stays raw: the stage log and diagnostic dumps are where the notice is visible, and it is what explains the failure.

**Correction to the issue as filed.** #646 described two defects, the second being "a successful retry is not re-read". That is wrong — the retry path already re-parses and adopts a successful retry (L3342-3348). One cause, two symptoms.

**Tests:** 5 unit + 2 driving `run_stage` end to end, because a correct extractor does not prove the orchestrator uses it. RED-verified by bypassing the wiring.

| Suite | Result |
|---|---|
| test-json-parsing | 64/64 |
| test-stage-runner | 115/116 (1 pre-existing) |
| test-timeout-escalation | 36/36 |
| cost-accounting | 35/35 |
| bundle parity | 9/9 |