### PR TITLE
chore(plugin): bump pipeline-core to 0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
Bumps `plugin.json` and `marketplace.json` to 0.6.0 (both, so the version-match assertion in `tests/marketplace-smoke.bats` stays green).

**Minor, not patch** — this release changes pipeline behaviour:

- **#686** narrows the bash-scope test stage to the suites a branch actually changed, and adds a non-blocking full-suite check for that scope. Measured on the first bash-scope run after it merged: test loop **44 min → ~40s**.
- **#678** derives parallel task wall time per complexity, so an L task is no longer given a ceiling tighter than its own serial timeout.

Also carries reporting-integrity and merge-safety work: #714, #690, #689, #675, #740, #693, #694, #721.

**Release checks**
- `main` clean, CI green (Bundle Parity)
- bundle parity: only test dirs differ (not bundled)
- all bundle scripts parse clean under `bash -n`
- `tests/marketplace-smoke.bats`: 31 tests, 0 failures
- bundle verified by marker to carry each fix (`changed_bats_files`, `statusCheckRollup`, `get_task_wall_time`, `skipped (preflight)`, `regenerate_bundle_if_needed`, `_issue_body_is_repo_path`)

**Known limitation, deliberately not blocking:** #743 — 117 of 177 tests in two orchestrator BATS suites fail under Linux bash 5. That is the orchestrator's own test harness, which consumers never run; no shipped script is affected.