### PR TITLE
fix(issue-788): trigger bundle-parity CI on hook tree changes

### DIFF
--- a/.github/workflows/bundle-parity.yml
+++ b/.github/workflows/bundle-parity.yml
@@ -7,6 +7,15 @@ name: Bundle Parity
 # made only to one side fails before it can be tagged (AC5), independent of
 # skill-golden.yml's decide-*/schemas/skills-scoped triggers.
 #
+# The hook trees (.claude/hooks/ and plugins/pipeline-core/hooks/scripts/) are
+# in the trigger set too (issue #788). test-bundle-parity.bats has asserted
+# hook parity since #640, but the triggers listed only the script trees, so a
+# hook-only change could not reach the guard: PR #785 shipped a drifted
+# post-pr-simplify.sh with `gh pr checks` reporting no checks at all, and the
+# break reached main and later blocked an unrelated PR from merging. Every
+# tree the guard compares must appear here — enforced by the "(#788) triggers
+# on every tree the parity guard checks" test in tests/sync-bundle.bats.
+#
 # sync.sh and tests/sync-bundle.bats are in the trigger set too: sync.sh is
 # the generator that produces the bundle, and its BUNDLE_SCRIPT_SUBDIRS list
 # must stay in lockstep with the guard's PARITY_SUBDIRS, so a change to
@@ -19,6 +28,8 @@ on:
     paths:
       - '.claude/scripts/**'
       - 'plugins/pipeline-core/scripts/**'
+      - '.claude/hooks/**'
+      - 'plugins/pipeline-core/hooks/scripts/**'
       - 'sync.sh'
       - 'tests/sync-bundle.bats'
       - '.github/workflows/bundle-parity.yml'
@@ -26,6 +37,8 @@ on:
     paths:
       - '.claude/scripts/**'
       - 'plugins/pipeline-core/scripts/**'
+      - '.claude/hooks/**'
+      - 'plugins/pipeline-core/hooks/scripts/**'
       - 'sync.sh'
       - 'tests/sync-bundle.bats'
       - '.github/workflows/bundle-parity.yml'

--- a/tests/sync-bundle.bats
+++ b/tests/sync-bundle.bats
@@ -98,6 +98,74 @@ teardown() {
 	}
 }
 
+# A parity assertion whose tree cannot trigger the workflow is unreachable in
+# CI. PR #785 shipped a drifted plugins/pipeline-core/hooks/scripts/ because
+# .claude/hooks/ was guarded by test-bundle-parity.bats but absent from
+# bundle-parity.yml's trigger paths — `gh pr checks` reported no checks at all,
+# and the break reached main and later blocked an unrelated PR from merging.
+@test "(#788) bundle-parity workflow triggers on every tree the parity guard checks" {
+	local wf parity_bats
+	wf="$REPO_ROOT/.github/workflows/bundle-parity.yml"
+	parity_bats="$REPO_ROOT/.claude/scripts/implement-issue-test"
+	parity_bats+="/test-bundle-parity.bats"
+
+	[[ -f "$wf" ]] || {
+		printf 'FAIL: workflow not found: %s\n' "$wf" >&2
+		return 1
+	}
+	[[ -f "$parity_bats" ]] || {
+		printf 'FAIL: parity guard not found: %s\n' "$parity_bats" >&2
+		return 1
+	}
+
+	# Every repo tree the guard compares.
+	local -a guarded_trees=(
+		'.claude/scripts'
+		'plugins/pipeline-core/scripts'
+		'.claude/hooks'
+		'plugins/pipeline-core/hooks/scripts'
+	)
+
+	# Cross-check the hook trees against the guard's own directory variables,
+	# so this list cannot silently fall behind the guard it mirrors.
+	local d
+	for d in '.claude/hooks' 'plugins/pipeline-core/hooks/scripts'; do
+		grep -qF -- "REPO_ROOT/$d\"" "$parity_bats" || {
+			printf 'FAIL: guard no longer references %s — update guarded_trees\n' \
+				"$d" >&2
+			return 1
+		}
+	done
+
+	# The trigger lists are duplicated between push: and pull_request: (the
+	# workflow notes Actions does not reliably support YAML anchors), so both
+	# are checked — updating only one leaves half the triggers blind.
+	local section body tree
+	local -a missing=()
+	for section in push pull_request; do
+		body=$(awk -v s="  $section:" '
+			$0 == s { inside = 1; next }
+			inside && (/^  [a-z_]+:/ || /^[a-z_]+:/) { inside = 0 }
+			inside { print }
+		' "$wf")
+
+		[[ -n "$body" ]] || {
+			printf 'FAIL: no %s: trigger block in %s\n' "$section" "$wf" >&2
+			return 1
+		}
+
+		for tree in "${guarded_trees[@]}"; do
+			grep -qF -- "- '$tree/**'" <<<"$body" || missing+=("$section: $tree")
+		done
+	done
+
+	(( ${#missing[@]} == 0 )) || {
+		printf 'FAIL: the parity guard checks trees the workflow cannot be triggered by:\n' >&2
+		printf '  %s\n' "${missing[@]}" >&2
+		return 1
+	}
+}
+
 # =============================================================================
 # Integration — run `sync.sh bundle` against a fake repo.
 # =============================================================================


### PR DESCRIPTION
## Problem

`test-bundle-parity.bats` has asserted hook parity since #640 (tests 4–9, including "every allowlisted hook matches its `plugins/pipeline-core/hooks/scripts` counterpart"). But `bundle-parity.yml`'s `on.push.paths` / `on.pull_request.paths` listed only the *script* trees — so **a hook-only change could not trigger the workflow that guards it.**

That is not theoretical. PR #785 (issue #782) edited `.claude/hooks/post-pr-simplify.sh` without running `./sync.sh bundle`:

- `gh pr checks 785` → "no checks reported on the 'feature/issue-782' branch"
- the drifted bundle reached `main`, still emitting `decision: "block"` on an agent no repo ships — #782's AC6 silently unmet
- it then blocked the review-approved PR #786 (issue #783) from merging, until #787 regenerated the bundle by hand

PR #786 *did* get a parity run, but only incidentally: its AC3 fix touched `.claude/scripts/`, matching an existing trigger entry.

## Change

Adds `.claude/hooks/**` and `plugins/pipeline-core/hooks/scripts/**` to both trigger lists. The lists are duplicated between `push:` and `pull_request:` — the workflow's own header notes Actions does not reliably support YAML anchors — so both had to change, and the new test checks both.

## Test

`tests/sync-bundle.bats` gains a lockstep guard, mirroring the existing "bundle subdir list matches the parity guard's subdir list" test: every tree the parity guard compares must appear in both trigger lists. It also cross-checks the hook directories against the guard's own `REPO_ROOT` variables, so the list cannot silently fall behind the guard it mirrors.

Against `main` it fails, naming all four missing entries:

```
FAIL: the parity guard checks trees the workflow cannot be triggered by:
  push: .claude/hooks
  push: plugins/pipeline-core/hooks/scripts
  pull_request: .claude/hooks
  pull_request: plugins/pipeline-core/hooks/scripts
```

With the fix, `bats tests/sync-bundle.bats` is 35/35 green and `bats .claude/scripts/implement-issue-test/test-bundle-parity.bats` stays 9/9.

## Note on how this was implemented

Implemented by hand rather than through `/handle-issues`: `.github/workflows/**` is on `guard_commit_path_allowlist`'s hard denylist, verified non-overridable by `EXTRA_COMMIT_PATHS` (the denylist arm short-circuits before the override is consulted). The pipeline structurally cannot commit this change. That gap is itself worth considering — it is the same class as #789, but with no escape hatch.

Closes #788
