### PR TITLE
feat(issue-695): surgical fast-path change

### DIFF
--- a/tests/sync-bundle.bats
+++ b/tests/sync-bundle.bats
@@ -700,7 +700,7 @@ _init_pipeline_git_repo() {
 	# call and the push — i.e. no commit can slip in after regeneration and
 	# before the push unnoticed.
 	between=$(sed -n "$((closest_regen + 1)),$((push_line - 1))p" \
-		"$ORCHESTRATOR" | grep -vE '^\s*(#|$|log ")' || true)
+		"$ORCHESTRATOR" | grep -vE '^[[:space:]]*(#|$|log ")' || true)
 	[[ -z "$between" ]] || {
 		printf 'FAIL: unexpected code between regeneration and push:\n%s\n' \
 			"$between" >&2


### PR DESCRIPTION
Closes #695

Created by the surgical fast-path. The triage classifier determined this
change met all six fast-path criteria (test-only scope, surgical size,
established pattern, precise specification, benign failure mode, no security
concerns). See triage.json for the classification record.