### PR TITLE
chore(plugin): bump pipeline-core to 0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
Bumps `plugin.json` and `marketplace.json` together so the version-match assertion in `tests/marketplace-smoke.bats` stays green.

**Minor, not patch** — the E2E stage's contract changes. #745 and #763 make the three count fields required and add an `unmeasured` result; runs that previously reported green on an unfinished or partly-skipped E2E run now report degraded. Intended, and the same exposure #666 accepted for BATS.

### Ships to consumers
- **#745 + #763** — E2E verdict cross-check. Rejects a `passed` verdict carrying failures, retains the unmeasured signal on an empty summary, applies one rule on both initial and rerun paths, downgrades the persisted stage status, and distinguishes never-measured from rerun-unmeasured.
- **#759** — `process-pr` recognises the orchestrator's own `Result:` review format.
- **#746, #761** — explore/enrich-issue authoring guidance reconciled with the checks the orchestrator performs.

### Repo-only (not bundled)
- **#680** — `orchestrator-guards.yml` runs the timeout drift guards on Linux for every orchestrator change.
- **#743, #748, #749** — BATS harness fixes. Those two suites were **117 failures of 177** on Linux; now **0**, on both Linux and macOS.

### Release checks
- full suite on `main`: **2265 tests, 0 failures**
- `tests/marketplace-smoke.bats`: 34 tests, 0 failures
- bundle parity: in sync (test dirs excluded, as designed)
- all bundled scripts parse clean under `bash -n`
- CI green on `main`: Bundle Parity, Orchestrator Guards, Skill Golden Tests