### PR TITLE
test(integration): assert the CLOSED-issue guard by call, not by text position

### DIFF
--- a/.claude/scripts/implement-issue-test/test-integration.bats
+++ b/.claude/scripts/implement-issue-test/test-integration.bats
@@ -1223,11 +1223,20 @@ BATCH_ORCHESTRATOR="${SCRIPT_DIR}/batch-orchestrator.sh"
 }
 
 @test "batch-orchestrator up-front check handles CLOSED issue state" {
-    # The gh check must handle the CLOSED state returned by gh issue view.
+    # The up-front gate must handle the CLOSED state returned by gh issue view.
+    # Asserted through the call rather than by text position: the check lives in
+    # check_issue_resolved_upstream() and the loop invokes it, so grepping the
+    # loop body for a literal CLOSED fails on a correct extract-to-function
+    # refactor while the behaviour is intact.
     local loop_body
     loop_body=$(awk '/^for issue in.*ISSUE_ARRAY/,/^done$/' "$BATCH_ORCHESTRATOR" 2>/dev/null)
-    [[ "$loop_body" == *'CLOSED'* ]] || \
-        fail "Main issue loop must check for CLOSED issue state from gh"
+    [[ "$loop_body" == *'check_issue_resolved_upstream "$issue"'* ]] || \
+        fail "Main issue loop must call the up-front resolved-upstream guard"
+
+    local guard_body
+    guard_body=$(awk '/^check_issue_resolved_upstream\(\)/,/^}$/' "$BATCH_ORCHESTRATOR" 2>/dev/null)
+    [[ "$guard_body" == *'CLOSED'* ]] || \
+        fail "check_issue_resolved_upstream must check for CLOSED issue state from gh"
 }
 
 # --- Functional simulation tests ---


### PR DESCRIPTION
Answers #762: *"confirm whether the full run-tests.sh BATS suite failure is pre-existing on main."*

**It was, and the test was the thing at fault.**

Full suite on `main` (`bbdad5d4`): **2,265 tests, 1 failure** —
`batch-orchestrator up-front check handles CLOSED issue state`. Unrelated to
#746/PR #760, which touched neither that file nor that subsystem.

**Root cause.** The assertion grepped the main loop body for a literal `CLOSED`:

```bash
loop_body=$(awk '/^for issue in.*ISSUE_ARRAY/,/^done$/' "$BATCH_ORCHESTRATOR")
[[ "$loop_body" == *'CLOSED'* ]] || fail ...
```

The guard was extracted into a function and is still called:

| | |
|---|---|
| `batch-orchestrator.sh:992` | `check_issue_resolved_upstream()` |
| `:1002` | `if [[ "$issue_state" == "CLOSED" ]]` |
| `:2052` | loop calls `check_issue_resolved_upstream "$issue"` |

So the literal no longer sits between the loop's `for` and its `done`, and the
test failed on a correct refactor while the behaviour was intact.

**Fix.** Assert both halves of the contract instead of the code's shape: the loop
invokes the guard, and the guard handles `CLOSED`.

**Mutation-verified:**

| Mutation | Result |
|---|---|
| guard stops checking `CLOSED` | RED |
| loop stops calling the guard | RED |
| clean code | GREEN |

The first draft matched the bare function name and let mutation 2 through by
substring (`..._X` still matched). Tightened to the full call form.

Same defect class as #709, #702 and #710 — tests coupled to exact text rather
than behaviour.