### PR TITLE
feat(issue-670): comment helper QUIET coverage and skill resolution

### DIFF
--- a/.claude/scripts/implement-issue-test/test-comment-helpers.bats
+++ b/.claude/scripts/implement-issue-test/test-comment-helpers.bats
@@ -375,3 +375,31 @@ EOF
 
     [ ! -f "$gh_calls" ] || fail "gh should not have been called when QUIET=true"
 }
+
+@test "comment_issue still calls gh when QUIET=false" {
+    local gh_calls="$TEST_TMP/gh-calls.txt"
+    cat > "$TEST_TMP/bin/gh" << EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$gh_calls"
+exit 0
+EOF
+    chmod +x "$TEST_TMP/bin/gh"
+
+    QUIET=false comment_issue "Test Title" "Test body"
+
+    [ -f "$gh_calls" ] || fail "gh should have been called when QUIET=false"
+}
+
+@test "comment_pr still calls gh when QUIET=false" {
+    local gh_calls="$TEST_TMP/gh-calls.txt"
+    cat > "$TEST_TMP/bin/gh" << EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$gh_calls"
+exit 0
+EOF
+    chmod +x "$TEST_TMP/bin/gh"
+
+    QUIET=false comment_pr 456 "Test Title" "Test body"
+
+    [ -f "$gh_calls" ] || fail "gh should have been called when QUIET=false"
+}

--- a/.claude/scripts/implement-issue-test/test-skill-validate.bats
+++ b/.claude/scripts/implement-issue-test/test-skill-validate.bats
@@ -378,8 +378,18 @@ typo_field: oops"
 
 _real_skill_run() {
 	local skill_name="$1"
-	local real_skills="$SCRIPT_DIR/../skills"
+	local canonical_skills="$SCRIPT_DIR/../skills"
+	local bundle_skills="$SCRIPT_DIR/../../plugins/pipeline-core/skills"
 	local real_schema="$SCRIPT_DIR/schemas/skill-frontmatter.json"
+	local real_skills="$canonical_skills"
+
+	# Some skills (e.g. writing-agents) ship only inside the plugin bundle
+	# and are never copied into the canonical .claude/skills tree. Resolve
+	# those from the bundle instead of requiring a canonical copy.
+	if [[ ! -f "$canonical_skills/$skill_name/SKILL.md" ]] \
+		&& [[ -f "$bundle_skills/$skill_name/SKILL.md" ]]; then
+		real_skills="$bundle_skills"
+	fi
 
 	run env \
 		SKILLS_DIR="$real_skills" \


### PR DESCRIPTION


---

**Partial delivery — #670 stays open.** This PR delivers 2 of #670's 5 tasks:
the skill-validate bundle resolution and the comment-helper `QUIET=false` coverage.

Still outstanding on #670, per the convergence gate's own report:

- task 1 — sub-issue guard failures (`test-create-issue-parent.bats`)
- task 3 — full-suite BATS scope-gating test (`test-stage-runner.bats`)
- task 4 — CI check asserting the orchestrator suite is green on main (`.github/workflows/bundle-parity.yml`)

The auto-close keyword was removed deliberately so those three are not orphaned.
