### PR TITLE
chore(plugin): bump pipeline-core to 0.8.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
Bumps `pipeline-core` 0.8.1 → 0.8.2 in both `.claude-plugin/marketplace.json` and `plugins/pipeline-core/.claude-plugin/plugin.json`, matching the 0.8.1 bump (23e402ba).

## Headline

**`post-pr-simplify` no longer hard-blocks PR creation on an agent the plugin never ships.**

Before 0.8.2 the *bundled* hook emitted `decision: "block"` for every PR with ≥100 added lines or ≥10 files, instructing `subagent_type='code-simplifier'` — which resolves in no repo, including this one. Consumers hit an instruction nobody could satisfy. It now resolves the agent first and, when absent, allows with a warning naming the missing agent and how to add it.

Note this took two commits to actually deliver: #785 fixed the canonical hook but not the generated bundle, so consumers were still blocked until #787 regenerated it.

## Contents since 0.8.1

| PR | Issue | Change |
|----|-------|--------|
| #785 | #782 | hook warns instead of blocking when `code-simplifier` is unresolvable |
| #787 | #782 | regenerate the shipped bundle copy — what actually reaches consumers |
| #786 | #783 | `agent-templates.md` cites only agents that exist; README corrected; orchestrator usage comment uses a generic placeholder instead of one consumer's agent name |
| #792 | #789 | commit path allowlist admits root-level markdown docs; `.github/workflows/**` hard denylist unchanged |
| #793 | #790 | no-op guard consults a task's deliverable annotation and verifies the declared marker rather than trusting it |

## Why patch-level

No behavioural change to agent defaults. #786's orchestrator edit was a usage comment only; #789 widens the allowlist without weakening the denylist; #790 narrows a false-failure case without loosening the guard (an unannotated no-op still fails, and a bogus marker still fails).

## Verification on `origin/main`, in a clean worktree

```
bats .claude/scripts/implement-issue-test/test-bundle-parity.bats   0 failures
bats tests/sync-bundle.bats                                         0 failures
grep -c agent_resolved plugins/.../post-pr-simplify.sh              5   (bundle carries the fix)
```

The canonical and bundled `implement-issue-orchestrator.sh` are byte-identical.
