### PR TITLE
fix(ci): gate tests/ suite on test and resolver changes; release 0.8.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "pipeline-core",
       "source": "./plugins/pipeline-core",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "description": "Core explore -> issue -> implement engine, platform scripts, and hooks for the Claude Pipeline."
     }
   ]

--- a/.github/workflows/skill-golden.yml
+++ b/.github/workflows/skill-golden.yml
@@ -7,6 +7,18 @@ on:
       - '.claude/scripts/schemas/**'
       - '.claude/skills/*/SKILL.md'
       - 'plugins/pipeline-core/skills/*/SKILL.md'
+      # The decision-scripts job below runs the whole tests/ tree, so a change
+      # to those tests — or to the scripts they exercise — must fire this
+      # workflow. Without these entries the suite ran only when a skill or
+      # schema happened to change: #821 altered issue-body-lib.sh and three
+      # test files, the job never fired, and the PR merged with its own
+      # acceptance criterion unevaluated (issue #820).
+      - 'tests/**'
+      - '.claude/scripts/issue-body-lib.sh'
+      - '.claude/scripts/implement-issue-orchestrator.sh'
+      # Re-run when this workflow itself changes, so a triggers/scope edit is
+      # verified by the run it configures rather than on the next unrelated PR.
+      - '.github/workflows/skill-golden.yml'
   pull_request:
     paths:
       - '.claude/skills/**'
@@ -15,6 +27,10 @@ on:
       - '.claude/scripts/skill-golden.sh'
       - '.claude/scripts/skill-golden-lib.sh'
       - '.claude/scripts/decide-*.sh'
+      - 'tests/**'
+      - '.claude/scripts/issue-body-lib.sh'
+      - '.claude/scripts/implement-issue-orchestrator.sh'
+      - '.github/workflows/skill-golden.yml'
   workflow_dispatch: {}
   schedule:
     - cron: '0 6 1 * *'  # 1st of each month, 06:00 UTC
@@ -115,8 +131,12 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+            # Must stay in step with this workflow's pull_request paths: filter.
+            # The workflow firing is necessary but NOT sufficient — this gate
+            # decides whether bats actually runs, so a path added above and
+            # omitted here silently skips the suite.
             if printf '%s\n' "$changed" | grep -qE \
-              '^\.claude/(scripts/decide-[^/]+\.sh|scripts/schemas/|skills/[^/]+/SKILL\.md)'; then
+              '^(tests/|\.github/workflows/skill-golden\.yml|\.claude/(scripts/(decide-[^/]+\.sh|issue-body-lib\.sh|implement-issue-orchestrator\.sh|schemas/)|skills/[^/]+/SKILL\.md))'; then
               echo "run=true" >> "$GITHUB_OUTPUT"
             else
               echo "run=false" >> "$GITHUB_OUTPUT"

--- a/plugins/pipeline-core/.claude-plugin/plugin.json
+++ b/plugins/pipeline-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Core explore -> issue -> implement engine for the Claude Pipeline: self-contained bundle of scripts + schemas (scripts/), bin/ entrypoints, and hooks. Scripts self-locate via BASH_SOURCE (CLAUDE_PLUGIN_ROOT is not relied on at runtime).",
   "skills": "./skills"
 }


### PR DESCRIPTION
## Problem

The **Decision Script BATS Tests** job runs the entire `tests/` tree (`find tests -maxdepth 1 -name '*.bats'`), but nothing caused it to fire when those tests — or the scripts they exercise — changed.

Two independent gates were both too narrow:

1. `on.push.paths` / `on.pull_request.paths` omitted `tests/**` and the resolver scripts.
2. The `decision-scripts` job's own scope regex independently decides whether bats runs, and matched only `decide-*.sh`, `schemas/`, and `SKILL.md`.

Fixing either alone is insufficient: the workflow firing is necessary but not sufficient, because the job gate can still set `run=false`.

## Evidence

- **PR #821** changed `issue-body-lib.sh` and three test files. The job never fired, and the PR merged with its own acceptance criterion (issue #820 AC6, *"the Decision Script BATS Tests CI job passes on the PR"*) silently unevaluated.
- **PR #819** was checked only incidentally — it happened to edit `adapting-claude-pipeline/SKILL.md`, matching `.claude/skills/**`. Its `((x++))` errexit bug is invisible on macOS bash 3.2 and surfaced only because CI runs bash 5. A coincidence of file paths is the sole reason that defect was caught before release.
- Across all workflows, only two test files were trigger paths: `tests/sync-bundle.bats` and `tests/timeout-budget.bats`.

## Changes

- Add `tests/**`, `.claude/scripts/issue-body-lib.sh`, and `.claude/scripts/implement-issue-orchestrator.sh` to both `paths:` filters.
- Extend the job's scope regex to match the same set, with a comment noting the two must stay in step.
- Include `.github/workflows/skill-golden.yml` in both, so a triggers edit is verified by the run it configures — **this PR fires the job it fixes**.
- Bump `pipeline-core` 0.8.3 → 0.8.4 in `plugin.json` and `marketplace.json`.

## Release note

0.8.3 predates both merged fixes. The installed 0.8.3 bundle contains **no** `_issue_body_agent_name`, so the agent name-resolution fix is not active for consumers. Since the plugin cache is keyed by version, a bump is required for anyone to receive:

- **#818** — resolve agent names via the `name:` frontmatter field
- **#820** — CI-gated name-frontmatter test suite

## Verification

- Scope regex checked against 7 should-match and 5 should-not-match paths, including this PR's own workflow file.
- `bats tests/*.bats` → 251/251 pass, 0 failures.
- Bundle parity confirmed after `./sync.sh bundle`; both manifests validate as JSON.
- The real check is CI on this PR: Decision Script BATS Tests should now appear, where it was absent on #821.

https://claude.ai/code/session_013knfXJDv3ysQxoPjtetMZn