### PR TITLE
fix(issue-695): replace remaining GNU-only \S with a POSIX class in sync-bundle.bats

### DIFF
--- a/tests/sync-bundle.bats
+++ b/tests/sync-bundle.bats
@@ -705,7 +705,7 @@ _init_pipeline_git_repo() {
 	# sitting between them.
 	between=$(sed -n "$((closest_regen + 1)),$((push_line - 1))p" \
 		"$ORCHESTRATOR" \
-		| grep -E '\bgit([[:space:]]+-C[[:space:]]+\S+)?[[:space:]]+(commit|add)\b' \
+		| grep -E '\bgit([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+(commit|add)\b' \
 		|| true)
 	[[ -z "$between" ]] || {
 		printf 'FAIL: git commit/add between regeneration and push:\n%s\n' \


### PR DESCRIPTION
Closes #695. Supersedes #713.

`tests/sync-bundle.bats` used `\S` inside a `grep -E` pattern. That is a GNU extension — BSD/macOS `grep` does not honour it, so the assertion silently fails to match and the test reports a spurious failure.

```diff
-  | grep -E '\bgit([[:space:]]+-C[[:space:]]+\S+)?[[:space:]]+(commit|add)\b' \
+  | grep -E '\bgit([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+(commit|add)\b' \
```

## Why this supersedes #713

#713 was produced by the surgical fast-path on 2026-07-31 and fixed a *different* GNU-only construct in the same file (`^\s*` → `^[[:space:]]*`). That change has since landed on `main` independently via #717/#718/#722, so #713's diff is now empty of value and its branch is 12 commits behind with a conflict.

This branch is cut from current `main` and fixes the one remaining instance — verified by diffing against `origin/main` rather than by grep, after an over-escaped pattern initially gave me a false negative.

## Note on how this was raised
The batch run for #695 completed the work but its `pr` stage failed with `already exists` — GitHub will not open a second PR for a head branch that already has one, and #713 occupied `feature/issue-695`. Raising under a distinct head rather than force-pushing over the existing branch. The prior tip is preserved locally as `salvage/pr-713-fastpath`.