### PR TITLE
feat(issue-677): treat missing bats_result as incomplete

### DIFF
--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -7934,6 +7934,17 @@ Do NOT set result to 'failed' based on BATS test failures alone.
 "
         fi
 
+        # A scope that runs the BATS command (bash/mixed, same condition as
+        # bats_section above) must have bats_result rejected at the CLI
+        # boundary when omitted, not just caught by the post-hoc incomplete
+        # check below (issue #677 AC4). Scopes that never run BATS keep the
+        # base schema so they aren't forced to report a verdict they have
+        # nothing to say about.
+        local test_schema="implement-issue-test-validate.json"
+        if [[ "$change_scope" == "bash" || "$change_scope" == "mixed" ]]; then
+            test_schema="implement-issue-test-validate-bats.json"
+        fi
+
         # Build validation section for the combined prompt
         local validation_section=""
         if [[ -n "$changed_files" ]]; then
@@ -8086,7 +8097,7 @@ Output both test results and validation findings in one structured response.
 - bats_summary: summary of BATS test findings (informational only)"
 
         local test_result
-        test_result=$(run_stage "test-iter-$test_iteration" "$test_prompt" "implement-issue-test-validate.json" "default" "$loop_complexity")
+        test_result=$(run_stage "test-iter-$test_iteration" "$test_prompt" "$test_schema" "default" "$loop_complexity")
         _halt_if_budget_exceeded
 
         # Handle timeout: skip result inspection and retry on next iteration
@@ -8130,6 +8141,13 @@ Output both test results and validation findings in one structured response.
         # the agent never reported a verdict at all. That is just as
         # unconfirmed as an explicit 'incomplete' and must not fall through
         # to the "TESTS PASSED" branch below as a silent pass.
+        #
+        # Invariant: bats_section is non-empty exactly when change_scope is
+        # bash/mixed — the same condition that embeds $bash_test_command into
+        # the prompt above and that selects $test_schema. bash_test_command
+        # itself is always non-empty regardless of scope, so it cannot be
+        # used as the key here — a future informational-only bats_section
+        # that stops embedding a runnable command must update this guard too.
         if [[ -n "$bats_section" && -z "$bats_status" ]]; then
             bats_status="incomplete"
             bats_summary_out="${bats_summary_out:-No bats_result reported for this iteration.}"

--- a/.claude/scripts/implement-issue-orchestrator.sh
+++ b/.claude/scripts/implement-issue-orchestrator.sh
@@ -8125,6 +8125,16 @@ Output both test results and validation findings in one structured response.
         bats_status=$(printf '%s' "$test_result" | jq -r '.output.bats_result // ""')
         bats_summary_out=$(printf '%s' "$test_result" | jq -r '.output.bats_summary // ""')
 
+        # A missing or empty bats_result on a scope that actually ran the
+        # BATS command (bats_section non-empty, i.e. bash/mixed scope) means
+        # the agent never reported a verdict at all. That is just as
+        # unconfirmed as an explicit 'incomplete' and must not fall through
+        # to the "TESTS PASSED" branch below as a silent pass.
+        if [[ -n "$bats_section" && -z "$bats_status" ]]; then
+            bats_status="incomplete"
+            bats_summary_out="${bats_summary_out:-No bats_result reported for this iteration.}"
+        fi
+
         if [[ "$bats_status" == "incomplete" ]]; then
             DEGRADED_STAGES+=("test:bats_incomplete:iter=$test_iteration")
             if [[ -z "${_bats_incomplete_commented:-}" ]]; then

--- a/.claude/scripts/implement-issue-test/test-stage-runner.bats
+++ b/.claude/scripts/implement-issue-test/test-stage-runner.bats
@@ -2665,6 +2665,76 @@ _setup_bats_incomplete_repo() {
 	done
 }
 
+# A scope that actually runs the BATS command (bash/mixed) but whose agent
+# comes back with no bats_result at all — or an empty string — must be
+# treated the same as an explicit 'incomplete' verdict. Silently defaulting
+# a missing key to "" (as the `// ""` jq fallback alone would) lets that
+# response fall straight past the incomplete check into the "TESTS PASSED"
+# branch, reporting green with zero confirmed BATS pass/fail evidence.
+@test "run_test_loop records test:bats_incomplete when bats_result is missing from the agent response" {
+	local -a DEGRADED_STAGES=()
+	_setup_bats_incomplete_repo "feature-bats-missing-key"
+
+	run_stage() {
+		case "$1" in
+			test-iter-*)
+				echo '{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped"}}'
+				;;
+		esac
+	}
+	export -f run_stage
+
+	run_test_loop "$TEST_TMP/repo" "feature-bats-missing-key" "" "mixed"
+
+	printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" \
+		| grep -qx 'test:bats_incomplete:iter=1' || \
+		fail "Expected test:bats_incomplete:iter=1 when bats_result is absent from a mixed-scope response; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
+}
+
+@test "run_test_loop records test:bats_incomplete when bats_result is an empty string" {
+	local -a DEGRADED_STAGES=()
+	_setup_bats_incomplete_repo "feature-bats-empty-string"
+
+	run_stage() {
+		case "$1" in
+			test-iter-*)
+				echo '{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped","bats_result":"","bats_summary":""}}'
+				;;
+		esac
+	}
+	export -f run_stage
+
+	run_test_loop "$TEST_TMP/repo" "feature-bats-empty-string" "" "mixed"
+
+	printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" \
+		| grep -qx 'test:bats_incomplete:iter=1' || \
+		fail "Expected test:bats_incomplete:iter=1 when bats_result is an empty string on a mixed-scope response; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
+}
+
+# A scope that never asks the agent to run BATS at all (bats_section is
+# empty) has no BATS verdict to be missing — a response with no bats_result
+# key is simply the normal case, not a degraded one.
+@test "run_test_loop does NOT record bats_incomplete when the scope never runs BATS" {
+	local -a DEGRADED_STAGES=()
+	_setup_bats_incomplete_repo "feature-bats-not-run"
+
+	run_stage() {
+		case "$1" in
+			test-iter-*)
+				echo '{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped"}}'
+				;;
+		esac
+	}
+	export -f run_stage
+
+	run_test_loop "$TEST_TMP/repo" "feature-bats-not-run" "" "typescript"
+
+	local marker
+	marker=$(printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" | grep -c '^test:bats_incomplete:' || true)
+	[ "$marker" -eq 0 ] || \
+		fail "typescript scope never runs BATS; must not record test:bats_incomplete; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
+}
+
 # AC3: the marker run_test_loop records must change a merge-gate decision,
 # not just appear in status.json. reconcile_failed_tasks_with_branch_evidence
 # is the shipped consumer — it refuses to promote a failed-but-evidenced task

--- a/.claude/scripts/implement-issue-test/test-stage-runner.bats
+++ b/.claude/scripts/implement-issue-test/test-stage-runner.bats
@@ -2614,6 +2614,35 @@ _setup_bats_incomplete_repo() {
 	export -f comment_issue
 }
 
+# Shared driver for the scope rows below: they differ only in scope and in the
+# stubbed agent response, so the identical run_stage stub lives here once.
+# DEGRADED_STAGES stays declared in the caller — run_test_loop appends to it via
+# dynamic scoping, which reaches into a subshell but not back out of one, so
+# this must not be wrapped in `run` or $( ).
+_run_loop_with_stubbed_test_response() {
+	local branch="$1" scope="$2"
+	export STUBBED_TEST_RESPONSE="$3"
+
+	_setup_bats_incomplete_repo "$branch"
+
+	run_stage() {
+		case "$1" in
+			test-iter-*) printf '%s\n' "$STUBBED_TEST_RESPONSE" ;;
+		esac
+	}
+	export -f run_stage
+
+	local loop_status=0
+	run_test_loop "$TEST_TMP/repo" "$branch" "" "$scope" || loop_status=$?
+	return "$loop_status"
+}
+
+# Number of bats_incomplete markers in the caller's DEGRADED_STAGES.
+_count_bats_incomplete_markers() {
+	printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" \
+		| grep -c '^test:bats_incomplete:' || true
+}
+
 @test "run_test_loop records test:bats_incomplete when bats_result is 'incomplete'" {
 	local -a DEGRADED_STAGES=()
 	_setup_bats_incomplete_repo "feature-bats-incomplete"
@@ -2671,93 +2700,38 @@ _setup_bats_incomplete_repo() {
 # a missing key to "" (as the `// ""` jq fallback alone would) lets that
 # response fall straight past the incomplete check into the "TESTS PASSED"
 # branch, reporting green with zero confirmed BATS pass/fail evidence.
-@test "run_test_loop records test:bats_incomplete when bats_result is missing from the agent response" {
-	local -a DEGRADED_STAGES=()
-	_setup_bats_incomplete_repo "feature-bats-missing-key"
+#
+# Table-driven over the scopes that build a bats_section — mixed, and bash
+# whose section is labelled BLOCKING (distinct wording/behaviour, see the
+# "bash scope bats_section is labelled BLOCKING" tests above) — plus one that
+# never builds one (typescript), where a response with no bats_result key is
+# simply the normal case rather than a degraded one. Adding a scope here is a
+# one-line row.
+@test "run_test_loop records bats_incomplete for an unreported BATS verdict on exactly the scopes that run BATS" {
+	local no_key='{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped"}}'
+	local empty_key='{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped","bats_result":"","bats_summary":""}}'
 
-	run_stage() {
-		case "$1" in
-			test-iter-*)
-				echo '{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped"}}'
-				;;
-		esac
-	}
-	export -f run_stage
+	# scope|label|stubbed agent response|expected bats_incomplete marker count
+	local row
+	for row in \
+		"mixed|missing-key|$no_key|1" \
+		"mixed|empty-string|$empty_key|1" \
+		"bash|missing-key|$no_key|1" \
+		"typescript|missing-key|$no_key|0"
+	do
+		local scope label response expected
+		IFS='|' read -r scope label response expected <<< "$row"
 
-	run_test_loop "$TEST_TMP/repo" "feature-bats-missing-key" "" "mixed"
+		local -a DEGRADED_STAGES=()
+		_run_loop_with_stubbed_test_response "feature-bats-$scope-$label" "$scope" "$response"
 
-	printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" \
-		| grep -qx 'test:bats_incomplete:iter=1' || \
-		fail "Expected test:bats_incomplete:iter=1 when bats_result is absent from a mixed-scope response; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
-}
+		local marker
+		marker=$(_count_bats_incomplete_markers)
+		[ "$marker" -eq "$expected" ] || \
+			fail "scope '$scope' with a $label bats_result: expected $expected bats_incomplete marker(s), got $marker; DEGRADED_STAGES: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
 
-@test "run_test_loop records test:bats_incomplete when bats_result is an empty string" {
-	local -a DEGRADED_STAGES=()
-	_setup_bats_incomplete_repo "feature-bats-empty-string"
-
-	run_stage() {
-		case "$1" in
-			test-iter-*)
-				echo '{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped","bats_result":"","bats_summary":""}}'
-				;;
-		esac
-	}
-	export -f run_stage
-
-	run_test_loop "$TEST_TMP/repo" "feature-bats-empty-string" "" "mixed"
-
-	printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" \
-		| grep -qx 'test:bats_incomplete:iter=1' || \
-		fail "Expected test:bats_incomplete:iter=1 when bats_result is an empty string on a mixed-scope response; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
-}
-
-# The bash scope builds a BLOCKING bats_section (distinct wording/behaviour
-# from mixed's informational-only section — see the "bash scope bats_section
-# is labelled BLOCKING" tests above), but the missing-bats_result guard keys
-# only on bats_section being non-empty. Confirm the omission is caught on
-# the bash branch too, not just on mixed.
-@test "run_test_loop records test:bats_incomplete when bats_result is missing on bash scope" {
-	local -a DEGRADED_STAGES=()
-	_setup_bats_incomplete_repo "feature-bats-bash-missing-key"
-
-	run_stage() {
-		case "$1" in
-			test-iter-*)
-				echo '{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped"}}'
-				;;
-		esac
-	}
-	export -f run_stage
-
-	run_test_loop "$TEST_TMP/repo" "feature-bats-bash-missing-key" "" "bash"
-
-	printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" \
-		| grep -qx 'test:bats_incomplete:iter=1' || \
-		fail "Expected test:bats_incomplete:iter=1 when bats_result is absent from a bash-scope response; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
-}
-
-# A scope that never asks the agent to run BATS at all (bats_section is
-# empty) has no BATS verdict to be missing — a response with no bats_result
-# key is simply the normal case, not a degraded one.
-@test "run_test_loop does NOT record bats_incomplete when the scope never runs BATS" {
-	local -a DEGRADED_STAGES=()
-	_setup_bats_incomplete_repo "feature-bats-not-run"
-
-	run_stage() {
-		case "$1" in
-			test-iter-*)
-				echo '{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped"}}'
-				;;
-		esac
-	}
-	export -f run_stage
-
-	run_test_loop "$TEST_TMP/repo" "feature-bats-not-run" "" "typescript"
-
-	local marker
-	marker=$(printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" | grep -c '^test:bats_incomplete:' || true)
-	[ "$marker" -eq 0 ] || \
-		fail "typescript scope never runs BATS; must not record test:bats_incomplete; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
+		rm -rf "$TEST_TMP/repo"
+	done
 }
 
 # config scope is even more distinct: run_test_loop bails out at its own
@@ -2767,27 +2741,94 @@ _setup_bats_incomplete_repo() {
 # there is no BATS verdict to be missing because BATS was never asked for.
 @test "run_test_loop still passes for a config-scope run reporting no bats_result" {
 	local -a DEGRADED_STAGES=()
-	_setup_bats_incomplete_repo "feature-bats-config-scope"
+	local no_key='{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped"}}'
 
-	run_stage() {
-		case "$1" in
-			test-iter-*)
-				echo '{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped"}}'
-				;;
-		esac
-	}
-	export -f run_stage
-
-	run_test_loop "$TEST_TMP/repo" "feature-bats-config-scope" "" "config"
-	local loop_status=$?
+	# `run` is intentionally not used here: it captures output via a
+	# subshell, which would discard run_test_loop's writes to the DEGRADED_STAGES
+	# array declared above (bash's dynamic scoping only reaches into
+	# subshells, not back out of them), breaking the marker assertion below.
+	# `|| loop_status=$?` captures a non-zero exit without a subshell and
+	# without tripping bats' errexit abort, so the assertion below can
+	# actually observe a failing exit code.
+	local loop_status=0
+	_run_loop_with_stubbed_test_response "feature-bats-config-scope" "config" "$no_key" || loop_status=$?
 
 	[ "$loop_status" -eq 0 ] || \
 		fail "Expected run_test_loop to pass (exit 0) for config scope; got exit $loop_status"
 
 	local marker
-	marker=$(printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" | grep -c '^test:bats_incomplete:' || true)
+	marker=$(_count_bats_incomplete_markers)
 	[ "$marker" -eq 0 ] || \
 		fail "config scope never runs BATS; must not record test:bats_incomplete; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
+}
+
+# AC4: the omission must be rejected at the CLI boundary, not only by the
+# post-hoc guard above. run_stage hands its schema argument to the CLI as the
+# output schema, so "rejected" is expressed as bats_result appearing in the
+# schema's `required` list. Only the variant used by scopes that run the BATS
+# command carries the constraint — the base schema must stay unchanged so a
+# config/TypeScript-only run is not forced to report a verdict it was never
+# asked to produce.
+@test "the BATS-scope test schema requires bats_result and the base schema does not" {
+	local base="$SCHEMA_DIR/implement-issue-test-validate.json"
+	local bats_variant="$SCHEMA_DIR/implement-issue-test-validate-bats.json"
+
+	[ -f "$bats_variant" ] || fail "Missing schema: $bats_variant"
+
+	jq -e '.required | index("bats_result")' "$bats_variant" >/dev/null || \
+		fail "implement-issue-test-validate-bats.json must list bats_result as required; got: $(jq -c '.required' "$bats_variant")"
+
+	if jq -e '.required | index("bats_result")' "$base" >/dev/null; then
+		fail "implement-issue-test-validate.json must NOT require bats_result — non-BATS scopes have no verdict to report; got: $(jq -c '.required' "$base")"
+	fi
+
+	# The two files are hand-maintained copies of one contract; only the
+	# `required` list may differ, or the variant silently drops fields the
+	# base gained.
+	diff <(jq -S '.properties' "$base") <(jq -S '.properties' "$bats_variant") || \
+		fail "The two test-validate schemas' properties have drifted apart"
+}
+
+# The constraint is only load-bearing if the loop actually selects the
+# stricter schema for the scopes that run BATS — and leaves every other scope
+# on the base schema.
+@test "run_test_loop passes the bats_result-requiring schema only for scopes that run BATS" {
+	local passing='{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped","bats_result":"passed","bats_summary":"all green"}}'
+
+	# scope|schema file run_stage must be handed
+	local row
+	for row in \
+		"mixed|implement-issue-test-validate-bats.json" \
+		"bash|implement-issue-test-validate-bats.json" \
+		"typescript|implement-issue-test-validate.json"
+	do
+		local scope="${row%%|*}" expected_schema="${row##*|}"
+		local -a DEGRADED_STAGES=()
+
+		SCHEMA_CAPTURE="$TEST_TMP/schema-arg-$scope.txt"
+		export SCHEMA_CAPTURE
+		: > "$SCHEMA_CAPTURE"
+
+		export STUBBED_TEST_RESPONSE="$passing"
+		_setup_bats_incomplete_repo "feature-schema-$scope"
+
+		run_stage() {
+			case "$1" in
+				test-iter-*)
+					printf '%s\n' "$3" >> "$SCHEMA_CAPTURE"
+					printf '%s\n' "$STUBBED_TEST_RESPONSE"
+					;;
+			esac
+		}
+		export -f run_stage
+
+		run_test_loop "$TEST_TMP/repo" "feature-schema-$scope" "" "$scope"
+
+		grep -qx "$expected_schema" "$SCHEMA_CAPTURE" || \
+			fail "scope '$scope' must run the test stage against $expected_schema; got: $(cat "$SCHEMA_CAPTURE")"
+
+		rm -rf "$TEST_TMP/repo"
+	done
 }
 
 # AC3: the marker run_test_loop records must change a merge-gate decision,

--- a/.claude/scripts/implement-issue-test/test-stage-runner.bats
+++ b/.claude/scripts/implement-issue-test/test-stage-runner.bats
@@ -2711,6 +2711,31 @@ _setup_bats_incomplete_repo() {
 		fail "Expected test:bats_incomplete:iter=1 when bats_result is an empty string on a mixed-scope response; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
 }
 
+# The bash scope builds a BLOCKING bats_section (distinct wording/behaviour
+# from mixed's informational-only section — see the "bash scope bats_section
+# is labelled BLOCKING" tests above), but the missing-bats_result guard keys
+# only on bats_section being non-empty. Confirm the omission is caught on
+# the bash branch too, not just on mixed.
+@test "run_test_loop records test:bats_incomplete when bats_result is missing on bash scope" {
+	local -a DEGRADED_STAGES=()
+	_setup_bats_incomplete_repo "feature-bats-bash-missing-key"
+
+	run_stage() {
+		case "$1" in
+			test-iter-*)
+				echo '{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped"}}'
+				;;
+		esac
+	}
+	export -f run_stage
+
+	run_test_loop "$TEST_TMP/repo" "feature-bats-bash-missing-key" "" "bash"
+
+	printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" \
+		| grep -qx 'test:bats_incomplete:iter=1' || \
+		fail "Expected test:bats_incomplete:iter=1 when bats_result is absent from a bash-scope response; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
+}
+
 # A scope that never asks the agent to run BATS at all (bats_section is
 # empty) has no BATS verdict to be missing — a response with no bats_result
 # key is simply the normal case, not a degraded one.
@@ -2733,6 +2758,36 @@ _setup_bats_incomplete_repo() {
 	marker=$(printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" | grep -c '^test:bats_incomplete:' || true)
 	[ "$marker" -eq 0 ] || \
 		fail "typescript scope never runs BATS; must not record test:bats_incomplete; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
+}
+
+# config scope is even more distinct: run_test_loop bails out at its own
+# early "Config/markdown-only changes detected" check before bats_section is
+# ever built or run_stage is ever invoked for a test iteration. A response
+# reporting no bats_result at all must still leave the run passing clean —
+# there is no BATS verdict to be missing because BATS was never asked for.
+@test "run_test_loop still passes for a config-scope run reporting no bats_result" {
+	local -a DEGRADED_STAGES=()
+	_setup_bats_incomplete_repo "feature-bats-config-scope"
+
+	run_stage() {
+		case "$1" in
+			test-iter-*)
+				echo '{"status":"success","output":{"result":"passed","summary":"Tests passed","validation_result":"skipped"}}'
+				;;
+		esac
+	}
+	export -f run_stage
+
+	run_test_loop "$TEST_TMP/repo" "feature-bats-config-scope" "" "config"
+	local loop_status=$?
+
+	[ "$loop_status" -eq 0 ] || \
+		fail "Expected run_test_loop to pass (exit 0) for config scope; got exit $loop_status"
+
+	local marker
+	marker=$(printf '%s\n' "${DEGRADED_STAGES[@]+"${DEGRADED_STAGES[@]}"}" | grep -c '^test:bats_incomplete:' || true)
+	[ "$marker" -eq 0 ] || \
+		fail "config scope never runs BATS; must not record test:bats_incomplete; got: ${DEGRADED_STAGES[*]+"${DEGRADED_STAGES[*]}"}"
 }
 
 # AC3: the marker run_test_loop records must change a merge-gate decision,

--- a/.claude/scripts/schemas/implement-issue-test-validate-bats.json
+++ b/.claude/scripts/schemas/implement-issue-test-validate-bats.json
@@ -1,0 +1,48 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {"enum": ["passed", "failed"]},
+    "total_tests": {"type": "integer"},
+    "passed_tests": {"type": "integer"},
+    "failed_tests": {"type": "integer"},
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "test": {"type": "string"},
+          "message": {"type": "string"}
+        }
+      }
+    },
+    "summary": {"type": "string"},
+    "validation_result": {"enum": ["passed", "failed", "skipped"]},
+    "validation_issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": {"enum": ["major", "minor"]},
+          "description": {"type": "string"},
+          "file": {"type": "string"}
+        }
+      }
+    },
+    "pre_existing_issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "description": {"type": "string"},
+          "file": {"type": "string"}
+        }
+      }
+    },
+    "validation_summary": {"type": "string"},
+    "e2e_result": {"enum": ["passed", "failed", "skipped"]},
+    "e2e_summary": {"type": "string"},
+    "bats_result": {"enum": ["passed", "failed", "skipped", "incomplete"]},
+    "bats_summary": {"type": "string"}
+  },
+  "required": ["result", "summary", "validation_result", "bats_result"]
+}

--- a/.github/workflows/bundle-parity.yml
+++ b/.github/workflows/bundle-parity.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Run bundle generator tests
         run: bats tests/sync-bundle.bats
 
+      # Guards against the silent-backlog-re-accumulation problem in issue #670:
+      # without this, a red orchestrator suite on main goes unnoticed until it
+      # becomes load-bearing for every unrelated PR that touches a .bats file.
+      - name: Run orchestrator BATS suite
+        run: ./run-tests.sh
+        working-directory: .claude/scripts/implement-issue-test
+
       # The bundle is PRODUCED, not hand-edited: regenerating it from the
       # canonical tree must be a no-op on a correct commit. This catches a
       # bundle-only edit that happens to keep the trees byte-identical only

--- a/.github/workflows/bundle-parity.yml
+++ b/.github/workflows/bundle-parity.yml
@@ -51,13 +51,6 @@ jobs:
       - name: Run bundle generator tests
         run: bats tests/sync-bundle.bats
 
-      # Guards against the silent-backlog-re-accumulation problem in issue #670:
-      # without this, a red orchestrator suite on main goes unnoticed until it
-      # becomes load-bearing for every unrelated PR that touches a .bats file.
-      - name: Run orchestrator BATS suite
-        run: ./run-tests.sh
-        working-directory: .claude/scripts/implement-issue-test
-
       # The bundle is PRODUCED, not hand-edited: regenerating it from the
       # canonical tree must be a no-op on a correct commit. This catches a
       # bundle-only edit that happens to keep the trees byte-identical only

--- a/plugins/pipeline-core/scripts/implement-issue-orchestrator.sh
+++ b/plugins/pipeline-core/scripts/implement-issue-orchestrator.sh
@@ -7934,6 +7934,17 @@ Do NOT set result to 'failed' based on BATS test failures alone.
 "
         fi
 
+        # A scope that runs the BATS command (bash/mixed, same condition as
+        # bats_section above) must have bats_result rejected at the CLI
+        # boundary when omitted, not just caught by the post-hoc incomplete
+        # check below (issue #677 AC4). Scopes that never run BATS keep the
+        # base schema so they aren't forced to report a verdict they have
+        # nothing to say about.
+        local test_schema="implement-issue-test-validate.json"
+        if [[ "$change_scope" == "bash" || "$change_scope" == "mixed" ]]; then
+            test_schema="implement-issue-test-validate-bats.json"
+        fi
+
         # Build validation section for the combined prompt
         local validation_section=""
         if [[ -n "$changed_files" ]]; then
@@ -8086,7 +8097,7 @@ Output both test results and validation findings in one structured response.
 - bats_summary: summary of BATS test findings (informational only)"
 
         local test_result
-        test_result=$(run_stage "test-iter-$test_iteration" "$test_prompt" "implement-issue-test-validate.json" "default" "$loop_complexity")
+        test_result=$(run_stage "test-iter-$test_iteration" "$test_prompt" "$test_schema" "default" "$loop_complexity")
         _halt_if_budget_exceeded
 
         # Handle timeout: skip result inspection and retry on next iteration
@@ -8130,6 +8141,13 @@ Output both test results and validation findings in one structured response.
         # the agent never reported a verdict at all. That is just as
         # unconfirmed as an explicit 'incomplete' and must not fall through
         # to the "TESTS PASSED" branch below as a silent pass.
+        #
+        # Invariant: bats_section is non-empty exactly when change_scope is
+        # bash/mixed — the same condition that embeds $bash_test_command into
+        # the prompt above and that selects $test_schema. bash_test_command
+        # itself is always non-empty regardless of scope, so it cannot be
+        # used as the key here — a future informational-only bats_section
+        # that stops embedding a runnable command must update this guard too.
         if [[ -n "$bats_section" && -z "$bats_status" ]]; then
             bats_status="incomplete"
             bats_summary_out="${bats_summary_out:-No bats_result reported for this iteration.}"

--- a/plugins/pipeline-core/scripts/implement-issue-orchestrator.sh
+++ b/plugins/pipeline-core/scripts/implement-issue-orchestrator.sh
@@ -8125,6 +8125,16 @@ Output both test results and validation findings in one structured response.
         bats_status=$(printf '%s' "$test_result" | jq -r '.output.bats_result // ""')
         bats_summary_out=$(printf '%s' "$test_result" | jq -r '.output.bats_summary // ""')
 
+        # A missing or empty bats_result on a scope that actually ran the
+        # BATS command (bats_section non-empty, i.e. bash/mixed scope) means
+        # the agent never reported a verdict at all. That is just as
+        # unconfirmed as an explicit 'incomplete' and must not fall through
+        # to the "TESTS PASSED" branch below as a silent pass.
+        if [[ -n "$bats_section" && -z "$bats_status" ]]; then
+            bats_status="incomplete"
+            bats_summary_out="${bats_summary_out:-No bats_result reported for this iteration.}"
+        fi
+
         if [[ "$bats_status" == "incomplete" ]]; then
             DEGRADED_STAGES+=("test:bats_incomplete:iter=$test_iteration")
             if [[ -z "${_bats_incomplete_commented:-}" ]]; then

--- a/plugins/pipeline-core/scripts/schemas/implement-issue-test-validate-bats.json
+++ b/plugins/pipeline-core/scripts/schemas/implement-issue-test-validate-bats.json
@@ -1,0 +1,48 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {"enum": ["passed", "failed"]},
+    "total_tests": {"type": "integer"},
+    "passed_tests": {"type": "integer"},
+    "failed_tests": {"type": "integer"},
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "test": {"type": "string"},
+          "message": {"type": "string"}
+        }
+      }
+    },
+    "summary": {"type": "string"},
+    "validation_result": {"enum": ["passed", "failed", "skipped"]},
+    "validation_issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": {"enum": ["major", "minor"]},
+          "description": {"type": "string"},
+          "file": {"type": "string"}
+        }
+      }
+    },
+    "pre_existing_issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "description": {"type": "string"},
+          "file": {"type": "string"}
+        }
+      }
+    },
+    "validation_summary": {"type": "string"},
+    "e2e_result": {"enum": ["passed", "failed", "skipped"]},
+    "e2e_summary": {"type": "string"},
+    "bats_result": {"enum": ["passed", "failed", "skipped", "incomplete"]},
+    "bats_summary": {"type": "string"}
+  },
+  "required": ["result", "summary", "validation_result", "bats_result"]
+}


### PR DESCRIPTION


---

**Partial delivery — #677 stays open.** This closes the *absent* `bats_result` case and adds a BATS-scope schema that requires the field.

Still outstanding: **AC6** — a `bats_result` of `skipped` on a run that did not complete is still accepted. That variant was observed on #670's own run (`result: failed`, `bats_result: skipped`, summary stating the run did not complete) and the prompt at `:7920` explicitly forbids it. The auto-close keyword was removed so it is not orphaned.
