### PR TITLE
chore(plugin): bump pipeline-core to 0.8.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
Bumps `pipeline-core` 0.8.2 → 0.8.3 in both `.claude-plugin/marketplace.json` and `plugins/pipeline-core/.claude-plugin/plugin.json`.

## Headline

**The E2E container rebuild is now opt-out.** Before 0.8.3 both E2E call sites unconditionally ran `docker-compose build --no-cache frontend backend`. A consumer whose test runner starts its own dev server (Playwright `webServer`, Vite preview, `next dev`) has no compose file, so the rebuild always failed — and the two sites then failed *differently*:

- the **test loop** caught it and silently skipped E2E
- **e2e_verify** did not skip, because its guard was dead code: `rebuild_rc=$?` ran after `|| true`, so it always read 0 and the `exit 1` was unreachable. E2E ran against a non-existent server with `rebuild_status="failed"` in the prompt.

Reported from a consumer where four merges shipped with E2E effectively absent — one fix with zero effect, one merged against an unachievable AC, two merged with their own new tests red.

## Contents since 0.8.2

| PR | Issue | Change |
|----|-------|--------|
| #805 | #801 | gate both call sites behind `E2E_CONTAINER_REBUILD` (default `true`), and repair the unreachable `rebuild_rc` guard |
| #806 | #802 | warn at startup when `FRONTEND_PATH_PATTERNS` is empty while `TEST_E2E_CMD` is set |
| #803 | #799 | persist the full-suite BATS log; build the RED comment from failing test names, not a 40-line tail |
| #804 | #800 | reserve wall-clock budget for `run_stage`'s same-model retry |

The post-fix Docker rebuild is deliberately **unchanged** — it self-gates on `Dockerfile*`/`docker-compose*` having changed and is already non-fatal.

## Why patch-level

`E2E_CONTAINER_REBUILD` defaults to `true`, so a consumer that does not set it takes exactly the path it takes today. #802's warning is advisory and fires only on a configuration that is already broken. #803 and #804 change pipeline internals, not consumer-visible behaviour.

## Verification on `origin/main`, clean worktree

```
bats .claude/scripts/implement-issue-test/test-bundle-parity.bats   0 failures
bats tests/sync-bundle.bats                                         0 failures
```

Canonical and bundled `implement-issue-orchestrator.sh` are byte-identical; `E2E_CONTAINER_REBUILD` appears in both.

## Note

The pipeline that produced these changes was itself running 0.8.1, so none of these fixes were active during their own development. Picking up 0.8.3 requires a Claude Code restart / plugin refresh.
