### PR TITLE
chore(plugin): bump pipeline-core to 0.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
Bumps `plugin.json` and `marketplace.json` together so the version-match assertion in `tests/marketplace-smoke.bats` stays green.

**Minor, not patch** — #771 adds a new operator control (`SKIP_ON_MERGED_PR`) and changes a default.

### What changes for consumers

The batch orchestrator's up-front gate no longer treats a merged PR on `feature/issue-N` as resolution for an issue that is still **open** — it logs and processes the issue instead.

That check was only ever reached for issues `gh` had just reported OPEN (the closed-issue branch returns first), so "merged PR means done" was applied exactly where it is contradicted: the pipeline closes an issue when its PR merges, so an open issue carrying a merged PR is evidence the merge *didn't* resolve it.

Reported from a consuming repo on 0.7.0 — four open issues skipped as completed, and re-running them required hand-patching a copy of the orchestrator inside the plugin cache. This release makes that patch redundant, which matters because the patch would have been wiped by this very update.

A skip recorded by this gate now reports `skipped` rather than `completed`, so it no longer counts toward `progress.completed` — the distinction #690 established for the preflight skip, which did not reach this path.

`SKIP_ON_MERGED_PR` restores the previous behaviour as an opt-in.

### Release checks
- bundle parity: in sync
- all bundled scripts parse clean under `bash -n`
- `tests/marketplace-smoke.bats`: 34 tests, 0 failures
- CI green on `main`: Bundle Parity, Orchestrator Guards, Skill Golden Tests
- full suite: **2275 tests, 1 failure** — see below

### Known failure, not a blocker
`check_wall_timeout returns 0 at exact boundary` is a pre-existing clock race in **test-only** code (`implement-issue-test/` is not bundled). The test captures `date +%s`, then the function under test reads the clock again; a second tick between the two pushes elapsed to 3601 and trips the strictly-greater-than check. Passes 5/5 in isolation; unrelated to #771, which touches neither that file nor `check_wall_timeout`.