### PR TITLE
chore(plugin): bump pipeline-core to 0.8.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
Bumps `plugin.json` and `marketplace.json` together so the version-match assertion in `tests/marketplace-smoke.bats` stays green.

### What ships
- **#775 / #778** — both orchestrators re-exec from a private copy at startup, so a run that merges a change to its own script no longer parses a file shifting underneath it. Observed twice before the fix: the run finished its work, then died in top-level code with a mid-token syntax error, losing the terminal state and summary.
- **#774** — `check_wall_timeout` takes an optional current time (defaulting to the clock), removing a one-sided race in the exact-boundary test. Production behaviour unchanged when omitted.

### ⚠️ Behaviour note for consumers
The orchestrators' **process command line now names the private copy under `TMPDIR`**, not the tracked script:

```
bash /var/folders/.../T//batch-orchestrator.XXXXXX --manifest logs/handle-issues/manifest-....json
```

Anything identifying them by script path — `pgrep -f batch-orchestrator.sh` and similar — will stop matching and **silently report a live run as dead**. Match on the manifest argument instead.

Shipped as a patch because pipeline function is unchanged, but this is externally observable and worth knowing before upgrading.

### Release checks
- bundle parity: in sync
- all bundled scripts parse clean under `bash -n`
- `tests/marketplace-smoke.bats`: 0 failures
- CI green on `main`: Bundle Parity, Orchestrator Guards
- full suite: reported below once the run completes