### PR TITLE
fix(tests): update wall-budget expectation to match #651's re-derivation

### DIFF
--- a/tests/timeout-budget.bats
+++ b/tests/timeout-budget.bats
@@ -592,11 +592,17 @@ _mock_diff_count() {
 	local budget
 	budget=$(calc_orchestrator_wall_time)
 
-	# Default: test-loop(1500×3+120=4620) + pr-review(1200×2+120=2520)
-	#          + overhead(5700) = 12840  (test-iter raised 900→1500, issue #512)
-	[[ "$budget" -eq 12840 ]] || {
+	# Default: test-loop(1500×3+120=4620) + pr-review(1200×2+1800+120=4320)
+	#          + overhead(5700) = 14640
+	#
+	# The pr-review term gained the 1800s fix stage in issue #651: the budget
+	# check moved inside the changes_requested branch, so the worst case now
+	# includes a fix and its confirming re-review rather than reviews alone.
+	# This expectation was left at the pre-#651 value of 12840 and has been
+	# failing on main since 510da980.
+	[[ "$budget" -eq 14640 ]] || {
 		printf \
-			'FAIL: expected default budget=12840, got %s\n' \
+			'FAIL: expected default budget=14640, got %s\n' \
 			"$budget" >&2
 		return 1
 	}


### PR DESCRIPTION
`tests/timeout-budget.bats` still asserted the pre-#651 default of **12840**. #651 deliberately raised it to **14640** — the worst case now includes a fix stage and its confirming re-review, and the reviewer on PR #674 verified the arithmetic.

The expectation was not updated alongside the change, so `Decision Script BATS Tests` has been red on `main` since `510da980`, and it was blocking PR #683 (#677).

`tests/timeout-budget.bats` 24/24 locally.