### PR TITLE
chore(plugin): bump pipeline-core to 0.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
The `0.5.0` version string was consumed by #665 before today's reporting-integrity work landed. Consumers cached that tree — it has #646, #673, #631, #640 but **not** #666, #667, #651, #669, #677.

Because the version string matches, `claude plugin update` reports *"already at the latest version (0.5.0)"* and never re-fetches, so a cached 0.5.0 is a different tree from the `v0.5.0` tag.

Bumping rather than re-tagging: a version string that has denoted two different trees cannot be repaired in caches that already hold the first.