### PR TITLE
chore(plugin): bump pipeline-core to 0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
Publishes the seven fixes merged tonight to plugin consumers.

The installed `0.4.0` predates all of them — verified against the cache rather than assumed:

```
~/.claude/plugins/cache/claude-pipeline/pipeline-core/0.4.0/scripts/implement-issue-orchestrator.sh
  #652 load_skill installed-layout probe : 0
  #650 set -f guard                      : 0
  #642 status.json lock                  : 0
```

Included in 0.5.0:

| # | Fix |
|---|---|
| #652 | `load_skill` probes the installed-plugin layout — skills no longer load empty headless |
| #653 | canonical orchestrator exec bit restored; bundle parity now compares **mode**; exec failure reported distinctly |
| #650 | `set -f` around `_matches_frontend_pattern` — `e2e_verify` no longer silently skipped |
| #642 | status.json writes serialised behind a per-write temp path + timeout-bounded lock |
| #648 | `default` recognised as the reserved fallback — no more spurious unknown-agent warnings |
| #630 | ancestor walk bounded to 3 missing segments (invented deep paths rejected, App Router paths still validate) |
| #641 | `sync.sh to` returns success against a consumer with no `.claude/agents/` |

## Scope
Two version manifests only — no code. Both must move together or the marketplace and plugin disagree.

## Rollout note
All nine consumers already have the plugin enabled with `autoUpdate: true`, so they pick this up on next session start (the running session holds the old `bin/` PATH entry until restart). Seven of nine still carry a copied `.claude/scripts/` tree; because `resolve-pipeline-root.sh` self-locates, those copies still win for any direct `.claude/scripts/…` invocation. Retiring them is #610.